### PR TITLE
(CTH-42) Add ping module with ping action

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SOURCES
     "${CMAKE_CURRENT_LIST_DIR}/module.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/external_module.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/modules/echo.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/modules/ping.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/../vendor/jsoncpp/jsoncpp.cpp"
     "${VENDOR_DIRECTORY}/cthun-client/cthun-client/src/connection.cpp"
     "${VENDOR_DIRECTORY}/cthun-client/cthun-client/src/connection_manager.cpp"

--- a/src/agent.cpp
+++ b/src/agent.cpp
@@ -1,5 +1,6 @@
 #include "agent.h"
 #include "modules/echo.h"
+#include "modules/ping.h"
 #include "external_module.h"
 #include "schemas.h"
 
@@ -20,6 +21,7 @@ namespace CthunAgent {
 Agent::Agent() {
     // declare internal modules
     modules_["echo"] = std::unique_ptr<Module>(new Modules::Echo);
+    modules_["ping"] = std::unique_ptr<Module>(new Modules::Ping);
 
     // load external modules
     boost::filesystem::path module_path { "modules" };

--- a/src/modules/ping.cpp
+++ b/src/modules/ping.cpp
@@ -1,0 +1,52 @@
+#include "ping.h"
+#include <boost/date_time/posix_time/posix_time.hpp>
+#include <valijson/constraints/concrete_constraints.hpp>
+#include <ctime>
+#include <string>
+#include <sstream>
+#include <cthun-client/src/log/log.h>
+
+LOG_DECLARE_NAMESPACE("agent.agent");
+
+namespace CthunAgent {
+namespace Modules {
+
+Ping::Ping() {
+    name = "ping";
+
+    valijson::constraints::TypeConstraint json_type_object(valijson::constraints::TypeConstraint::kObject);
+
+    valijson::Schema input_schema;
+    input_schema.addConstraint(json_type_object);
+
+    valijson::Schema output_schema;
+    output_schema.addConstraint(json_type_object);
+
+    actions["ping"] = Action { input_schema, output_schema };
+}
+
+void Ping::ping_action(const Json::Value& input, Json::Value& output) {
+    int sender_timestamp;
+    std::istringstream(input["sender_timestamp"].asString()) >> sender_timestamp;
+    boost::posix_time::ptime current_date_microseconds = boost::posix_time::microsec_clock::local_time();
+    long current_date_milliseconds = current_date_microseconds.time_of_day().total_milliseconds();
+    long time_to_agent = current_date_milliseconds - sender_timestamp;
+    Json::Value result;
+    result["time_to_agent"] = std::to_string(time_to_agent);
+    result["agent_timestamp"] = std::to_string(current_date_milliseconds);
+    output = result;
+}
+
+void Ping::call_action(std::string action, const Json::Value& input, Json::Value& output) {
+    if (action.compare("ping") == 0) {
+        ping_action(input, output);
+    } else {
+        LOG_ERROR("Invalid action for module ping: %s", action);
+        Json::Value result;
+        result["error"] = "Unknown action: '" + action + "'";
+        output = result;
+    }
+}
+
+}  // namespace Modules
+}  // namespace CthunAgent

--- a/src/modules/ping.h
+++ b/src/modules/ping.h
@@ -1,0 +1,22 @@
+#ifndef SRC_MODULES_PING_H_
+#define SRC_MODULES_PING_H_
+
+#include "../module.h"
+
+namespace CthunAgent {
+namespace Modules {
+
+class Ping : public CthunAgent::Module {
+  public:
+    Ping();
+    void call_action(std::string name, const Json::Value& input, Json::Value& output);
+    /// Ping action calculates the time it took for a message to travel from
+    /// the controller to the agent. It will then add that duration and the
+    /// current server time in milliseconds to the response.
+    void ping_action(const Json::Value& input, Json::Value& output);
+};
+
+}  // namespace Modules
+}  // namespace CthunAgent
+
+#endif  // SRC_MODULES_PING_H_


### PR DESCRIPTION
This commit adds the native ping module to cthun-agent.

The module responds to the ping action which will update the response
message with the time it took the message to travel from controller to
agent and the current time in ms on the agent.
