### PR TITLE
(CTH-76) resolve external modules dir path

### DIFF
--- a/src/agent/agent_endpoint.cpp
+++ b/src/agent/agent_endpoint.cpp
@@ -22,30 +22,44 @@ namespace Agent {
 static const uint CONNECTION_STATE_CHECK_INTERVAL { 15 };
 static const int DEFAULT_MESSAGE_TIMEOUT_IN_SECONDS { 10 };
 
-AgentEndpoint::AgentEndpoint() {
+AgentEndpoint::AgentEndpoint(std::string bin_path) {
     // declare internal modules
     modules_["echo"] = std::shared_ptr<Module>(new Modules::Echo);
     modules_["inventory"] = std::shared_ptr<Module>(new Modules::Inventory);
     modules_["ping"] = std::shared_ptr<Module>(new Modules::Ping);
     modules_["status"] = std::shared_ptr<Module>(new Modules::Status);
 
-    // load external modules
-    // TODO(ale): fix; this breaks if cthun-agent is not invoked from root dir
-    boost::filesystem::path module_path { "modules" };
-    boost::filesystem::directory_iterator end;
+    // TODO(ale): CTH-76 this doesn't work if bin_path (= argv[0]) has
+    // only the name of the executable, neither when cthun_agent is
+    // called by a symlink. The only safe way to refer to external
+    // modules is to store them in a knwon location (ex. ~/cthun/).
 
-    for (auto file = boost::filesystem::directory_iterator(module_path);
-            file != end; ++file) {
-        if (!boost::filesystem::is_directory(file->status())) {
-            LOG_INFO(file->path().string());
+    boost::filesystem::path module_path {
+        boost::filesystem::canonical(
+            boost::filesystem::system_complete(
+                boost::filesystem::path(bin_path)).parent_path().parent_path())
+    };
+    module_path += "/modules";
 
-            try {
-                ExternalModule* external = new ExternalModule(file->path().string());
-                modules_[external->module_name] = std::shared_ptr<Module>(external);
-            } catch (...) {
-                LOG_ERROR("failed to load: %1%", file->path().string());
+    if (boost::filesystem::is_directory(module_path)) {
+        boost::filesystem::directory_iterator end;
+
+        for (auto file = boost::filesystem::directory_iterator(module_path);
+                file != end; ++file) {
+            if (!boost::filesystem::is_directory(file->status())) {
+                LOG_INFO(file->path().string());
+
+                try {
+                    ExternalModule* external = new ExternalModule(file->path().string());
+                    modules_[external->module_name] = std::shared_ptr<Module>(external);
+                } catch (...) {
+                    LOG_ERROR("failed to load: %1%", file->path().string());
+                }
             }
         }
+    } else {
+        LOG_WARNING("failed to locate the modules directory; external modules "
+                    "will not be loaded");
     }
 }
 

--- a/src/agent/agent_endpoint.h
+++ b/src/agent/agent_endpoint.h
@@ -16,7 +16,7 @@ namespace Agent {
 
 class AgentEndpoint {
   public:
-    AgentEndpoint();
+    explicit AgentEndpoint(std::string bin_path);
     ~AgentEndpoint();
 
     // Daemon entry point.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,6 @@
 #include "src/common/file_utils.h"
 
 #include <boost/program_options.hpp>
-#include <boost/filesystem.hpp>
 
 LOG_DECLARE_NAMESPACE("agent_main");
 
@@ -167,7 +166,7 @@ int main(int argc, char *argv[]) {
     // start the agent
 
     try {
-        Agent::AgentEndpoint agent;
+        Agent::AgentEndpoint agent { std::string(argv[0]) };
 
         agent.startAgent(app_options.server, app_options.ca, app_options.cert, app_options.key);
     } catch (Agent::fatal_error&  e) {


### PR DESCRIPTION
Use argv[0] to obtain the root of the cthun-agent dir tree and establish
the path of the external modules dir.

Note that this fix will not work in case argv[0] does not give the
entire path of the executable (this is up to the operating system) or in
case cthun-agent is invoked by a symlink.

Also, with this fix, the program will not break if it fails to determine
the path of the modules dir; in that case it won't try to load any
external module.
