### PR TITLE
(CTH-57) - Copying WebSocket functionality from cthun-client

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,20 +26,18 @@ endif()
 # Find libraries
 
 find_package(Boost 1.54 REQUIRED
-  COMPONENTS program_options filesystem system date_time thread log log_setup regex random)
+  COMPONENTS program_options filesystem system date_time thread log regex random)
 
 find_package(OpenSSL REQUIRED)
 
-# Include vendored libraries
+# Specify the .cmake files for vendored libraries
 
-include(${VENDOR_DIRECTORY}/gmock.cmake)
-
-# TODO(ale): cthun-agent won't comile with boost 1.56 due to valijson;
+# TODO(ale): cthun-agent won't compile with boost 1.56 due to valijson;
 # must investigate valijson compatibility. Error:
 # valijson/schema.hpp:177:16: error:
 #   no viable conversion from 'const boost::optional<std::string>' to 'bool'
 include(${VENDOR_DIRECTORY}/valijson.cmake)
-
+include(${VENDOR_DIRECTORY}/gmock.cmake)
 include(${VENDOR_DIRECTORY}/boost-process.cmake)
 include(${VENDOR_DIRECTORY}/websocketpp.cmake)
 
@@ -48,11 +46,9 @@ include(${VENDOR_DIRECTORY}/websocketpp.cmake)
 include_directories(
     ${Boost_INCLUDE_DIRS}
     ${Boost_Process_INCLUDE_DIRS}
-    "${VENDOR_DIRECTORY}/jsoncpp"
     ${WEBSOCKETPP_INCLUDE_DIRS}
-    "${VENDOR_DIRECTORY}/cthun-client"
     ${VALIJSON_INCLUDE_DIRS}
-    ${facter_INCLUDE_DIRS}
+    "${VENDOR_DIRECTORY}/jsoncpp"
 )
 
 # Add the main binary

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,21 +1,25 @@
 cmake_minimum_required(VERSION 2.8.12)
 
+# allow include directives with absolute paths
+set(BASEPATH "${CMAKE_CURRENT_LIST_DIR}")
+INCLUDE_DIRECTORIES("${BASEPATH}")
+
 set(SOURCES
     "${CMAKE_CURRENT_LIST_DIR}/main.cpp"
-    "${CMAKE_CURRENT_LIST_DIR}/agent_endpoint.cpp"
-    "${CMAKE_CURRENT_LIST_DIR}/schemas.cpp"
-    "${CMAKE_CURRENT_LIST_DIR}/module.cpp"
-    "${CMAKE_CURRENT_LIST_DIR}/external_module.cpp"
-    "${CMAKE_CURRENT_LIST_DIR}/modules/echo.cpp"
-    "${CMAKE_CURRENT_LIST_DIR}/modules/inventory.cpp"
-    "${CMAKE_CURRENT_LIST_DIR}/modules/ping.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/agent/agent_endpoint.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/agent/schemas.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/agent/module.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/agent/external_module.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/agent/modules/echo.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/agent/modules/inventory.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/agent/modules/ping.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/common/file_utils.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/common/string_utils.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/common/log.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/websocket/endpoint.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/websocket/connection.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/websocket/connection_manager.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/../vendor/jsoncpp/jsoncpp.cpp"
-    "${VENDOR_DIRECTORY}/cthun-client/cthun-client/src/connection.cpp"
-    "${VENDOR_DIRECTORY}/cthun-client/cthun-client/src/connection_manager.cpp"
-    "${VENDOR_DIRECTORY}/cthun-client/cthun-client/src/endpoint.cpp"
-    "${VENDOR_DIRECTORY}/cthun-client/cthun-client/src/log/log.cpp"
-    "${VENDOR_DIRECTORY}/cthun-client/cthun-client/src/common/string_utils.cpp"
-    "${VENDOR_DIRECTORY}/cthun-client/cthun-client/src/common/file_utils.cpp"
 )
 
 add_executable(cthun-agent ${SOURCES})

--- a/src/agent/action.h
+++ b/src/agent/action.h
@@ -1,5 +1,5 @@
-#ifndef SRC_ACTION_H_
-#define SRC_ACTION_H_
+#ifndef SRC_AGENT_ACTION_H_
+#define SRC_AGENT_ACTION_H_
 
 #include <valijson/schema.hpp>
 
@@ -15,4 +15,4 @@ class Action {
 }  // namespace Agent
 }  // namespace Cthun
 
-#endif  // SRC_ACTION_H_
+#endif  // SRC_AGENT_ACTION_H_

--- a/src/agent/agent_endpoint.h
+++ b/src/agent/agent_endpoint.h
@@ -1,9 +1,8 @@
-#ifndef SRC_AGENT_ENDPOINT_H_
-#define SRC_AGENT_ENDPOINT_H_
+#ifndef SRC_AGENT_AGENT_ENDPOINT_H_
+#define SRC_AGENT_AGENT_ENDPOINT_H_
 
-#include "module.h"
-
-#include <cthun-client/src/connection_manager.h>
+#include "agent/module.h"
+#include "websocket/connection_manager.h"
 
 #include <map>
 #include <memory>
@@ -20,7 +19,7 @@ namespace Agent {
 
 class HeartbeatTask {
   public:
-    explicit HeartbeatTask(Cthun::Client::Connection::Ptr connection_ptr);
+    explicit HeartbeatTask(Cthun::WebSocket::Connection::Ptr connection_ptr);
     ~HeartbeatTask();
     void start();
     void stop();
@@ -29,7 +28,7 @@ class HeartbeatTask {
     bool must_stop_;
     std::thread heartbeat_thread_;
     std::string binary_payload_ { "cthun ping payload" };
-    Cthun::Client::Connection::Ptr connection_ptr_ { nullptr };
+    Cthun::WebSocket::Connection::Ptr connection_ptr_ { nullptr };
 
     void heartbeatThread();
 };
@@ -56,15 +55,15 @@ class AgentEndpoint {
     std::unique_ptr<HeartbeatTask> heartbeat_task_;
 
     void list_modules();
-    void send_login(Cthun::Client::Client_Type* client_ptr);
-    void handle_message(Cthun::Client::Client_Type* client_ptr,
+    void send_login(Cthun::WebSocket::Client_Type* client_ptr);
+    void handle_message(Cthun::WebSocket::Client_Type* client_ptr,
                         std::string message);
 
     std::map<std::string, std::shared_ptr<Module>> modules_;
-    Cthun::Client::Connection::Ptr connection_ptr_ { nullptr };
+    Cthun::WebSocket::Connection::Ptr connection_ptr_ { nullptr };
 };
 
 }  // namespace Agent
 }  // namespace Cthun
 
-#endif  // SRC_AGENT_ENDPOINT_H_
+#endif  // SRC_AGENT_AGENT_ENDPOINT_H_

--- a/src/agent/errors.h
+++ b/src/agent/errors.h
@@ -1,5 +1,5 @@
-#ifndef SRC_ERRORS_H_
-#define SRC_ERRORS_H_
+#ifndef SRC_AGENT_ERRORS_H_
+#define SRC_AGENT_ERRORS_H_
 
 #include <stdexcept>
 #include <string>
@@ -34,4 +34,4 @@ class validation_error : public agent_error {
 }  // namespace Agent
 }  // namespace Cthun
 
-#endif  // SRC_ERRORS_H_
+#endif  // SRC_AGENT_ERRORS_H_

--- a/src/agent/external_module.cpp
+++ b/src/agent/external_module.cpp
@@ -1,8 +1,7 @@
-#include "external_module.h"
-#include "schemas.h"
-#include "action.h"
-
-#include <cthun-client/src/log/log.h>
+#include "agent/external_module.h"
+#include "agent/schemas.h"
+#include "agent/action.h"
+#include "common/log.h"
 
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/path.hpp>

--- a/src/agent/external_module.h
+++ b/src/agent/external_module.h
@@ -1,9 +1,10 @@
-#ifndef SRC_EXTERNAL_MODULE_H_
-#define SRC_EXTERNAL_MODULE_H_
+#ifndef SRC_AGENT_EXTERNAL_MODULE_H_
+#define SRC_AGENT_EXTERNAL_MODULE_H_
+
+#include "module.h"
 
 #include <map>
 #include <string>
-#include "module.h"
 
 namespace Cthun {
 namespace Agent {
@@ -20,4 +21,4 @@ class ExternalModule : public Module {
 }  // namespace Agent
 }  // namespace Cthun
 
-#endif  // SRC_EXTERNAL_MODULE_H_
+#endif  // SRC_AGENT_EXTERNAL_MODULE_H_

--- a/src/agent/module.cpp
+++ b/src/agent/module.cpp
@@ -1,8 +1,7 @@
-#include "module.h"
-#include "schemas.h"
-#include "errors.h"
-
-#include <cthun-client/src/log/log.h>
+#include "agent/module.h"
+#include "agent/schemas.h"
+#include "agent/errors.h"
+#include "common/log.h"
 
 #include <valijson/adapters/jsoncpp_adapter.hpp>
 #include <valijson/schema_parser.hpp>

--- a/src/agent/module.h
+++ b/src/agent/module.h
@@ -1,12 +1,12 @@
-#ifndef SRC_MODULE_H_
-#define SRC_MODULE_H_
+#ifndef SRC_AGENT_MODULE_H_
+#define SRC_AGENT_MODULE_H_
 
-#include <map>
-#include <string>
+#include "agent/action.h"
 
 #include <json/json.h>
 
-#include "action.h"
+#include <map>
+#include <string>
 
 namespace Cthun {
 namespace Agent {
@@ -31,4 +31,4 @@ class Module {
 }  // namespace Agent
 }  // namespace Cthun
 
-#endif  // SRC_MODULE_H_
+#endif  // SRC_AGENT_MODULE_H_

--- a/src/agent/modules/echo.cpp
+++ b/src/agent/modules/echo.cpp
@@ -1,4 +1,4 @@
-#include "echo.h"
+#include "agent/modules/echo.h"
 
 #include <valijson/constraints/concrete_constraints.hpp>
 

--- a/src/agent/modules/echo.h
+++ b/src/agent/modules/echo.h
@@ -1,15 +1,15 @@
-#ifndef SRC_MODULES_INVENTORY_H_
-#define SRC_MODULES_INVENTORY_H_
+#ifndef SRC_AGENT_MODULES_ECHO_H_
+#define SRC_AGENT_MODULES_ECHO_H_
 
-#include "../module.h"
+#include "agent/module.h"
 
 namespace Cthun {
 namespace Agent {
 namespace Modules {
 
-class Inventory : public Cthun::Agent::Module {
+class Echo : public Cthun::Agent::Module {
   public:
-    Inventory();
+    Echo();
     void call_action(std::string action_name, const Json::Value& input,
                      Json::Value& output);
 };
@@ -18,4 +18,4 @@ class Inventory : public Cthun::Agent::Module {
 }  // namespace Agent
 }  // namespace Cthun
 
-#endif  // SRC_MODULES_INVENTORY_H_
+#endif  // SRC_AGENT_MODULES_ECHO_H_

--- a/src/agent/modules/inventory.cpp
+++ b/src/agent/modules/inventory.cpp
@@ -1,14 +1,13 @@
-#include "inventory.h"
+#include "agent/modules/inventory.h"
+#include "common/log.h"
 
 #include <facter/facts/collection.hpp>
-
-#include <cthun-client/src/log/log.h>
 
 #include <valijson/constraints/concrete_constraints.hpp>
 
 #include <sstream>
 
-LOG_DECLARE_NAMESPACE("agent.inventory");
+LOG_DECLARE_NAMESPACE("agent.modules.inventory");
 
 namespace Cthun {
 namespace Agent {

--- a/src/agent/modules/inventory.h
+++ b/src/agent/modules/inventory.h
@@ -1,15 +1,15 @@
-#ifndef SRC_MODULES_ECHO_H_
-#define SRC_MODULES_ECHO_H_
+#ifndef SRC_AGENT_MODULES_INVENTORY_H_
+#define SRC_AGENT_MODULES_INVENTORY_H_
 
-#include "../module.h"
+#include "agent/module.h"
 
 namespace Cthun {
 namespace Agent {
 namespace Modules {
 
-class Echo : public Cthun::Agent::Module {
+class Inventory : public Cthun::Agent::Module {
   public:
-    Echo();
+    Inventory();
     void call_action(std::string action_name, const Json::Value& input,
                      Json::Value& output);
 };
@@ -18,4 +18,4 @@ class Echo : public Cthun::Agent::Module {
 }  // namespace Agent
 }  // namespace Cthun
 
-#endif  // SRC_MODULES_ECHO_H_
+#endif  // SRC_AGENT_MODULES_INVENTORY_H_

--- a/src/agent/modules/ping.cpp
+++ b/src/agent/modules/ping.cpp
@@ -1,6 +1,5 @@
-#include "ping.h"
-
-#include <cthun-client/src/log/log.h>
+#include "agent/modules/ping.h"
+#include "common/log.h"
 
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <valijson/constraints/concrete_constraints.hpp>
@@ -9,7 +8,7 @@
 #include <string>
 #include <sstream>
 
-LOG_DECLARE_NAMESPACE("agent.ping");
+LOG_DECLARE_NAMESPACE("agent.modules.ping");
 
 namespace Cthun {
 namespace Agent {

--- a/src/agent/modules/ping.h
+++ b/src/agent/modules/ping.h
@@ -1,7 +1,7 @@
-#ifndef SRC_MODULES_PING_H_
-#define SRC_MODULES_PING_H_
+#ifndef SRC_AGENT_MODULES_PING_H_
+#define SRC_AGENT_MODULES_PING_H_
 
-#include "../module.h"
+#include "agent/module.h"
 
 namespace Cthun {
 namespace Agent {
@@ -23,4 +23,4 @@ class Ping : public Cthun::Agent::Module {
 }  // namespace Agent
 }  // namespace Cthun
 
-#endif  // SRC_MODULES_PING_H_
+#endif  // SRC_AGENT_MODULES_PING_H_

--- a/src/agent/schemas.cpp
+++ b/src/agent/schemas.cpp
@@ -1,4 +1,4 @@
-#include "schemas.h"
+#include "agent/schemas.h"
 
 #include <valijson/adapters/jsoncpp_adapter.hpp>
 #include <valijson/schema_parser.hpp>

--- a/src/agent/schemas.h
+++ b/src/agent/schemas.h
@@ -1,5 +1,5 @@
-#ifndef SRC_SCHEMAS_H_
-#define SRC_SCHEMAS_H_
+#ifndef SRC_AGENT_SCHEMAS_H_
+#define SRC_AGENT_SCHEMAS_H_
 
 #include <json/json.h>
 #include <valijson/schema.hpp>
@@ -20,4 +20,4 @@ class Schemas {
 }  // namespace Agent
 }  // namespace Cthun
 
-#endif  // SRC_SCHEMAS_H_
+#endif  // SRC_AGENT_SCHEMAS_H_

--- a/src/common/file_utils.cpp
+++ b/src/common/file_utils.cpp
@@ -1,0 +1,74 @@
+#include "common/file_utils.h"
+#include "common/log.h"
+
+#include <wordexp.h>
+#include <fstream>
+#include <unistd.h>
+#include <sys/types.h>
+#include <pwd.h>
+
+LOG_DECLARE_NAMESPACE("common.file_utils");
+
+namespace Cthun {
+namespace Common {
+namespace FileUtils {
+
+// HERE(ale): copied from Pegasus
+
+// TODO(ale): look for boost alternatives
+
+std::string expandAsDoneByShell(std::string txt) {
+    // This will store the expansion outcome
+    wordexp_t result;
+
+    // Expand and check the success
+    if (wordexp(txt.c_str(), &result, 0) != 0) {
+        wordfree(&result);
+        return "";
+    }
+
+    // Get the expanded text and free the memory
+    std::string expanded_txt { result.we_wordv[0] };
+    wordfree(&result);
+    return expanded_txt;
+}
+
+bool fileExists(const std::string& file_path) {
+    bool exists { false };
+    if (file_path.empty()) {
+        LOG_WARNING("file path is an empty string");
+    } else {
+        std::ifstream file_stream { file_path };
+        exists = file_stream.good();
+        file_stream.close();
+    }
+    return exists;
+}
+
+void removeFile(const std::string& file_path) {
+    if (FileUtils::fileExists(file_path)) {
+        if (std::remove(file_path.c_str()) != 0) {
+            throw file_error { "failed to remove " + file_path };
+        }
+    }
+}
+
+void streamToFile(const std::string& text,
+                  const std::string& file_path,
+                  std::ios_base::openmode mode) {
+    std::ofstream ofs;
+    ofs.open(file_path, mode);
+    if (!ofs.is_open()) {
+        throw file_error { "failed to open " + file_path };
+    }
+    ofs << text;
+}
+
+void writeToFile(const std::string& text, const std::string& file_path) {
+    streamToFile(text, file_path, std::ofstream::out
+                                | std::ofstream::trunc);
+}
+
+}  // namespace FileUtils
+}  // namespace Common
+}  // namespace Cthun

--- a/src/common/file_utils.h
+++ b/src/common/file_utils.h
@@ -1,0 +1,53 @@
+#ifndef SRC_COMMON_FILEUTILS_H_
+#define SRC_COMMON_FILEUTILS_H_
+
+#include <wordexp.h>
+#include <fstream>
+#include <stdexcept>
+
+namespace Cthun {
+namespace Common {
+namespace FileUtils {
+
+//
+// Error
+//
+
+/// Generic file error class.
+class file_error : public std::runtime_error {
+  public:
+    explicit file_error(std::string const& msg) : std::runtime_error(msg) {}
+};
+
+//
+// Free functions
+//
+
+/// Perform a shell expansion of txt.
+/// Return an empty string in case of failure.
+std::string expandAsDoneByShell(std::string txt);
+
+/// Return true if the specified file exists.
+bool fileExists(const std::string& file_path);
+
+/// Remove a file if exists.
+/// Throw a file_error if the removal fails.
+void removeFile(const std::string& file_path);
+
+/// Write content to file in the specified mode.
+/// Throw a file_error in case it fails to open the file to write.
+void streamToFile(const std::string& text,
+                  const std::string&  file_path,
+                  std::ios_base::openmode mode);
+
+/// Write content to file. If file exists, its previous content will
+/// be deleted.
+/// Throw a file_error in case it fails to open file to write.
+void writeToFile(const std::string& text,
+                 const std::string& file_path);
+
+}  // namespace FileUtils
+}  // namespace Common
+}  // namespace Cthun
+
+#endif  // SRC_COMMON_FILEUTILS_H_

--- a/src/common/log.cpp
+++ b/src/common/log.cpp
@@ -1,0 +1,129 @@
+#include "common/log.h"
+
+// boost includes are not always warning-clean. Disable warnings that
+// cause problems before including the headers, then re-enable the warnings.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wextra"
+
+#include <boost/log/support/date_time.hpp>
+#include <boost/log/expressions/attr.hpp>
+#include <boost/log/expressions/formatters/date_time.hpp>
+#include <boost/log/utility/setup/console.hpp>
+#include <boost/log/utility/setup/common_attributes.hpp>
+
+#include <boost/log/sources/severity_logger.hpp>
+#include <boost/log/sources/record_ostream.hpp>
+#include <boost/log/attributes/scoped_attribute.hpp>
+#include <boost/log/attributes/current_thread_id.hpp>
+
+#include <vector>
+#include <unistd.h>
+
+#pragma GCC diagnostic pop
+
+namespace Cthun {
+
+bool Log::is_log_enabled(const std::string &logger, Log::log_level level) {
+    // If the severity_logger returns a record for the specified
+    // level, logging is enabled. Otherwise it isn't.
+    // This is the guard call used in BOOST_LOG_SEV; see
+    // www.boost.org/doc/libs/1_54_0/libs/log/doc/html/log/detailed/sources.html
+    boost::log::sources::severity_logger<Log::log_level> slg;
+    return (slg.open_record(boost::log::keywords::severity = level) ? true : false);
+}
+
+void Log::configure_logging(Log::log_level level, std::ostream &dst) {
+    // Set filtering based on log_level (info, warning, debug, etc).
+    auto sink = boost::log::add_console_log(dst);
+
+    sink->set_formatter(boost::log::expressions::stream
+        << boost::log::expressions::format_date_time<boost::posix_time::ptime>(
+            "TimeStamp", "%Y-%m-%d %H:%M:%S.%f")
+        << " " << boost::log::expressions::attr<
+            boost::log::attributes::current_thread_id::value_type>("ThreadID")
+        << " " << std::left << std::setfill(' ') << std::setw(5)
+        << Log::log_level_attr << " ["
+        << Log::namespace_attr << ":"
+        << boost::log::expressions::smessage);
+
+    sink->set_filter(log_level_attr >= level);
+    boost::log::add_common_attributes();
+}
+
+std::ostream& Log::operator<<(std::ostream& strm, Log::log_level level) {
+    std::vector<std::string> levels {
+        "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL" };
+    if (static_cast<size_t>(level) < levels.size()) {
+        strm << levels[static_cast<size_t>(level)];
+    } else {
+        strm << static_cast<int>(level);
+    }
+    return strm;
+}
+
+void Log::log(const std::string &logger, Log::log_level level, int line_num,
+              boost::format& message) {
+    log(logger, level, line_num, message.str());
+}
+
+//
+// POSIX implementation of log()
+//
+
+// HERE(ale): we don't have the Win32 implementation; see cfacter
+
+static std::string cyan(std::string const& message) {
+    return "\33[0;36m" + message + "\33[0m";
+}
+
+static std::string green(std::string const& message) {
+    return "\33[0;32m" + message + "\33[0m";
+}
+
+static std::string yellow(std::string const& message) {
+    return "\33[0;33m" + message + "\33[0m";
+}
+
+static std::string red(std::string const& message) {
+    return "\33[0;31m" + message + "\33[0m";
+}
+
+void Log::log(const std::string &logger, Log::log_level level, int line_num,
+              std::string const& message) {
+    boost::log::sources::severity_logger<Log::log_level> slg;
+    slg.add_attribute("Namespace",
+                      boost::log::attributes::constant<std::string>(logger));
+
+    static bool color = isatty(fileno(stderr));
+    if (!color) {
+        BOOST_LOG_SEV(slg, level) << message;
+        return;
+    }
+
+    switch (level) {
+        case Log::log_level::trace:
+            BOOST_LOG_SEV(slg, level) << line_num << "] - " << cyan(message);
+            break;
+        case Log::log_level::debug:
+            BOOST_LOG_SEV(slg, level) << line_num << "] - " << cyan(message);
+            break;
+        case Log::log_level::info:
+            BOOST_LOG_SEV(slg, level) << line_num << "] - " << green(message);
+            break;
+        case Log::log_level::warning:
+            BOOST_LOG_SEV(slg, level) << line_num << "] - " << yellow(message);
+            break;
+        case Log::log_level::error:
+            BOOST_LOG_SEV(slg, level) << line_num << "] - " << red(message);
+            break;
+        case Log::log_level::fatal:
+            BOOST_LOG_SEV(slg, level) << line_num << "] - " << red(message);
+            break;
+        default:
+            BOOST_LOG_SEV(slg, level) << line_num << "] - "
+                                      << "Invalid logging level used.";
+            break;
+    }
+}
+
+}  // namespace Cthun

--- a/src/common/log.h
+++ b/src/common/log.h
@@ -1,0 +1,258 @@
+#ifndef SRC_COMMON_LOG_H_
+#define SRC_COMMON_LOG_H_
+
+// HERE(ale): this code was originally copied from cfacter
+
+// TODO(ale): change "//**" to "///" for doc consistency (?)
+
+// To use this header, you must:
+// - Have Boost on the include path
+// - Link in Boost.Log
+// - Configure Boost.Log at runtime before any logging takes place
+
+/**
+ * See Boost.Log's documentation.
+ */
+#define BOOST_LOG_DYN_LINK
+
+#include <boost/log/core.hpp>
+#include <boost/log/expressions.hpp>
+#include <boost/format.hpp>
+
+#include <cstdio>
+#include <string>
+
+/**
+ * Defines the root logging namespace.
+ */
+#define LOG_ROOT_NAMESPACE "puppetlabs.cthun."
+
+/**
+ * Used to declare a logging namespace for a source file.
+ * This macro must be used before any other logging macro.
+ * @param ns The logging namespace name.
+ */
+#define LOG_DECLARE_NAMESPACE(ns) static const std::string g_logger = \
+    LOG_ROOT_NAMESPACE ns;
+
+/**
+ * Logs a message.
+ * @param level The logging level for the message.
+ * @param line_num The number of the log line in the source file.
+ * @param format The format message.
+ * @param ... The format message parameters.
+ */
+#define LOG_MESSAGE(level, line_num, format, ...) \
+    if (Cthun::Log::is_log_enabled(g_logger, level)) { \
+        Cthun::Log::log(g_logger, level, line_num, format, ##__VA_ARGS__); \
+    }
+
+/**
+ * Logs a trace message.
+ * @param format The format message.
+ * @param ... The format message parameters.
+ */
+#define LOG_TRACE(format, ...) LOG_MESSAGE(Cthun::Log::log_level::trace, \
+                                           __LINE__, format, ##__VA_ARGS__)
+
+/**
+ * Logs a debug message.
+ * @param format The format message.
+ * @param ... The format message parameters.
+ */
+#define LOG_DEBUG(format, ...) LOG_MESSAGE(Cthun::Log::log_level::debug, \
+                                           __LINE__, format, ##__VA_ARGS__)
+
+/**
+ * Logs an info message.
+ * @param format The format message.
+ * @param ... The format message parameters.
+ */
+#define LOG_INFO(format, ...) LOG_MESSAGE(Cthun::Log::log_level::info, \
+                                          __LINE__, format, ##__VA_ARGS__)
+
+/**
+ * Logs a warning message.
+ * @param format The format message.
+ * @param ... The format message parameters.
+ */
+#define LOG_WARNING(format, ...) LOG_MESSAGE(Cthun::Log::log_level::warning, \
+                                             __LINE__, format, ##__VA_ARGS__)
+
+/**
+ * Logs an error message.
+ * @param format The format message.
+ * @param ... The format message parameters.
+ */
+#define LOG_ERROR(format, ...) LOG_MESSAGE(Cthun::Log::log_level::error, \
+                                           __LINE__, format, ##__VA_ARGS__)
+
+/**
+ * Logs a fatal message.
+ * @param format The format message.
+ * @param ... The format message parameters.
+ */
+#define LOG_FATAL(format, ...) LOG_MESSAGE(Cthun::Log::log_level::fatal, \
+                                           __LINE__, format, ##__VA_ARGS__)
+
+/**
+ * Determines if the given logging level is enabled.
+ * @param level The logging level to check.
+ */
+#define LOG_IS_ENABLED(level) Cthun::Log::is_log_enabled(g_logger, level)
+
+/**
+ * Determines if the trace logging level is enabled.
+ * @returns Returns true if trace logging is enabled or false if it is
+ * not enabled.
+ */
+#define LOG_IS_TRACE_ENABLED() LOG_IS_ENABLED(Cthun::Log::log_level::trace)
+
+/**
+ * Determines if the debug logging level is enabled.
+ * @returns Returns true if debug logging is enabled or false if it is
+ * not enabled.
+ */
+#define LOG_IS_DEBUG_ENABLED() LOG_IS_ENABLED(Cthun::Log::log_level::debug)
+
+/**
+ * Determines if the info logging level is enabled.
+ * @returns Returns true if info logging is enabled or false if it is
+ * not enabled.
+ */
+#define LOG_IS_INFO_ENABLED() LOG_IS_ENABLED(Cthun::Log::log_level::info)
+
+/**
+ * Determines if the warning logging level is enabled.
+ * @returns Returns true if warning logging is enabled or false if it
+ * is not enabled.
+ */
+#define LOG_IS_WARNING_ENABLED() LOG_IS_ENABLED(Cthun::Log::log_level::warning)
+
+/**
+ * Determines if the error logging level is enabled.
+ * @returns Returns true if error logging is enabled or false if it is
+ *not enabled.
+ */
+#define LOG_IS_ERROR_ENABLED() LOG_IS_ENABLED(Cthun::Log::log_level::error)
+
+/**
+ * Determines if the fatal logging level is enabled.
+ * @returns Returns true if fatal logging is enabled or false if it is
+ * not enabled.
+ */
+#define LOG_IS_FATAL_ENABLED() LOG_IS_ENABLED(Cthun::Log::log_level::fatal)
+
+//
+// namespace Cthun::Log
+//
+
+namespace Cthun {
+namespace Log {
+
+/**
+ * Represents the supported logging levels.
+ */
+enum class log_level {
+    trace,
+    debug,
+    info,
+    warning,
+    error,
+    fatal
+};
+
+/**
+ * The Boost.Log attribute for log level (severity).
+ * The BOOST_LOG_SEV macro implicitly adds a source-specific attribute
+ * "Severity" of the template type on construction, so the attribute
+ * name "Severity" of log_level_attr is tied to BOOST_LOG_SEV.
+ */
+BOOST_LOG_ATTRIBUTE_KEYWORD(log_level_attr, "Severity", log_level);
+
+/**
+ * The Boost.Log attribute for namespace.
+ */
+BOOST_LOG_ATTRIBUTE_KEYWORD(namespace_attr, "Namespace", std::string);
+
+/**
+ * Produces the printed representation of logging level.
+ * @param strm The stream to write.
+ * @param level The logging level to print.
+ * @return Returns the stream after writing to it.
+ */
+std::ostream& operator<<(std::ostream& strm, log_level level);
+
+/**
+ * Configures default logging to the specified stream.
+ * @param level The logging level to allow on the console.
+ * @param dst Destination stream for logging output.
+ */
+void configure_logging(log_level level, std::ostream &dst);
+
+/**
+ * Determines if the given log level is enabled for the given logger.
+ * @param logger The logger to check.
+ * @param level The logging level to check.
+ * @return Returns true if the logging level is enabled or false if it
+ * is not.
+ */
+bool is_log_enabled(const std::string &logger, log_level level);
+
+/**
+ * Logs a given message to the given logger.
+ * @param logger The logger to log the message to.
+ * @param level The logging level to log with.
+ * @param message The message to log.
+ */
+void log(const std::string &logger, log_level level, int line_num,
+         std::string const& message);
+
+/**
+ * Logs a given format message to the given logger.
+ * @param logger The logger to log the message to.
+ * @param level The logging level to log with.
+ * @param line_num The number of the log line in the source file.
+ * @param message The message being formatted.
+ */
+void log(const std::string &logger, log_level level, int line_num,
+         boost::format& message);
+
+/**
+ * Logs a given format message to the given logger.
+ * @tparam T The type of the first argument.
+ * @tparam TArgs The types of the remaining arguments.
+ * @param logger The logger to log to.
+ * @param level The logging level to log with.
+ * @param line_num The number of the log line in the source file.
+ * @param message The message being formatted.
+ * @param arg The first argument to the message.
+ * @param args The remaining arguments to the message.
+ */
+template <typename T, typename... TArgs>
+void log(const std::string &logger, log_level level, int line_num,
+         boost::format& message, T arg, TArgs... args) {
+    message % arg;
+    log(logger, level, line_num, message, std::forward<TArgs>(args)...);
+}
+
+/**
+ * Logs a given format message to the given logger.
+ * @tparam TArgs The types of the arguments to format the message with.
+ * @param logger The logger to log to.
+ * @param level The logging level to log with.
+ * @param line_num The number of the log line in the source file.
+ * @param format The message format.
+ * @param args The remaining arguments to the message.
+ */
+template <typename... TArgs>
+void log(const std::string &logger, log_level level, int line_num,
+         std::string const& format, TArgs... args) {
+    boost::format message { format };
+    log(logger, level, line_num, message, std::forward<TArgs>(args)...);
+}
+
+}  // namespace Log
+}  // namespace Cthun
+
+#endif  // SRC_COMMON_LOG_H_

--- a/src/common/string_utils.cpp
+++ b/src/common/string_utils.cpp
@@ -1,0 +1,62 @@
+#include "common/string_utils.h"
+
+#include <iostream>
+#include <ctime>
+#include <time.h>
+
+namespace Cthun {
+namespace Common {
+namespace StringUtils {
+
+std::string plural(int num_of_things) {
+    return num_of_things > 1 ? "s" : "";
+}
+
+template<>
+std::string plural<std::string>(std::vector<std::string> things) {
+    return plural(things.size());
+}
+
+std::string getExpiryDatetime(int expiry_minutes) {
+    struct tm expiry_time_info;
+    char expiry_time_buffer[80];
+
+    // Get current time and add the specified minutes
+    time_t expiry_time { time(nullptr) };
+    expiry_time += 60 * expiry_minutes;
+
+    // Get local time structure
+    localtime_r(&expiry_time, &expiry_time_info);
+
+    // Return the formatted string
+    if (strftime(expiry_time_buffer, 80, "%FT%TZ", &expiry_time_info) == 0) {
+        // invalid buffer
+        return "";
+    }
+
+    return std::string { expiry_time_buffer };
+}
+
+// TODO(ale): test on Linux
+void displayProgress(double percent, int len, std::string status) {
+    printf("%c[2K", 27);
+    printf("\r");
+
+    if (percent > 0) {
+        std::string progress {};
+        for (int idx = 0; idx < len; ++idx) {
+            if (idx < static_cast<int>(len * percent)) {
+                progress += "=";
+            } else {
+                progress += " ";
+            }
+        }
+        std::cout << status << " [" << progress << "] "
+                  << static_cast<int>(100 * percent) << "%";
+        std::flush(std::cout);
+    }
+}
+
+}  // namespace StringUtils
+}  // namespace Common
+}  // namespace Cthun

--- a/src/common/string_utils.h
+++ b/src/common/string_utils.h
@@ -1,0 +1,32 @@
+#ifndef SRC_COMMON_STRINGUTILS_H_
+#define SRC_COMMON_STRINGUTILS_H_
+
+#include <string>
+#include <vector>
+
+namespace Cthun {
+namespace Common {
+namespace StringUtils {
+
+/// Return the "s" string in case of more than one things,
+/// an empty string otherwise.
+std::string plural(int num_of_things);
+
+template<typename T>
+std::string plural(std::vector<T> things);
+
+/// Adds the specified expiry_minutes to the current time and returns
+/// the related date time string in UTC format.
+/// Returns an empty string in case it fails to allocate the buffer.
+std::string getExpiryDatetime(int expiry_minutes = 1);
+
+/// Erases the current line on stdout, places the cursor at the
+/// beginning of it, and displays a progress message.
+void displayProgress(double percent, int len,
+                     std::string status = "in progress");
+
+}  // namespace StringUtils
+}  // namespace Common
+}  // namespace Cthun
+
+#endif  // SRC_COMMON_STRINGUTILS_H_

--- a/src/common/uuid.h
+++ b/src/common/uuid.h
@@ -1,0 +1,27 @@
+#ifndef SRC_COMMON_UUID_H_
+#define SRC_COMMON_UUID_H_
+
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+
+#include <string>
+
+namespace Cthun {
+namespace Common {
+
+typedef std::string UUID;
+
+static UUID getUUID() __attribute__((unused));
+
+/// Return a new UUID instance
+static UUID getUUID() {
+    static boost::uuids::random_generator gen;
+    boost::uuids::uuid uuid = gen();
+    return boost::uuids::to_string(uuid);
+}
+
+}  // namespace Common
+}  // namespace Cthun
+
+#endif  // SRC_COMMON_UUID_H_

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,13 +1,12 @@
-#include "agent_endpoint.h"
-#include "errors.h"
-
-#include <cthun-client/src/log/log.h>
-#include <cthun-client/src/common/file_utils.h>
+#include "agent/agent_endpoint.h"
+#include "agent/errors.h"
+#include "common/log.h"
+#include "common/file_utils.h"
 
 #include <boost/program_options.hpp>
 #include <boost/filesystem.hpp>
 
-LOG_DECLARE_NAMESPACE("agent.main");
+LOG_DECLARE_NAMESPACE("agent_main");
 
 namespace po = boost::program_options;
 
@@ -19,7 +18,7 @@ namespace Cthun {
 
 static const Log::log_level DEFAULT_LOG_LEVEL { Log::log_level::info };
 
-// TODO(ale): log on file
+// TODO(ale): allow configuring log and out files
 static std::ostream& DEFAULT_LOG_STREAM = std::cout;
 
 // TODO(ale): remove this; it's just for development

--- a/src/websocket/connection.cpp
+++ b/src/websocket/connection.cpp
@@ -1,0 +1,190 @@
+#include "websocket/connection.h"
+#include "common/uuid.h"
+#include "common/log.h"
+
+#include <string>
+#include <iostream>
+
+LOG_DECLARE_NAMESPACE("websocket.connection");
+
+namespace Cthun {
+namespace WebSocket {
+
+Connection::Connection(const std::string& url)
+    : url_ { url },
+      id_ { Common::getUUID() },
+      state_ { Connection_State_Values::connecting },
+      remote_server_ { "N/A" } {
+    // TODO(ale): validate url
+}
+
+void Connection::waitForOpen(int max_num_checks, int interval_check) {
+    int idx { 0 };
+    do {
+        if (state_ == Cthun::WebSocket::Connection_State_Values::open) {
+            return;
+        }
+        idx++;
+        sleep(interval_check);
+    } while (idx < max_num_checks);
+    throw connection_error { "on open event timeout (waited for "
+                             + std::to_string(max_num_checks * interval_check)
+                             + " s)" };
+}
+
+//
+// Configuration
+//
+
+void Connection::setConnectionHandle(Connection_Handle hdl) {
+    connection_hdl_ = hdl;
+}
+
+// HERE(ale): in case of multiple connections, be careful with the
+// context binding when defining lambdas to avoid races.
+
+void Connection::setOnOpenCallback(Event_Callback callback) {
+    onOpen_callback_ = callback;
+}
+
+void Connection::setOnCloseCallback(Event_Callback callback) {
+    onClose_callback_ = callback;
+}
+
+void Connection::setOnFailCallback(Event_Callback callback) {
+    onFail_callback_ = callback;
+}
+
+void Connection::setOnMessageCallback(OnMessage_Callback callback) {
+    onMessage_callback_ = callback;
+}
+
+void Connection::setOnPingCallback(Ping_Callback callback) {
+    onPing_callback_ = callback;
+}
+
+void Connection::setOnPongCallback(Pong_Callback callback) {
+    onPong_callback_ = callback;
+}
+
+void Connection::setOnPongTimeoutCallback(Pong_Callback callback) {
+    onPongTimeout_callback_ = callback;
+}
+
+//
+// Accessors
+//
+
+std::string Connection::getURL() const {
+    return url_;
+}
+
+Connection_ID Connection::getID() const {
+    return id_;
+}
+
+Connection_Handle Connection::getConnectionHandle() const {
+    return connection_hdl_;
+}
+
+// TODO(ale): Need locks? Expensive; better enforce async handlers.
+// In case, is it possible to differentiate between read/write locks?
+// Use futures?
+
+Connection_State Connection::getState() const {
+    return state_;
+}
+
+std::string Connection::getErrorReason() const {
+    return error_reason_;
+}
+
+std::string Connection::getRemoteServer() const {
+    return remote_server_;
+}
+
+std::string Connection::getRemoteCloseReason() const {
+    return remote_close_reason_;
+}
+
+Close_Code Connection::getRemoteCloseCode() const {
+    return remote_close_code_;
+}
+
+//
+// Event handlers
+//
+
+// TODO(ale): use templates (?)
+
+void Connection::onOpen(Client_Type* client_ptr, Connection_Handle hdl) {
+    LOG_TRACE("triggered onOpen");
+
+    state_ = Connection_State_Values::open;
+    Client_Type::connection_ptr websocket_ptr { client_ptr->get_con_from_hdl(hdl) };
+
+    std::string server_name { websocket_ptr->get_response_header("Server") };
+    if (!server_name.empty()) {
+        remote_server_ = server_name;
+    }
+
+    onOpen_callback_(client_ptr, shared_from_this());
+}
+
+void Connection::onClose(Client_Type* client_ptr, Connection_Handle hdl) {
+    LOG_TRACE("triggered onClose");
+    state_ = Connection_State_Values::closed;
+
+    Client_Type::connection_ptr websocket_ptr { client_ptr->get_con_from_hdl(hdl) };
+    remote_close_reason_ = websocket_ptr->get_remote_close_reason();
+    remote_close_code_ = websocket_ptr->get_remote_close_code();
+
+    onClose_callback_(client_ptr, shared_from_this());
+}
+
+void Connection::onFail(Client_Type* client_ptr, Connection_Handle hdl) {
+    LOG_TRACE("triggered onFail");
+
+    state_ = Connection_State_Values::closed;
+    Client_Type::connection_ptr websocket_ptr { client_ptr->get_con_from_hdl(hdl) };
+
+    std::string server_name { websocket_ptr->get_response_header("Server") };
+    if (!server_name.empty()) {
+        remote_server_ = server_name;
+    }
+
+    error_reason_ = websocket_ptr->get_ec().message();
+
+    onFail_callback_(client_ptr, shared_from_this());
+}
+
+void Connection::onMessage(Client_Type* client_ptr, Connection_Handle hdl,
+                           Client_Type::message_ptr msg) {
+    LOG_TRACE("triggered onMessage:\n%1%", msg->get_payload());
+
+    onMessage_callback_(client_ptr, shared_from_this(), msg->get_payload());
+}
+
+bool Connection::onPing(Client_Type* client_ptr, Connection_Handle hdl,
+                        std::string binary_payload) {
+    LOG_TRACE("triggered onPing: %1%", binary_payload);
+
+    return onPing_callback_(client_ptr, shared_from_this(), binary_payload);
+}
+
+void Connection::onPong(Client_Type* client_ptr, Connection_Handle hdl,
+                        std::string binary_payload) {
+    LOG_TRACE("triggered onPong: %1%", binary_payload);
+
+    onPong_callback_(client_ptr, shared_from_this(), binary_payload);
+}
+
+void Connection::onPongTimeout(Client_Type* client_ptr, Connection_Handle hdl,
+                               std::string binary_payload) {
+    LOG_TRACE("triggered onPongTimeout: %1%", binary_payload);
+
+    onPongTimeout_callback_(client_ptr, shared_from_this(), binary_payload);
+}
+
+}  // namespace WebSocket
+}  // namespace Cthun

--- a/src/websocket/connection.h
+++ b/src/websocket/connection.h
@@ -1,0 +1,169 @@
+#ifndef SRC_WEBSOCKET_CONNECTION_H_
+#define SRC_WEBSOCKET_CONNECTION_H_
+
+#include "websocket/macros.h"
+
+#include <websocketpp/common/connection_hdl.hpp>
+
+#include <memory>
+#include <string>
+
+namespace Cthun {
+namespace WebSocket {
+
+// NB: enable_shared_from_this<> is to create a shared_ptr to *this
+
+class Connection : public std::enable_shared_from_this<Connection> {
+  public:
+    /// Connection shared pointer type
+    using Ptr = std::shared_ptr<Connection>;
+
+    /// Generic event callback type
+    using Event_Callback = std::function<void(Client_Type* client_ptr,
+                                              Connection::Ptr connection_ptr)>;
+
+    /// OnMessage event callback type
+    using OnMessage_Callback = std::function<void(Client_Type* client_ptr,
+                                                  Connection::Ptr connection_ptr,
+                                                  std::string message)>;
+
+    /// ping callback type
+    using Ping_Callback = std::function<bool(Client_Type* client_ptr,
+                                             Connection::Ptr connection_ptr,
+                                             std::string binary_payload)>;
+
+    /// pong and pongTimeout callback type
+    using Pong_Callback = std::function<void(Client_Type* client_ptr,
+                                             Connection::Ptr connection_ptr,
+                                             std::string binary_payload)>;
+
+    explicit Connection(const std::string& url);
+
+    void waitForOpen(int max_num_checks = 5, int interval_check = 1);
+
+    //
+    // Configuration
+    //
+
+    /// Connection handle setter.
+    void setConnectionHandle(Connection_Handle hdl);
+
+    /// Callback called by onOpen.
+    void setOnOpenCallback(Event_Callback callback);
+
+    /// Callback called by onClose.
+    void setOnCloseCallback(Event_Callback callback);
+
+    /// Callback called by onFail.
+    void setOnFailCallback(Event_Callback callback);
+
+    /// Callback called by onMessage.
+    void setOnMessageCallback(OnMessage_Callback callback);
+
+    /// Callback called by onPing.
+    void setOnPingCallback(Ping_Callback callback);
+
+    /// Callback called by onPong.
+    /// Set it to a function returning false to disable pong responses.
+    void setOnPongCallback(Pong_Callback callback);
+
+    /// Callback called by onPongTimeout.
+    void setOnPongTimeoutCallback(Pong_Callback callback);
+
+    //
+    // Accessors
+    //
+
+    /// Returns the remote url
+    std::string getURL() const;
+
+    /// Returns the connection ID
+    Connection_ID getID() const;
+
+    /// Returns the connection handle used by the underlying transport
+    Connection_Handle getConnectionHandle() const;
+
+    /// Returns the current connection state
+    Connection_State getState() const;
+
+    /// Returns the error string
+    std::string getErrorReason() const;
+
+    /// Returns the remote server, parsed from a received message
+    std::string getRemoteServer() const;
+
+    /// Returns the remote close reason
+    std::string getRemoteCloseReason() const;
+
+    /// Returns the remote close code
+    Close_Code getRemoteCloseCode() const;
+
+    //
+    // Event handlers
+    //
+
+    // NB: the TLS initialization handler is bound to the Endpoint, so
+    // it's applied to all connections. Binding it here doesn't work.
+
+    /// Event handler: on open.
+    virtual void onOpen(Client_Type* client_ptr, Connection_Handle hdl);
+
+    /// Event handler: on close.
+    virtual void onClose(Client_Type* client_ptr, Connection_Handle hdl);
+
+    /// Event handler: on fail.
+    virtual void onFail(Client_Type* client_ptr, Connection_Handle hdl);
+
+    /// Event handler: on message.
+    virtual void onMessage(Client_Type* client_ptr, Connection_Handle hdl,
+                           Client_Type::message_ptr msg);
+
+    /// Event handler: on message.
+    virtual bool onPing(Client_Type* client_ptr, Connection_Handle hdl,
+                        std::string binary_payload);
+
+    /// Event handler: on message.
+    virtual void onPong(Client_Type* client_ptr, Connection_Handle hdl,
+                        std::string binary_payload);
+
+    /// Event handler: on message.
+    virtual void onPongTimeout(Client_Type* client_ptr, Connection_Handle hdl,
+                               std::string binary_payload);
+
+  protected:
+    std::string url_;
+    Connection_ID id_;
+    Connection_Handle connection_hdl_;
+    Connection_State state_;
+    std::string error_reason_;
+    std::string remote_server_;
+    std::string remote_close_reason_;
+    Close_Code remote_close_code_;
+
+    Event_Callback onOpen_callback_ {
+        [](Client_Type* client_ptr, Connection::Ptr connection_ptr) {} };
+    Event_Callback onClose_callback_ {
+        [](Client_Type* client_ptr, Connection::Ptr connection_ptr) {} };
+    Event_Callback onFail_callback_ {
+        [](Client_Type* client_ptr, Connection::Ptr connection_ptr) {} };
+    OnMessage_Callback onMessage_callback_ {
+        [](Client_Type* client_ptr, Connection::Ptr connection_ptr,
+           std::string message) {} };
+
+    // Returning true by default to send back pong
+    Ping_Callback onPing_callback_ {
+        [](Client_Type* client_ptr, Connection::Ptr connection_ptr,
+           std::string binary_payload) { return true; } };
+
+    Pong_Callback onPong_callback_ {
+        [](Client_Type* client_ptr, Connection::Ptr connection_ptr,
+           std::string binary_payload) {} };
+    Pong_Callback onPongTimeout_callback_ {
+        [](Client_Type* client_ptr, Connection::Ptr connection_ptr,
+           std::string binary_payload) {} };
+};
+
+}  // namespace WebSocket
+}  // namespace Cthun
+
+#endif  // SRC_WEBSOCKET_CONNECTION_H_

--- a/src/websocket/connection_manager.cpp
+++ b/src/websocket/connection_manager.cpp
@@ -1,0 +1,110 @@
+#include "websocket/connection_manager.h"
+#include "common/log.h"
+#include "common/file_utils.h"
+
+LOG_DECLARE_NAMESPACE("websocket.connection_manager");
+
+namespace Cthun {
+namespace WebSocket {
+
+ConnectionManager& ConnectionManager::Instance() {
+    static ConnectionManager instance;
+    return instance;
+}
+
+void ConnectionManager::configureSecureEndpoint(
+        const std::string& ca_crt_path,
+        const std::string& client_crt_path,
+        const std::string& client_key_path) {
+    if (endpoint_running_) {
+        throw endpoint_error { "an endpoint has already started" };
+    }
+
+    for (auto crt : std::vector<std::string> {
+                        ca_crt_path, client_crt_path, client_key_path }) {
+        if (crt.empty()) {
+            throw endpoint_error { "not all certificates were specified" };
+        }
+        if (!Common::FileUtils::fileExists(crt)) {
+            throw endpoint_error { crt + " does not exist" };
+        }
+    }
+
+    ca_crt_path_ = ca_crt_path;
+    client_crt_path_ = client_crt_path;
+    client_key_path_ = client_key_path;
+    is_secure_ = true;
+}
+
+void ConnectionManager::resetEndpoint() {
+    if (endpoint_running_) {
+        endpoint_ptr_->closeConnections();
+        endpoint_ptr_.reset();
+        endpoint_running_ = false;
+    }
+}
+
+Connection::Ptr ConnectionManager::createConnection(std::string url) {
+    return Connection::Ptr(new Connection(url));
+}
+
+void ConnectionManager::open(Connection::Ptr connection_ptr) {
+    startEndpointIfNeeded();
+    endpoint_ptr_->open(connection_ptr);
+}
+
+void ConnectionManager::send(Connection::Ptr connection_ptr, Message message) {
+    startEndpointIfNeeded();
+    endpoint_ptr_->send(connection_ptr, message);
+}
+
+void ConnectionManager::ping(Connection::Ptr connection_ptr,
+                             const std::string& binary_payload) {
+    startEndpointIfNeeded();
+    endpoint_ptr_->ping(connection_ptr, binary_payload);
+}
+
+void ConnectionManager::close(Connection::Ptr connection_ptr,
+                              Close_Code code, Message reason) {
+    startEndpointIfNeeded();
+    endpoint_ptr_->close(connection_ptr, code, reason);
+}
+
+void ConnectionManager::closeAllConnections() {
+    if (endpoint_running_) {
+        endpoint_ptr_->closeConnections();
+    }
+}
+
+std::vector<Connection_ID> ConnectionManager::getConnectionIDs() {
+    if (endpoint_running_) {
+        return endpoint_ptr_->getConnectionIDs();
+    }
+    return std::vector<Connection_ID> {};
+}
+
+//
+// Private interface
+//
+
+ConnectionManager::ConnectionManager()
+    : endpoint_ptr_ { nullptr },
+      endpoint_running_ { false } {
+}
+
+void ConnectionManager::startEndpointIfNeeded() {
+    if (!endpoint_running_) {
+        endpoint_running_ = true;
+        if (is_secure_) {
+            LOG_INFO("initializing secure endpoint");
+            endpoint_ptr_.reset(
+                new Endpoint(ca_crt_path_, client_crt_path_, client_key_path_));
+        } else {
+            LOG_INFO("initializing endpoint");
+            endpoint_ptr_.reset(new Endpoint());
+        }
+    }
+}
+
+}  // namespace WebSocket
+}  // namespace Cthun

--- a/src/websocket/connection_manager.h
+++ b/src/websocket/connection_manager.h
@@ -1,0 +1,91 @@
+#ifndef SRC_API_WEBSOCKET_H_
+#define SRC_API_WEBSOCKET_H_
+
+#include "websocket/endpoint.h"
+#include "websocket/connection.h"
+#include "websocket/errors.h"
+#include "websocket/macros.h"
+
+#include <vector>
+#include <string>
+#include <memory>
+
+namespace Cthun {
+namespace WebSocket {
+
+//
+// CONNECTION_MANAGER singleton
+//
+
+#define CONNECTION_MANAGER ConnectionManager::Instance()
+
+class ConnectionManager {
+  public:
+    static ConnectionManager& Instance();
+
+    /// Throw a endpoint_error in case the endpoint has already started
+    /// or in case of a missing certificate file.
+    void configureSecureEndpoint(const std::string& ca_crt_path,
+                                 const std::string& client_crt_path,
+                                 const std::string& client_key_path);
+
+    /// Attempt to close all connections (message errors will be
+    /// logged and filtered) and deletes the Endpoint instance.
+    /// Throws a message_error in case it fails to close a connection.
+    void resetEndpoint();
+
+    /// Return a pointer to a new connection.
+    /// The connection will not be opened.
+    /// The connection ID will not be stored.
+    Connection::Ptr createConnection(std::string url);
+
+    /// Starts the pointed connection.
+    /// Throw a connection_error in case of failure.
+    void open(Connection::Ptr connection_ptr);
+
+    /// Send message on the pointed connection.
+    /// Throw a message_error in case of failure.
+    void send(Connection::Ptr connection_ptr, Message message);
+
+    /// Ping the other endpoint of the pointed connection.
+    /// Throw a message_error in case of failure.
+    void ping(Connection::Ptr connection_ptr,
+              const std::string& binary_payload);
+
+    /// Close the pointed connection; reason and code are optional
+    /// (respectively default to "Closed by client" and normal as
+    /// in rfc6455).
+    /// Throw a message_error in case of failure.
+    void close(Connection::Ptr connection_ptr,
+               Close_Code code = Close_Code_Values::normal,
+               Message reason = DEFAULT_CLOSE_REASON);
+
+    /// Close all connections that are in 'open' state.
+    /// Reset the list of connections managed by the endpoint.
+    /// Throw a message_error in case of failure.
+    void closeAllConnections();
+
+    /// Return the IDs of the connections managed by the endpoint,
+    /// regardless of their state.
+    std::vector<Connection_ID> getConnectionIDs();
+
+
+  private:
+    Endpoint::Ptr endpoint_ptr_;
+    bool is_secure_ { false };
+    std::string ca_crt_path_;
+    std::string client_crt_path_;
+    std::string client_key_path_;
+
+    // To verify the Endpoint instantiation
+    bool endpoint_running_;
+
+    ConnectionManager();
+
+    void startEndpointIfNeeded();
+};
+
+}  // namespace WebSocket
+}  // namespace Cthun
+
+#endif  // SRC_API_WEBSOCKET_H_

--- a/src/websocket/endpoint.cpp
+++ b/src/websocket/endpoint.cpp
@@ -1,0 +1,203 @@
+#include "websocket/endpoint.h"
+#include "common/log.h"
+#include "common/string_utils.h"
+
+LOG_DECLARE_NAMESPACE("websocket.endpoint");
+
+namespace Cthun {
+namespace WebSocket {
+
+Endpoint::Endpoint(const std::string& ca_crt_path,
+                   const std::string& client_crt_path,
+                   const std::string& client_key_path)
+    : ca_crt_path_ { ca_crt_path },
+      client_crt_path_ { client_crt_path },
+      client_key_path_ { client_key_path } {
+    // Disable websocketpp logging to avoid clashing with ours
+    // TODO(ale): it could be useful to stream it to a file
+
+    client_.clear_access_channels(websocketpp::log::alevel::all);
+    client_.clear_error_channels(websocketpp::log::elevel::all);
+
+    // Initialize the transport system. Note that in perpetual mode,
+    // the event loop does not terminate when there are no connections
+
+    client_.init_asio();
+    client_.start_perpetual();
+
+#ifdef CTHUN_CLIENT_SECURE_TRANSPORT
+    // Bind the TLS init function
+    using websocketpp::lib::bind;
+    client_.set_tls_init_handler(bind(&Endpoint::onTlsInit, this, ::_1));
+#endif  // CTHUN_CLIENT_SECURE_TRANSPORT
+
+    // Start the event loop thread
+    endpoint_thread_.reset(
+        new std::thread(&Client_Type::run, &client_));
+}
+
+Endpoint::~Endpoint() {
+    client_.stop_perpetual();
+    closeConnections();
+    if (endpoint_thread_ != nullptr && endpoint_thread_->joinable()) {
+        endpoint_thread_->join();
+    }
+}
+
+// open
+
+void Endpoint::open(Connection::Ptr connection_ptr) {
+    // Create a websocketpp connection
+
+    websocketpp::lib::error_code ec;
+    typename Client_Type::connection_ptr websocket_ptr {
+        client_.get_connection(connection_ptr->getURL(), ec) };
+    if (ec) {
+        throw connection_error {
+            "Failed to connect to " + connection_ptr->getURL() + ": "
+            + ec.message() };
+    }
+
+    // Store the websocket handle in the Connection instance
+
+    Connection_Handle hdl { websocket_ptr->get_handle() };
+    connection_ptr->setConnectionHandle(hdl);
+
+    // Bind the event handlers to the connection
+
+    using websocketpp::lib::bind;
+
+    websocket_ptr->set_open_handler(bind(
+        &Connection::onOpen, connection_ptr, &client_, ::_1));
+    websocket_ptr->set_close_handler(bind(
+        &Connection::onClose, connection_ptr, &client_, ::_1));
+    websocket_ptr->set_fail_handler(bind(
+        &Connection::onFail, connection_ptr, &client_, ::_1));
+    websocket_ptr->set_message_handler(bind(
+        &Connection::onMessage, connection_ptr, &client_, ::_1, ::_2));
+    websocket_ptr->set_ping_handler(bind(
+        &Connection::onPing, connection_ptr, &client_, ::_1, ::_2));
+    websocket_ptr->set_pong_handler(bind(
+        &Connection::onPong, connection_ptr, &client_, ::_1, ::_2));
+    websocket_ptr->set_pong_timeout_handler(bind(
+        &Connection::onPongTimeout, connection_ptr, &client_, ::_1, ::_2));
+
+    // Finally, open the connection
+
+    client_.connect(websocket_ptr);
+
+    // Keep track of the Connection instance
+
+    connections_.insert(std::pair<Connection_ID, Connection::Ptr> {
+        connection_ptr->getID(), connection_ptr });
+}
+
+// send
+
+void Endpoint::send(Connection::Ptr connection_ptr, std::string msg) {
+    websocketpp::lib::error_code ec;
+    client_.send(connection_ptr->getConnectionHandle(), msg,
+                 websocketpp::frame::opcode::text, ec);
+    if (ec) {
+        throw message_error { "Failed to send message: " + ec.message() };
+    }
+}
+
+// ping (NB: no need for pong(); this is client-oriented)
+
+void Endpoint::ping(Connection::Ptr connection_ptr,
+                    const std::string& binary_payload) {
+    websocketpp::lib::error_code ec;
+    client_.ping(connection_ptr->getConnectionHandle(), binary_payload, ec);
+    if (ec) {
+        throw message_error { "Failed to ping: " + ec.message() };
+    }
+}
+
+// close
+
+void Endpoint::close(Connection::Ptr connection_ptr, Close_Code code,
+                     Message reason) {
+    websocketpp::lib::error_code ec;
+
+    LOG_DEBUG("About to close connection %1%", connection_ptr->getID());
+
+    client_.close(connection_ptr->getConnectionHandle(), code, reason, ec);
+    if (ec) {
+        throw message_error { "Failed to close connetion "
+            + connection_ptr->getID() + ": " + ec.message() };
+    }
+}
+
+// closeConnections
+
+void Endpoint::closeConnections() {
+    // Keep track of failures
+    std::vector<Connection_ID> failure_ids;
+
+    for (auto connections_iter = connections_.begin();
+         connections_iter != connections_.end(); connections_iter++) {
+        if (connections_iter->second->getState()
+                == Connection_State_Values::open) {
+            try {
+                close(connections_iter->second);
+            } catch (message_error) {
+                failure_ids.push_back(connections_iter->second->getID());
+            }
+        }
+    }
+
+    connections_.clear();
+
+    if (!failure_ids.empty()) {
+        std::string message {
+            "Failed to close " + std::to_string(failure_ids.size())
+            + " connection"
+            + Common::StringUtils::plural<Connection_ID>(failure_ids) + ":" };
+        for (auto id : failure_ids) {
+            message += " " + id;
+        }
+        throw message_error { message };
+    }
+}
+
+// TLS init handler (will be bound to all connections)
+
+// NB: for TLS certificates, refer to:
+// www.boost.org/doc/libs/1_56_0/doc/html/boost_asio/reference/ssl__context.html
+
+// TODO(ale): double check boost asio ssl options
+
+Context_Ptr Endpoint::onTlsInit(Connection_Handle hdl) {
+    Context_Ptr ctx {
+        new boost::asio::ssl::context(boost::asio::ssl::context::tlsv1) };
+
+    try {
+        ctx->set_options(boost::asio::ssl::context::default_workarounds |
+                         boost::asio::ssl::context::no_sslv2 |
+                         boost::asio::ssl::context::single_dh_use);
+        ctx->use_certificate_file(client_crt_path_,
+                                  boost::asio::ssl::context::file_format::pem);
+        ctx->use_private_key_file(client_key_path_,
+                                  boost::asio::ssl::context::file_format::pem);
+        ctx->load_verify_file(ca_crt_path_);
+    } catch (std::exception& e) {
+        // TODO(ale): this is what the the debug_client does and it
+        // seems to work, nonetheless check if we need to raise here
+        LOG_ERROR("failed to configure TLS: %1%", e.what());
+    }
+    return ctx;
+}
+
+// Connection IDs accessor
+
+std::vector<Connection_ID> Endpoint::getConnectionIDs() {
+    std::vector<Connection_ID> connection_ids;
+    for (auto connection_entry : connections_) {
+        connection_ids.push_back(connection_entry.first);
+    }
+    return connection_ids;
+}
+
+}  // namespace WebSocket
+}  // namespace Cthun

--- a/src/websocket/endpoint.h
+++ b/src/websocket/endpoint.h
@@ -1,0 +1,77 @@
+#ifndef SRC_WEBSOCKET_ENDPOINT_H_
+#define SRC_WEBSOCKET_ENDPOINT_H_
+
+#include "websocket/connection.h"
+#include "websocket/macros.h"
+
+#include <string>
+#include <vector>
+#include <memory>
+#include <map>
+#include <thread>
+
+namespace Cthun {
+namespace WebSocket {
+
+//
+// Endpoint
+//
+
+class Endpoint {
+  public:
+    using Ptr = std::shared_ptr<Endpoint>;
+
+    // TODO(ale): specify root dir for TSL certs instead of each file?
+    //            Use a default location? Dot file as Pegasus?
+    Endpoint(const std::string& ca_crt_path = "",
+             const std::string& client_crt_path = "",
+             const std::string& client_key_path = "");
+    ~Endpoint();
+
+    /// Open the specified connection.
+    /// Throw a connection_error in case of failure.
+    void open(Connection::Ptr connection_ptr);
+
+    /// Send message on the specified connection.
+    /// Throw a message_error in case of failure.
+    void send(Connection::Ptr connection_ptr, std::string msg);
+
+    /// Ping the other endpoint of the specified connection.
+    /// Throw a message_error in case of failure.
+    void ping(Connection::Ptr connection_ptr,
+              const std::string& binary_payload);
+
+    /// Close the specified connection; reason and code are optional
+    /// (respectively default to "Closed by client" and 'normal' as
+    /// in rfc6455).
+    /// Throw a message_error in case of failure.
+    void close(Connection::Ptr connection_ptr,
+               Close_Code code = Close_Code_Values::normal,
+               Message reason = DEFAULT_CLOSE_REASON);
+
+    /// Close all connections that are in 'open' state.
+    /// Throw a message_error in case it fails to close any
+    /// connection; note that it will attempt to close all of them.
+    void closeConnections();
+
+    /// Event loop TLS init callback.
+    Context_Ptr onTlsInit(Connection_Handle hdl);
+
+    /// Return the managed connections, regardless of their state.
+    std::vector<Connection_ID> getConnectionIDs();
+
+  private:
+    std::string ca_crt_path_;
+    std::string client_crt_path_;
+    std::string client_key_path_;
+    Client_Type client_;
+
+    // Keep track of connections to close them all when needed
+    std::map<Connection_ID, Connection::Ptr> connections_;
+    std::shared_ptr<std::thread> endpoint_thread_;
+};
+
+}  // namespace WebSocket
+}  // namespace Cthun
+
+#endif  // SRC_WEBSOCKET_ENDPOINT_H_

--- a/src/websocket/errors.h
+++ b/src/websocket/errors.h
@@ -1,0 +1,37 @@
+#ifndef SRC_WEBSOCKET_ERRORS_H_
+#define SRC_WEBSOCKET_ERRORS_H_
+
+#include <stdexcept>
+#include <string>
+
+namespace Cthun {
+namespace WebSocket {
+
+/// Base error class.
+class websocket_error : public std::runtime_error {
+  public:
+    explicit websocket_error(std::string const& msg) : std::runtime_error(msg) {}
+};
+
+/// Endpoint error class.
+class endpoint_error : public websocket_error {
+  public:
+    explicit endpoint_error(std::string const& msg) : websocket_error(msg) {}
+};
+
+/// Connection error class.
+class connection_error : public websocket_error {
+  public:
+    explicit connection_error(std::string const& msg) : websocket_error(msg) {}
+};
+
+/// Message sending error class.
+class message_error : public websocket_error {
+  public:
+    explicit message_error(std::string const& msg) : websocket_error(msg) {}
+};
+
+}  // namespace WebSocket
+}  // namespace Cthun
+
+#endif  // SRC_WEBSOCKET_ERRORS_H_

--- a/src/websocket/macros.h
+++ b/src/websocket/macros.h
@@ -1,0 +1,81 @@
+#ifndef SRC_WEBSOCKET_MACROS_H_
+#define SRC_WEBSOCKET_MACROS_H_
+
+// Comment the CTHUN_CLIENT_SECURE_TRANSPORT def to not use TLS
+#define CTHUN_CLIENT_SECURE_TRANSPORT
+
+//
+// websocketpp macros
+//
+
+// We need this hack to avoid the compilation error described in
+// https://github.com/zaphoyd/websocketpp/issues/365
+#define _WEBSOCKETPP_NULLPTR_TOKEN_ 0
+
+// See http://www.zaphoyd.com/websocketpp/manual/reference/cpp11-support
+// for prepocessor directives and choosing between boost and cpp11
+// C++11 STL tokens
+#define _WEBSOCKETPP_CPP11_FUNCTIONAL_
+#define _WEBSOCKETPP_CPP11_MEMORY_
+#define _WEBSOCKETPP_CPP11_RANDOM_DEVICE_
+#define _WEBSOCKETPP_CPP11_SYSTEM_ERROR_
+#define _WEBSOCKETPP_CPP11_THREAD_
+
+//
+// includes
+//
+
+#include "common/uuid.h"
+#include "websocket/errors.h"
+
+#include <websocketpp/common/connection_hdl.hpp>
+#include <websocketpp/client.hpp>
+// NB: we must include asio_client.hpp even if CTHUN_CLIENT_SECURE_TRANSPORT
+// is not defined in order to define Context_Ptr
+#include <websocketpp/config/asio_client.hpp>
+
+#ifndef CTHUN_CLIENT_SECURE_TRANSPORT
+#include <websocketpp/config/asio_no_tls_client.hpp>
+#endif  // CTHUN_CLIENT_SECURE_TRANSPORT
+
+#include <string>
+
+//
+// Tokens and aliases
+//
+
+namespace Cthun {
+namespace WebSocket {
+
+static const std::string DEFAULT_CLOSE_REASON { "Closed by client" };
+
+// TODO(ale): remove unnecessary aliases, to avoid masking
+
+// Define the transport layer configuration for the client endpoint;
+// used by Endpoint and Connection classes.
+#ifdef CTHUN_CLIENT_SECURE_TRANSPORT
+using Client_Type = websocketpp::client<websocketpp::config::asio_tls_client>;
+#else
+using Client_Type = websocketpp::client<websocketpp::config::asio_client>;
+#endif  // CTHUN_CLIENT_SECURE_TRANSPORT
+
+using Context_Ptr = websocketpp::lib::shared_ptr<boost::asio::ssl::context>;
+
+using Message = std::string;
+
+using Connection_ID = Common::UUID;
+using Connection_Handle = websocketpp::connection_hdl;
+
+using Close_Code = websocketpp::close::status::value;
+namespace Close_Code_Values = websocketpp::close::status;
+
+using Connection_State = websocketpp::session::state::value;
+namespace Connection_State_Values = websocketpp::session::state;
+
+using Frame_Opcode = websocketpp::frame::opcode::value;
+namespace Frame_Opcode_Values = websocketpp::frame::opcode;
+
+}  // namespace WebSocket
+}  // namespace Cthun
+
+#endif  // SRC_WEBSOCKET_MACROS_H_

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,11 +1,5 @@
 set(test_SOURCE
     "${CMAKE_CURRENT_LIST_DIR}/agent_test.cpp"
-    "${CMAKE_CURRENT_LIST_DIR}/../src/agent.cpp"
-    "${CMAKE_CURRENT_LIST_DIR}/../src/schemas.cpp"
-    "${CMAKE_CURRENT_LIST_DIR}/../src/module.cpp"
-    "${CMAKE_CURRENT_LIST_DIR}/../src/external_module.cpp"
-    "${CMAKE_CURRENT_LIST_DIR}/../src/modules/echo.cpp"
-    "${CMAKE_CURRENT_LIST_DIR}/../vendor/jsoncpp/jsoncpp.cpp"
 )
 
 set(test_BIN cthun-agent-unittests)


### PR DESCRIPTION
Copying WebSocket functionality from cthun-client. Reorganizing source
files by namespace. Copying boost::log wrappers.

Moving all source files related to the Cthun::Agent namesapce to
src/agent; WebSocket functionality will be in src/websocket; common
functionality, including logging, in src/common.
