### PR TITLE
(maint) - Cthun::Agent namespace instead of CthunAgent

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.12)
 
 set(SOURCES
     "${CMAKE_CURRENT_LIST_DIR}/main.cpp"
-    "${CMAKE_CURRENT_LIST_DIR}/agent.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/agent_endpoint.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/schemas.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/module.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/external_module.cpp"

--- a/src/action.h
+++ b/src/action.h
@@ -3,7 +3,8 @@
 
 #include <valijson/schema.hpp>
 
-namespace CthunAgent {
+namespace Cthun {
+namespace Agent {
 
 class Action {
   public:
@@ -11,6 +12,7 @@ class Action {
     valijson::Schema output_schema;
 };
 
-}  // namespace CthunAgent
+}  // namespace Agent
+}  // namespace Cthun
 
 #endif  // SRC_ACTION_H_

--- a/src/agent_endpoint.h
+++ b/src/agent_endpoint.h
@@ -1,5 +1,5 @@
-#ifndef SRC_AGENT_H_
-#define SRC_AGENT_H_
+#ifndef SRC_AGENT_ENDPOINT_H_
+#define SRC_AGENT_ENDPOINT_H_
 
 #include "module.h"
 
@@ -11,7 +11,8 @@
 #include <thread>
 #include <memory>
 
-namespace CthunAgent {
+namespace Cthun {
+namespace Agent {
 
 //
 // HeartbeatTask
@@ -34,13 +35,13 @@ class HeartbeatTask {
 };
 
 //
-// Agent
+// Agent Endpoint
 //
 
-class Agent {
+class AgentEndpoint {
   public:
-    Agent();
-    ~Agent();
+    AgentEndpoint();
+    ~AgentEndpoint();
 
     // for development purposes
     void run(std::string module, std::string action);
@@ -63,6 +64,7 @@ class Agent {
     Cthun::Client::Connection::Ptr connection_ptr_ { nullptr };
 };
 
-}  // namespace CthunAgent
+}  // namespace Agent
+}  // namespace Cthun
 
-#endif  // SRC_AGENT_H_
+#endif  // SRC_AGENT_ENDPOINT_H_

--- a/src/errors.h
+++ b/src/errors.h
@@ -4,7 +4,8 @@
 #include <stdexcept>
 #include <string>
 
-namespace CthunAgent {
+namespace Cthun {
+namespace Agent {
 
 /// Base error class.
 class agent_error : public std::runtime_error {
@@ -30,6 +31,7 @@ class validation_error : public agent_error {
     explicit validation_error(std::string const& msg) : agent_error(msg) {}
 };
 
-}  // namespace CthunAgent
+}  // namespace Agent
+}  // namespace Cthun
 
 #endif  // SRC_ERRORS_H_

--- a/src/external_module.cpp
+++ b/src/external_module.cpp
@@ -14,9 +14,11 @@
 
 LOG_DECLARE_NAMESPACE("agent.external_module");
 
-namespace CthunAgent {
+namespace Cthun {
+namespace Agent {
 
-void run_command(std::string exec, std::vector<std::string> args, std::string stdin, std::string &stdout, std::string &stderr) {
+void run_command(std::string exec, std::vector<std::string> args,
+                 std::string stdin, std::string &stdout, std::string &stderr) {
     boost::process::context context;
     context.stdin_behavior = boost::process::capture_stream();
     context.stdout_behavior = boost::process::capture_stream();
@@ -46,7 +48,7 @@ void run_command(std::string exec, std::vector<std::string> args, std::string st
 ExternalModule::ExternalModule(std::string path) : path_(path) {
     boost::filesystem::path module_path { path };
 
-    name = module_path.filename().string();
+    module_name = module_path.filename().string();
 
     valijson::Schema metadata_schema = Schemas::external_action_metadata();
 
@@ -99,7 +101,7 @@ ExternalModule::ExternalModule(std::string path) : path_(path) {
     }
 }
 
-void ExternalModule::call_action(const std::string action,
+void ExternalModule::call_action(const std::string action_name,
                                  const Json::Value& input,
                                  Json::Value& output) {
     std::string stdin = input.toStyledString();
@@ -107,7 +109,7 @@ void ExternalModule::call_action(const std::string action,
     std::string stderr;
     LOG_INFO(stdin);
 
-    run_command(path_, { path_, action }, stdin, stdout, stderr);
+    run_command(path_, { path_, action_name }, stdin, stdout, stderr);
     LOG_INFO("stdout: %1%", stdout);
     LOG_INFO("stderr: %1%", stderr);
 
@@ -118,4 +120,5 @@ void ExternalModule::call_action(const std::string action,
     }
 }
 
-}  // namespace CthunAgent
+}  // namespace Agent
+}  // namespace Cthun

--- a/src/external_module.h
+++ b/src/external_module.h
@@ -5,16 +5,19 @@
 #include <string>
 #include "module.h"
 
-namespace CthunAgent {
+namespace Cthun {
+namespace Agent {
 
 class ExternalModule : public Module {
   public:
     explicit ExternalModule(std::string path);
-    void call_action(std::string action, const Json::Value& input, Json::Value& output);
+    void call_action(std::string action_name, const Json::Value& input,
+                     Json::Value& output);
   private:
     std::string path_;
 };
 
-}  // namespace CthunAgent
+}  // namespace Agent
+}  // namespace Cthun
 
 #endif  // SRC_EXTERNAL_MODULE_H_

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -9,26 +9,27 @@
 
 LOG_DECLARE_NAMESPACE("agent.module");
 
-namespace CthunAgent {
+namespace Cthun {
+namespace Agent {
 
-void Module::call_action(std::string action, const Json::Value& input,
+void Module::call_action(std::string action_name, const Json::Value& input,
                          Json::Value& output) {
-    LOG_INFO("invoking native action %1%", action);
+    LOG_INFO("invoking native action %1%", action_name);
 }
 
-void Module::validate_and_call_action(std::string action,
+void Module::validate_and_call_action(std::string action_name,
                                       const Json::Value& input,
                                       Json::Value& output) {
-    if (actions.find(action) == actions.end()) {
-        throw validation_error { "unknown action for module " + name
-                                 + ": '" + action + "'" };
+    if (actions.find(action_name) == actions.end()) {
+        throw validation_error { "unknown action for module " + module_name
+                                 + ": '" + action_name + "'" };
     }
 
-    const Action& action_to_invoke = actions[action];
+    const Action& action = actions[action_name];
 
-    LOG_INFO("validating input for '%1% %2%'", name, action);
+    LOG_INFO("validating input for '%1% %2%'", module_name, action_name);
     std::vector<std::string> errors;
-    if (!Schemas::validate(input, action_to_invoke.input_schema, errors)) {
+    if (!Schemas::validate(input, action.input_schema, errors)) {
         LOG_ERROR("validation failed");
         for (auto error : errors) {
             LOG_ERROR("    %1%", error);
@@ -37,10 +38,10 @@ void Module::validate_and_call_action(std::string action,
         throw validation_error { "Input schema mismatch" };
     }
 
-    call_action(action, input, output);
+    call_action(action_name, input, output);
 
-    LOG_INFO("validating output for %1% %2%", name, action);
-    if (!Schemas::validate(output, action_to_invoke.output_schema, errors)) {
+    LOG_INFO("validating output for %1% %2%", module_name, action_name);
+    if (!Schemas::validate(output, action.output_schema, errors)) {
         LOG_ERROR("validation failed");
         for (auto error : errors) {
             LOG_ERROR("    %1%", error);
@@ -50,4 +51,5 @@ void Module::validate_and_call_action(std::string action,
     }
 }
 
-}  // namespace CthunAgent
+}  // namespace Agent
+}  // namespace Cthun

--- a/src/module.h
+++ b/src/module.h
@@ -8,26 +8,27 @@
 
 #include "action.h"
 
-namespace CthunAgent {
+namespace Cthun {
+namespace Agent {
 
 class Module {
   public:
-    std::string name;
+    std::string module_name;
     std::map<std::string, Action> actions;
 
-    virtual void call_action(std::string action,
-                             const Json::Value& input,
+    virtual void call_action(std::string action_name, const Json::Value& input,
                              Json::Value& output) = 0;
 
     /// Validate the json schemas of input and output.
     /// Execute the requested action for the particular module.
     /// Sets an error response in the referred output json object
     /// in case of unknown action or invalid schemas.
-    void validate_and_call_action(std::string action,
+    void validate_and_call_action(std::string action_name,
                                   const Json::Value& input,
                                   Json::Value& output);
 };
 
-}  // namespace CthunAgent
+}  // namespace Agent
+}  // namespace Cthun
 
 #endif  // SRC_MODULE_H_

--- a/src/modules/echo.cpp
+++ b/src/modules/echo.cpp
@@ -2,14 +2,15 @@
 
 #include <valijson/constraints/concrete_constraints.hpp>
 
-namespace CthunAgent {
+namespace Cthun {
+namespace Agent {
 namespace Modules {
 
 Echo::Echo() {
-    // Set the module name
-    name = "echo";
+    module_name = "echo";
 
-    valijson::constraints::TypeConstraint json_type_string(valijson::constraints::TypeConstraint::kString);
+    valijson::constraints::TypeConstraint json_type_string {
+        valijson::constraints::TypeConstraint::kString };
 
     valijson::Schema input_schema;
     input_schema.addConstraint(json_type_string);
@@ -20,9 +21,11 @@ Echo::Echo() {
     actions["echo"] = Action { input_schema, output_schema };
 }
 
-void Echo::call_action(std::string action, const Json::Value& input, Json::Value& output) {
+void Echo::call_action(std::string action_name, const Json::Value& input,
+                       Json::Value& output) {
     output = Json::Value { input.asString() };
 }
 
 }  // namespace Modules
-}  // namespace CthunAgent
+}  // namespace Agent
+}  // namespace Cthun

--- a/src/modules/echo.h
+++ b/src/modules/echo.h
@@ -3,16 +3,19 @@
 
 #include "../module.h"
 
-namespace CthunAgent {
+namespace Cthun {
+namespace Agent {
 namespace Modules {
 
-class Echo : public CthunAgent::Module {
+class Echo : public Cthun::Agent::Module {
   public:
     Echo();
-    void call_action(std::string name,  const Json::Value& input, Json::Value& output);
+    void call_action(std::string action_name, const Json::Value& input,
+                     Json::Value& output);
 };
 
 }  // namespace Modules
-}  // namespace CthunAgent
+}  // namespace Agent
+}  // namespace Cthun
 
 #endif  // SRC_MODULES_ECHO_H_

--- a/src/modules/inventory.cpp
+++ b/src/modules/inventory.cpp
@@ -10,12 +10,12 @@
 
 LOG_DECLARE_NAMESPACE("agent.inventory");
 
-namespace CthunAgent {
+namespace Cthun {
+namespace Agent {
 namespace Modules {
 
 Inventory::Inventory() {
-    // Set the module name
-    name = "inventory";
+    module_name = "inventory";
 
     valijson::constraints::TypeConstraint json_type_object {
         valijson::constraints::TypeConstraint::kObject
@@ -30,8 +30,7 @@ Inventory::Inventory() {
     actions["inventory"] = Action { input_schema, output_schema };
 }
 
-void Inventory::call_action(std::string action,
-                            const Json::Value& input,
+void Inventory::call_action(std::string action_name, const Json::Value& input,
                             Json::Value& output) {
     std::ostringstream fact_stream;
 
@@ -61,4 +60,5 @@ void Inventory::call_action(std::string action,
 }
 
 }  // namespace Modules
-}  // namespace CthunAgent
+}  // namespace Agent
+}  // namespace Cthun

--- a/src/modules/inventory.h
+++ b/src/modules/inventory.h
@@ -3,18 +3,19 @@
 
 #include "../module.h"
 
-namespace CthunAgent {
+namespace Cthun {
+namespace Agent {
 namespace Modules {
 
-class Inventory : public CthunAgent::Module {
+class Inventory : public Cthun::Agent::Module {
   public:
     Inventory();
-    void call_action(std::string name,
-                     const Json::Value& input,
+    void call_action(std::string action_name, const Json::Value& input,
                      Json::Value& output);
 };
 
 }  // namespace Modules
-}  // namespace CthunAgent
+}  // namespace Agent
+}  // namespace Cthun
 
 #endif  // SRC_MODULES_INVENTORY_H_

--- a/src/modules/ping.cpp
+++ b/src/modules/ping.cpp
@@ -11,12 +11,12 @@
 
 LOG_DECLARE_NAMESPACE("agent.ping");
 
-namespace CthunAgent {
+namespace Cthun {
+namespace Agent {
 namespace Modules {
 
 Ping::Ping() {
-    // Set the module name
-    name = "ping";
+    module_name = "ping";
 
     valijson::constraints::TypeConstraint json_type_object {
         valijson::constraints::TypeConstraint::kObject };
@@ -45,11 +45,12 @@ void Ping::ping_action(const Json::Value& input, Json::Value& output) {
     output = result;
 }
 
-void Ping::call_action(std::string action,
+void Ping::call_action(std::string action_name,
                        const Json::Value& input,
                        Json::Value& output) {
     ping_action(input, output);
 }
 
 }  // namespace Modules
-}  // namespace CthunAgent
+}  // namespace Agent
+}  // namespace Cthun

--- a/src/modules/ping.h
+++ b/src/modules/ping.h
@@ -3,13 +3,16 @@
 
 #include "../module.h"
 
-namespace CthunAgent {
+namespace Cthun {
+namespace Agent {
 namespace Modules {
 
-class Ping : public CthunAgent::Module {
+class Ping : public Cthun::Agent::Module {
   public:
     Ping();
-    void call_action(std::string name, const Json::Value& input, Json::Value& output);
+    void call_action(std::string action_name, const Json::Value& input,
+                     Json::Value& output);
+
     /// Ping action calculates the time it took for a message to travel from
     /// the controller to the agent. It will then add that duration and the
     /// current server time in milliseconds to the response.
@@ -17,6 +20,7 @@ class Ping : public CthunAgent::Module {
 };
 
 }  // namespace Modules
-}  // namespace CthunAgent
+}  // namespace Agent
+}  // namespace Cthun
 
 #endif  // SRC_MODULES_PING_H_

--- a/src/schemas.cpp
+++ b/src/schemas.cpp
@@ -7,9 +7,12 @@
 
 // TODO(ale): log messages
 
-namespace CthunAgent {
+namespace Cthun {
+namespace Agent {
 
-bool Schemas::validate(const Json::Value& document, const valijson::Schema& schema, std::vector<std::string>& errors) {
+bool Schemas::validate(const Json::Value& document,
+                       const valijson::Schema& schema,
+                       std::vector<std::string>& errors) {
     valijson::Validator validator(schema);
     valijson::adapters::JsonCppAdapter adapted_document(document);
 
@@ -34,8 +37,10 @@ bool Schemas::validate(const Json::Value& document, const valijson::Schema& sche
 
 valijson::Schema action_subschema() {
     // some common schema constants to reduce typing
-    valijson::constraints::TypeConstraint json_type_object(valijson::constraints::TypeConstraint::kObject);
-    valijson::constraints::TypeConstraint json_type_string(valijson::constraints::TypeConstraint::kString);
+    valijson::constraints::TypeConstraint json_type_object {
+        valijson::constraints::TypeConstraint::kObject };
+    valijson::constraints::TypeConstraint json_type_string {
+        valijson::constraints::TypeConstraint::kString };
 
     // action sub-schema
     valijson::Schema schema;
@@ -62,7 +67,8 @@ valijson::Schema action_subschema() {
                               pattern_properties));
 
     // specify the required properties
-    schema.addConstraint(new valijson::constraints::RequiredConstraint(required_properties));
+    schema.addConstraint(
+        new valijson::constraints::RequiredConstraint(required_properties));
 
     return schema;
 }
@@ -71,9 +77,12 @@ valijson::Schema Schemas::external_action_metadata() {
     valijson::Schema schema;
 
     // some common schema constants to reduce typing
-    valijson::constraints::TypeConstraint json_type_object(valijson::constraints::TypeConstraint::kObject);
-    valijson::constraints::TypeConstraint json_type_string(valijson::constraints::TypeConstraint::kString);
-    valijson::constraints::TypeConstraint json_type_array(valijson::constraints::TypeConstraint::kArray);
+    valijson::constraints::TypeConstraint json_type_object {
+        valijson::constraints::TypeConstraint::kObject };
+    valijson::constraints::TypeConstraint json_type_string {
+        valijson::constraints::TypeConstraint::kString };
+    valijson::constraints::TypeConstraint json_type_array {
+        valijson::constraints::TypeConstraint::kArray };
 
     valijson::constraints::PropertiesConstraint::PropertySchemaMap properties;
     valijson::constraints::PropertiesConstraint::PropertySchemaMap pattern_properties;
@@ -90,16 +99,19 @@ valijson::Schema Schemas::external_action_metadata() {
     properties["actions"].addConstraint(json_type_array);
 
     valijson::Schema action_schema = action_subschema();
-    valijson::constraints::ItemsConstraint items_of_type_action_schema(action_schema);
+    valijson::constraints::ItemsConstraint items_of_type_action_schema {
+        action_schema };
     properties["actions"].addConstraint(items_of_type_action_schema);
 
-    // constrain the properties to just those in the properies and pattern_properties maps
+    // constrain the properties to just those in the properies and
+    // pattern_properties maps
     schema.addConstraint(new valijson::constraints::PropertiesConstraint(
                              properties,
                              pattern_properties));
 
     // specify the required properties
-    schema.addConstraint(new valijson::constraints::RequiredConstraint(required_properties));
+    schema.addConstraint(
+        new valijson::constraints::RequiredConstraint(required_properties));
 
     return schema;
 }
@@ -108,10 +120,14 @@ valijson::Schema Schemas::network_message() {
     valijson::Schema schema;
 
     // some common schema constants to reduce typing
-    valijson::constraints::TypeConstraint json_type_object(valijson::constraints::TypeConstraint::kObject);
-    valijson::constraints::TypeConstraint json_type_string(valijson::constraints::TypeConstraint::kString);
-    valijson::constraints::TypeConstraint json_type_array(valijson::constraints::TypeConstraint::kArray);
-    valijson::constraints::TypeConstraint json_type_integer(valijson::constraints::TypeConstraint::kInteger);
+    valijson::constraints::TypeConstraint json_type_object {
+        valijson::constraints::TypeConstraint::kObject };
+    valijson::constraints::TypeConstraint json_type_string {
+        valijson::constraints::TypeConstraint::kString };
+    valijson::constraints::TypeConstraint json_type_array {
+        valijson::constraints::TypeConstraint::kArray };
+    valijson::constraints::TypeConstraint json_type_integer {
+        valijson::constraints::TypeConstraint::kInteger };
 
     valijson::constraints::PropertiesConstraint::PropertySchemaMap properties;
     valijson::constraints::PropertiesConstraint::PropertySchemaMap pattern_properties;
@@ -150,13 +166,15 @@ valijson::Schema Schemas::network_message() {
     // primitive.  cnc schema will be an object though
     properties["data"].addConstraint(json_type_object);
 
-    // constrain the properties to just those in the properies and pattern_properties maps
+    // constrain the properties to just those in the properies and
+    // pattern_properties maps
     schema.addConstraint(new valijson::constraints::PropertiesConstraint(
                              properties,
                              pattern_properties));
 
     // specify the required properties
-    schema.addConstraint(new valijson::constraints::RequiredConstraint(required_properties));
+    schema.addConstraint(
+        new valijson::constraints::RequiredConstraint(required_properties));
 
     return schema;
 }
@@ -165,8 +183,10 @@ valijson::Schema Schemas::cnc_data() {
     valijson::Schema schema;
 
     // some common schema constants to reduce typing
-    valijson::constraints::TypeConstraint json_type_object(valijson::constraints::TypeConstraint::kObject);
-    valijson::constraints::TypeConstraint json_type_string(valijson::constraints::TypeConstraint::kString);
+    valijson::constraints::TypeConstraint json_type_object {
+        valijson::constraints::TypeConstraint::kObject };
+    valijson::constraints::TypeConstraint json_type_string {
+        valijson::constraints::TypeConstraint::kString };
 
     valijson::constraints::PropertiesConstraint::PropertySchemaMap properties;
     valijson::constraints::PropertiesConstraint::PropertySchemaMap pattern_properties;
@@ -187,15 +207,18 @@ valijson::Schema Schemas::cnc_data() {
     properties["params"] = valijson::Schema {};
     // .addConstraint(json_type_object);
 
-    // constrain the properties to just those in the properies and pattern_properties maps
+    // constrain the properties to just those in the properies and
+    // pattern_properties maps
     schema.addConstraint(new valijson::constraints::PropertiesConstraint(
                              properties,
                              pattern_properties));
 
     // specify the required properties
-    schema.addConstraint(new valijson::constraints::RequiredConstraint(required_properties));
+    schema.addConstraint(
+        new valijson::constraints::RequiredConstraint(required_properties));
 
     return schema;
 }
 
-}  // namespace CthunAgent
+}  // namespace Agent
+}  // namespace Cthun

--- a/src/schemas.h
+++ b/src/schemas.h
@@ -4,7 +4,8 @@
 #include <json/json.h>
 #include <valijson/schema.hpp>
 
-namespace CthunAgent {
+namespace Cthun {
+namespace Agent {
 
 class Schemas {
   public:
@@ -16,6 +17,7 @@ class Schemas {
     static valijson::Schema cnc_data();
 };
 
-}  // namespace CthunAgent
+}  // namespace Agent
+}  // namespace Cthun
 
 #endif  // SRC_SCHEMAS_H_


### PR DESCRIPTION
Using Cthun::Agent to ease the integration of the cthun-client library.

Renaming Cthun::Agent::Agent to Cthun::Agent::AgentEndpoint (and relative .cpp .h files).
Renaming variables action and module to action_name and module_name.
Few format style changes.
