### PR TITLE
(maint) Fixup and use Findfacter.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,8 @@ find_package(Boost 1.54 REQUIRED
 
 find_package(OpenSSL REQUIRED)
 
+find_package(facter REQUIRED)
+
 # Specify the .cmake files for vendored libraries
 include(${VENDOR_DIRECTORY}/valijson.cmake)
 include(${VENDOR_DIRECTORY}/boost-process.cmake)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,7 +31,7 @@ SET(LIBS
     ${OPENSSL_SSL_LIBRARY}
     ${OPENSSL_CRYPTO_LIBRARY}
     ${PTHREADS}
-    facter
+    ${facter_LIBRARY}
 )
 
 add_library(cthun-agent ${LIBRARY_SOURCES})

--- a/vendor/Findfacter.cmake
+++ b/vendor/Findfacter.cmake
@@ -1,7 +1,10 @@
+find_library(facter_LIBRARY
+    NAMES facter)
+
 INCLUDE(FindDependency)
 find_dependency(facter DISPLAY "facter" HEADERS "facter/facts/collection.hpp" LIBRARY "facter")
 
 
 INCLUDE(FeatureSummary)
-SET_PACKAGE_PROPERTIES(Cfacter PROPERTIES DESCRIPTION "C++11 implementation of Puppet Facter" URL "https://github.com/puppetlabs/cfacter")
-set_package_properties(Cfacter PROPERTIES TYPE OPTIONAL PURPOSE "Enables gathering facts about the system.")
+SET_PACKAGE_PROPERTIES(facter PROPERTIES DESCRIPTION "C++11 implementation of Puppet Facter" URL "https://github.com/puppetlabs/cfacter")
+set_package_properties(facter PROPERTIES TYPE OPTIONAL PURPOSE "Enables gathering facts about the system.")


### PR DESCRIPTION
Findfacter was failing to find facter on my workstation, as it hadn't
been told how to find_library and the default via FindDependency failed hard.

Here we fix vendor/Findfacter.cmake for my machine (cfacter has been installed
via private tap https://github.com/puppetlabs/homebrew-private-tap) and restate
the library dependency in terms of the advanced variable $facter_LIBRARY
