### PR TITLE
(CTH-31) - Enabling logging from cthun-client

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,6 +11,7 @@ set(SOURCES
     "${VENDOR_DIRECTORY}/cthun-client/cthun-client/src/connection.cpp"
     "${VENDOR_DIRECTORY}/cthun-client/cthun-client/src/connection_manager.cpp"
     "${VENDOR_DIRECTORY}/cthun-client/cthun-client/src/endpoint.cpp"
+    "${VENDOR_DIRECTORY}/cthun-client/cthun-client/src/log/log.cpp"
 )
 
 add_executable(cthun-agent ${SOURCES})

--- a/src/agent.h
+++ b/src/agent.h
@@ -17,6 +17,7 @@ class Agent {
     // daemon entry point
     void connect_and_run();
     void run(std::string module, std::string action);
+
   private:
     void list_modules();
     void send_login(Cthun::Client::Client_Type* client_ptr);

--- a/src/log.h
+++ b/src/log.h
@@ -1,7 +1,0 @@
-#ifndef SRC_LOG_H_
-#define SRC_LOG_H_
-
-#define BOOST_LOG_DYN_LINK
-#include <boost/log/trivial.hpp>
-
-#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,18 @@
 #include "agent.h"
 
+#include <cthun-client/src/log/log.h>
+
+LOG_DECLARE_NAMESPACE("agent.main");
+
+static const Cthun::Log::log_level DEFAULT_LOG_LEVEL { Cthun::Log::log_level::debug };
+static std::ostream& DEFAULT_LOG_STREAM { std::cout };
+
 int main(int argc, char *argv[]) {
+    // TODO(ale): implement a Configuration module
+    // TODO(ale): get arguments from command line
+
+    Cthun::Log::configure_logging(DEFAULT_LOG_LEVEL, DEFAULT_LOG_STREAM);
+
     CthunAgent::Agent agent;
     //agent.run(argv[1], argv[2]);
     agent.connect_and_run();

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -1,41 +1,47 @@
 #include "module.h"
-#include "log.h"
 #include "schemas.h"
+
+#include <cthun-client/src/log/log.h>
 
 #include <valijson/adapters/jsoncpp_adapter.hpp>
 #include <valijson/schema_parser.hpp>
 
+LOG_DECLARE_NAMESPACE("agent.module");
+
 namespace CthunAgent {
 
-void Module::call_action(std::string action, const Json::Value& input, Json::Value& output) {
-    BOOST_LOG_TRIVIAL(info) << "Invoking native action " << action;
+void Module::call_action(std::string action, const Json::Value& input,
+                         Json::Value& output) {
+    LOG_INFO("invoking native action %1%", action);
 }
 
-void Module::validate_and_call_action(std::string action, const Json::Value& input, Json::Value& output) {
+void Module::validate_and_call_action(std::string action,
+                                      const Json::Value& input,
+                                      Json::Value& output) {
     const Action& action_to_invoke = actions[action];
 
-    BOOST_LOG_TRIVIAL(info) << "validating input for " << name << " " << action;
+    LOG_INFO("validating input for %1% %2%", name, action);
     std::vector<std::string> errors;
     if (!Schemas::validate(input, action_to_invoke.input_schema, errors)) {
-        BOOST_LOG_TRIVIAL(error) << "Validation failed";
+        LOG_ERROR("validation failed");
         for (auto error : errors) {
-            BOOST_LOG_TRIVIAL(error) << "    " << error;
+            LOG_ERROR("    %1%", error);
         }
         throw "input schema mismatch";
     }
 
     call_action(action, input, output);
 
-    BOOST_LOG_TRIVIAL(info) << "validating output for " << name << " " << action;
+    LOG_INFO("validating output for %1% %2%", name, action);
     if (!Schemas::validate(output, action_to_invoke.output_schema, errors)) {
-        BOOST_LOG_TRIVIAL(error) << "Validation failed";
+        LOG_ERROR("validation failed");
         for (auto error : errors) {
-            BOOST_LOG_TRIVIAL(error) << "    " << error;
+            LOG_ERROR("    %1%", error);
         }
         throw "output schema mismatch";
     }
 
-    BOOST_LOG_TRIVIAL(info) << "validated OK: " << output.toStyledString();
+    LOG_INFO("validated OK: %1%", output.toStyledString());
 }
 
-}
+}  // namespace CthunAgent

--- a/src/module.h
+++ b/src/module.h
@@ -14,8 +14,10 @@ class Module {
   public:
     std::string name;
     std::map<std::string,Action> actions;
-    virtual void call_action(std::string action, const Json::Value& input, Json::Value& output) = 0;
-    void validate_and_call_action(std::string action, const Json::Value& input, Json::Value& output);
+    virtual void call_action(std::string action, const Json::Value& input,
+                             Json::Value& output) = 0;
+    void validate_and_call_action(std::string action, const Json::Value& input,
+                                  Json::Value& output);
 };
 
 }  // namespace CthunAgent

--- a/src/modules/echo.cpp
+++ b/src/modules/echo.cpp
@@ -1,4 +1,5 @@
 #include "echo.h"
+
 #include <valijson/constraints/concrete_constraints.hpp>
 
 namespace CthunAgent {

--- a/src/schemas.h
+++ b/src/schemas.h
@@ -8,7 +8,9 @@ namespace CthunAgent {
 
 class Schemas {
   public:
-    static bool validate(const Json::Value& document, const valijson::Schema& schema, std::vector<std::string> &errors);
+    static bool validate(const Json::Value& document,
+                         const valijson::Schema& schema,
+                         std::vector<std::string> &errors);
     static valijson::Schema external_action_metadata();
     static valijson::Schema network_message();
     static valijson::Schema cnc_data();


### PR DESCRIPTION
Using the boost::log-based logging.

Ensuring that the onMessage callback doesn't throw an exception in case
it fails to validate the received message.
