### PR TITLE
(CTH-128) Refactor the action invocation mechanism

### DIFF
--- a/src/agent.h
+++ b/src/agent.h
@@ -8,8 +8,6 @@
 #include <map>
 #include <memory>
 #include <string>
-#include <thread>
-#include <vector>
 
 namespace CthunAgent {
 
@@ -27,9 +25,6 @@ class Agent {
   private:
     std::map<std::string, std::shared_ptr<Module>> modules_;
     std::unique_ptr<WebSocket::Endpoint> ws_endpoint_ptr_;
-
-    // Thread queue...sigh
-    std::vector<std::thread> thread_queue_;
 
     // Log the loaded modules.
     void listModules();
@@ -56,12 +51,6 @@ class Agent {
     // Periodically check the connection state; reconnect the agent
     // in case the connection is not open
     void monitorConnectionState();
-
-    // Task to validate and execute the specified action.
-    void delayedActionThread(std::shared_ptr<Module> module,
-                             std::string action_name,
-                             Message msg,
-                             std::string uuid);
 };
 
 }  // namespace CthunAgent

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -16,36 +16,39 @@ Configuration::Configuration() {
     }
 
     // configure the default values
-    defaults_.push_back(std::unique_ptr<EntryBase>(new Entry<std::string>("server",
-                                                                          "s",
-                                                                          "cthun servers url",
-                                                                          Types::String,
-                                                                          "")));
-    defaults_.push_back(std::unique_ptr<EntryBase>(new Entry<std::string>("ca",
-                                                                          "",
-                                                                          "CA certificate",
-                                                                          Types::String,
-                                                                          "")));
-    defaults_.push_back(std::unique_ptr<EntryBase>(new Entry<std::string>("cert",
-                                                                          "",
-                                                                          "cthun-agent certificate",
-                                                                          Types::String,
-                                                                          "")));
-    defaults_.push_back(std::unique_ptr<EntryBase>(new Entry<std::string>("key",
-                                                                          "",
-                                                                          "cthun-agent private key",
-                                                                          Types::String,
-                                                                          "")));
-    defaults_.push_back(std::unique_ptr<EntryBase>(new Entry<std::string>("logfile",
-                                                                          "",
-                                                                          "log file (defaults to console logging",
-                                                                          Types::String,
-                                                                          "")));
-    defaults_.push_back(std::unique_ptr<EntryBase>(new Entry<std::string>("config-file",
-                                                                          "",
-                                                                          "specify a non default config file to use",
-                                                                          Types::String,
-                                                                          "")));
+
+    using Base_ptr = std::unique_ptr<EntryBase>;
+
+    defaults_.push_back(Base_ptr(new Entry<std::string>("server",
+                                                        "s",
+                                                        "cthun servers url",
+                                                        Types::String,
+                                                        "")));
+    defaults_.push_back(Base_ptr(new Entry<std::string>("ca",
+                                                        "",
+                                                        "CA certificate",
+                                                        Types::String,
+                                                        "")));
+    defaults_.push_back(Base_ptr(new Entry<std::string>("cert",
+                                                        "",
+                                                        "cthun-agent certificate",
+                                                        Types::String,
+                                                        "")));
+    defaults_.push_back(Base_ptr(new Entry<std::string>("key",
+                                                        "",
+                                                        "cthun-agent private key",
+                                                        Types::String,
+                                                        "")));
+    defaults_.push_back(Base_ptr(new Entry<std::string>("logfile",
+                                                        "",
+                                                        "log file (defaults to console logging",
+                                                        Types::String,
+                                                        "")));
+    defaults_.push_back(Base_ptr(new Entry<std::string>("config-file",
+                                                        "",
+                                                        "specify a non default config file to use",
+                                                        Types::String,
+                                                        "")));
 }
 
 int Configuration::initialize(int argc, char *argv[]) {
@@ -56,7 +59,7 @@ int Configuration::initialize(int argc, char *argv[]) {
             flag_names += " " + entry->aliases;
         }
 
-        switch(entry->type) {
+        switch (entry->type) {
             case Integer:
                 {
                     Entry<int>* entry_ptr = (Entry<int>*) entry.get();
@@ -174,7 +177,7 @@ void Configuration::parseConfigFile() {
         if (entry->configured) {
             continue;
         }
-        switch(entry->type) {
+        switch (entry->type) {
             case Integer:
                 {
                     Entry<int>* entry_ptr = (Entry<int>*) entry.get();

--- a/src/data_container.h
+++ b/src/data_container.h
@@ -247,8 +247,8 @@ class Message : public DataContainer {
     Message() {}
     explicit Message(std::string msg) : DataContainer(msg) {}
     explicit Message(const rapidjson::Value& value) : DataContainer(value) {}
-    Message(Message& msg) : DataContainer(msg) {}
-    Message(Message&& msg) : DataContainer(msg) {}
+    Message(const Message& msg) : DataContainer(msg) {}
+    Message(const Message&& msg) : DataContainer(msg) {}
     Message& operator=(Message other) {
         DataContainer::operator=(other);
         return *this;

--- a/src/errors.h
+++ b/src/errors.h
@@ -88,13 +88,13 @@ class no_configfile_error : public configuration_error {
 /// Error thrown when required config variable isn't set
 class required_not_set_error : public configuration_error {
   public:
-    explicit required_not_set_error (std::string const& msg) : configuration_error(msg) {}
+    explicit required_not_set_error(std::string const& msg) : configuration_error(msg) {}
 };
 
 /// Error thrown when cli parse error occurs
 class cli_parse_error : public configuration_error {
   public:
-    explicit cli_parse_error (std::string const& msg) : configuration_error(msg) {}
+    explicit cli_parse_error(std::string const& msg) : configuration_error(msg) {}
 };
 
 

--- a/src/external_module.cpp
+++ b/src/external_module.cpp
@@ -5,6 +5,7 @@
 #include "src/log.h"
 #include "src/file_utils.h"
 #include "src/timer.h"
+#include "src/uuid.h"
 
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/path.hpp>
@@ -18,8 +19,14 @@ LOG_DECLARE_NAMESPACE("external_module");
 
 namespace CthunAgent {
 
-void run_command(std::string exec, std::vector<std::string> args,
-                 std::string stdin, std::string &stdout, std::string &stderr) {
+//
+// Free functions
+//
+
+// Execute binaries and get output and errors
+
+void runCommand(std::string exec, std::vector<std::string> args,
+                std::string stdin, std::string &stdout, std::string &stderr) {
     boost::process::context context;
     context.stdin_behavior = boost::process::capture_stream();
     context.stdout_behavior = boost::process::capture_stream();
@@ -45,130 +52,19 @@ void run_command(std::string exec, std::vector<std::string> args,
     child.wait();
 }
 
-ExternalModule::ExternalModule(std::string path) : path_(path) {
-    boost::filesystem::path module_path { path };
+// Perform delayed actions
 
-    module_name = module_path.filename().string();
+void delayedAction(Message request,
+                   std::string job_id,
+                   std::string module_path,
+                   std::string results_dir) {
+    // Get request parameters
+    auto request_id = request.get<std::string>("id");
+    auto module_name = request.get<std::string>("data", "module");
+    auto action_name = request.get<std::string>("data", "action");
+    auto input = request.get<DataContainer>("data", "params");
 
-    valijson::Schema metadata_schema = Schemas::external_action_metadata();
-
-    std::string metadata;
-    std::string error;
-    run_command(path, { path, "metadata" }, "", metadata, error);
-
-    if (!error.empty()) {
-        LOG_ERROR("Error while trying to load external module: %1%", path);
-        LOG_ERROR(error);
-        throw module_error { "failed to load external module" };
-    }
-
-    DataContainer document { metadata };
-
-    std::vector<std::string> errors;
-    if (!document.validate(metadata_schema, errors)) {
-        LOG_ERROR("validation failed");
-        for (auto error : errors) {
-            LOG_ERROR("    %1%", error);
-        }
-        throw module_error { "metadata did not match schema" };
-    }
-
-    LOG_INFO("validation OK");
-
-    for (auto action : document.get<std::vector<DataContainer>>("actions")) {
-        std::string action_name { action.get<std::string>("name") };
-        LOG_INFO("declaring action %1%", action_name);
-        valijson::Schema input_schema;
-        valijson::Schema output_schema;
-
-        // TODO(ploubser): This doesn't fit well with the Data abstraction.
-        // Should this go in the object?
-
-        // TODO(ale): unit tests for the validation once we move its logic
-
-        valijson::SchemaParser parser;
-        rapidjson::Value input { action.get<rapidjson::Value>("input") };
-        rapidjson::Value output { action.get<rapidjson::Value>("output") };
-
-        valijson::adapters::RapidJsonAdapter input_doc_schema(input);
-        valijson::adapters::RapidJsonAdapter output_doc_schema(output);
-
-        try {
-            parser.populateSchema(input_doc_schema, input_schema);
-        } catch (...) {
-            LOG_ERROR("Failed to parse input schema of %1%", action_name);
-            throw module_error { "invalid input schema of " + action_name };
-        }
-
-        std::string behaviour = "interactive";
-
-        if (!action.get<std::string>("behaviour").empty()) {
-            std::string behaviour_str = action.get<std::string>("behaviour");
-            if (behaviour_str.compare("interactive") == 0) {
-                LOG_DEBUG("Found interactive action: %1%", action_name);
-            } else if (behaviour_str.compare("delayed") == 0) {
-                LOG_DEBUG("Found delayed action: %1%", action_name);
-                behaviour = behaviour_str;
-            } else {
-                LOG_ERROR("Invalid behaviour defined for action %1%: %2%",
-                          action_name, behaviour_str);
-                throw module_error { "invalid behavior of " + action_name };
-            }
-        }
-
-        try {
-            parser.populateSchema(output_doc_schema, output_schema);
-        } catch (...) {
-            LOG_ERROR("Failed to parse output schema of %1%", action_name);
-            throw module_error { "invalid output schema of " + action_name };
-        }
-
-        actions[action.get<std::string>("name")] = Action {
-            input_schema, output_schema, behaviour };
-    }
-}
-
-DataContainer ExternalModule::call_action(std::string action_name,
-                                          const Message& request) {
-    std::string stdin = request.get<DataContainer>("data", "params").toString();
-    std::string stdout;
-    std::string stderr;
-    LOG_INFO(stdin);
-
-    run_command(path_, { path_, action_name }, stdin, stdout, stderr);
-    LOG_INFO("stdout: %1%", stdout);
-    LOG_INFO("stderr: %1%", stderr);
-
-    return DataContainer { stdout };
-}
-
-void ExternalModule::call_delayed_action(std::string action_name,
-                                         const Message& request,
-                                         std::string job_id) {
-    LOG_INFO("Starting delayed action with id: %1%", job_id);
-
-    DataContainer input { request.get<DataContainer>("data", "params") };
-
-    // check if the output directory exists. If it doesn't create it
-    if (!FileUtils::fileExists(RESULTS_ROOT_DIR)) {
-        LOG_INFO("%1% directory does not exist. Creating.", RESULTS_ROOT_DIR);
-        if (!FileUtils::createDirectory(RESULTS_ROOT_DIR)) {
-            LOG_ERROR("Failed to create %1%. Cannot start action.",
-                      RESULTS_ROOT_DIR);
-        }
-    }
-
-    std::string action_dir { RESULTS_ROOT_DIR + "/" + job_id };
-
-    // create job specific result directory
-    if (!FileUtils::fileExists(action_dir)) {
-        LOG_INFO("Creating result directory for action.");
-        if (!FileUtils::createDirectory(action_dir)) {
-            LOG_ERROR("Failed to create " + action_dir + ". Cannot start action.");
-        }
-    }
-
-    // create the exitcode file
+    // Initialize result files
     DataContainer status {};
     status.set<std::string>(module_name, "module");
     status.set<std::string>(action_name, "action");
@@ -182,29 +78,228 @@ void ExternalModule::call_delayed_action(std::string action_name,
     status.set<std::string>("running", "status");
     status.set<std::string>("0", "duration");
 
-    FileUtils::writeToFile(status.toString() + "\n", action_dir + "/status");
-    FileUtils::writeToFile("", action_dir + "/stdout");
-    FileUtils::writeToFile("", action_dir + "/stderr");
+    FileUtils::writeToFile(status.toString() + "\n", results_dir + "/status");
+    FileUtils::writeToFile("", results_dir + "/stdout");
+    FileUtils::writeToFile("", results_dir + "/stderr");
 
-    // prepare and run the command
+    // Prepare and run the command
     std::string stdin = input.toString();
     std::string stdout;
     std::string stderr;
-
     CthunAgent::Timer timer;
-    run_command(path_, { path_, action_name }, stdin, stdout, stderr);
-    status.set<std::string>(std::to_string(timer.elapsedSeconds()) + "s", "duration");
 
-    // Creating a DataContainer validates that the output is json
-    DataContainer result { stdout };
+    runCommand(module_path, { module_path, action_name }, stdin, stdout, stderr);
+
+    status.set<std::string>(std::to_string(timer.elapsedSeconds()) + "s",
+                            "duration");
+
+    // Validate (creating a DataContainer validates the json output)
+    try {
+        DataContainer result { stdout };
+    } catch (message_parse_error) {
+        // TODO(ale): report outcome (perhaps with a 'success' field)
+        stderr = "ERROR: failed to validate the '" + module_name + " "
+                 + action_name + "' output\n" + stderr;
+    }
+
+    // Write results to files
+    FileUtils::writeToFile(stdout + "\n", results_dir + "/stdout");
+
+    if (!stderr.empty()) {
+        FileUtils::writeToFile(stderr + "\n", results_dir + "/stderr");
+    }
 
     status.set<std::string>("completed", "status");
-
-    FileUtils::writeToFile(stdout + "\n", action_dir + "/stdout");
-    if (!stderr.empty()) {
-        FileUtils::writeToFile(stderr + "\n", action_dir + "/stderr");
-    }
-    FileUtils::writeToFile(status.toString() + "\n", action_dir + "/status");
+    FileUtils::writeToFile(status.toString() + "\n", results_dir + "/status");
 }
+
+//
+// ExternalModule
+//
+
+ExternalModule::ExternalModule(std::string path) : path_(path) {
+    boost::filesystem::path module_path { path };
+    module_name = module_path.filename().string();
+
+    auto metadata = validateModuleAndGetMetadata_();
+
+    for (auto action : metadata.get<std::vector<DataContainer>>("actions")) {
+        validateAndDeclareAction_(action);
+    }
+}
+
+DataContainer ExternalModule::callAction(const std::string& action_name,
+                                         const Message& request) {
+    // TODO(ale): consider moving this up to the Module class (enable
+    // blocking/non-blocking requests for a given module action pair)
+
+    if (actions[action_name].behaviour.compare("delayed") == 0) {
+        auto job_id = UUID::getUUID();
+        LOG_DEBUG("Delayed action execution requested. Creating job " \
+                  "with ID %1%", job_id);
+        return executeDelayedAction(action_name, request, job_id);
+    } else {
+        return callBlockingAction(action_name, request);
+    }
+}
+
+DataContainer ExternalModule::callBlockingAction(const std::string& action_name,
+                                                 const Message& request) {
+    std::string stdin = request.get<DataContainer>("data", "params").toString();
+    std::string stdout;
+    std::string stderr;
+    LOG_INFO(stdin);
+
+    runCommand(path_, { path_, action_name }, stdin, stdout, stderr);
+
+    LOG_INFO("stdout: %1%", stdout);
+    LOG_INFO("stderr: %1%", stderr);
+
+    return DataContainer { stdout };
+}
+
+DataContainer ExternalModule::executeDelayedAction(const std::string& action_name,
+                                                   const Message& request,
+                                                   const std::string& job_id) {
+    DataContainer input { request.get<DataContainer>("data", "params") };
+
+    // check if the output directory exists; if it doesn't, create it
+    if (!FileUtils::fileExists(RESULTS_ROOT_DIR)) {
+        LOG_INFO("%1% directory does not exist. Creating.", RESULTS_ROOT_DIR);
+        if (!FileUtils::createDirectory(RESULTS_ROOT_DIR)) {
+            throw validation_error { "failed to create directory "
+                                     + RESULTS_ROOT_DIR };
+        }
+    }
+
+    // create a job specific result directory
+    std::string results_dir { RESULTS_ROOT_DIR + "/" + job_id };
+
+    if (!FileUtils::fileExists(results_dir)) {
+        LOG_INFO("Creating result directory for delayed action '%1% %2%' %3%",
+                 module_name, action_name, job_id);
+        if (!FileUtils::createDirectory(results_dir)) {
+            throw validation_error { "failed to create directory " + results_dir };
+        }
+    }
+
+    LOG_INFO("Starting delayed action '%1% %2%' %3%",
+             module_name, action_name, job_id);
+
+    // TODO(ale): we must manage the thread lifecycle (no background)
+    // to avoid possible delays when the user quits the program;
+    // possible alternatives: capture signals and call std::terminate
+    // (i.e. mimic the old vector RIIA); future & timeout; thread pool
+
+    // start thread
+    try {
+        std::thread(&delayedAction,
+                    Message(request),
+                    job_id,
+                    std::string(path_),
+                    results_dir).detach();
+    } catch (std::exception& e) {
+        LOG_ERROR("Failed to spawn '%1% %2%' thread: %3%",
+                  module_name, action_name, e.what());
+        throw validation_error { "failed to create the delayed action thread" };
+    }
+
+    // return response with the job id
+    DataContainer response_output {};
+    response_output.set<std::string>("Requested excution of action: " + action_name,
+                                     "status");
+    response_output.set<std::string>(job_id, "id");
+    return response_output;
+}
+
+//
+// Private methods
+//
+
+const DataContainer ExternalModule::validateModuleAndGetMetadata_() {
+    valijson::Schema metadata_schema = Schemas::external_action_metadata();
+    std::string metadata_txt;
+    std::string error;
+
+    runCommand(path_, { path_, "metadata" }, "", metadata_txt, error);
+
+    if (!error.empty()) {
+        LOG_ERROR("Error while trying to load external module: %1%", path_);
+        LOG_ERROR(error);
+        throw module_error { "failed to load external module" };
+    }
+
+    DataContainer metadata { metadata_txt };
+
+    std::vector<std::string> errors;
+    if (!metadata.validate(metadata_schema, errors)) {
+        LOG_ERROR("validation failed");
+        for (auto error : errors) {
+            LOG_ERROR("    %1%", error);
+        }
+        throw module_error { "metadata did not match schema" };
+    }
+
+    LOG_INFO("External module %1%: metadata validation OK", module_name);
+
+    return metadata;
+}
+
+void ExternalModule::validateAndDeclareAction_(const DataContainer& action) {
+    std::string action_name { action.get<std::string>("name") };
+    LOG_INFO("Validating action %1%", action_name);
+    valijson::Schema input_schema;
+    valijson::Schema output_schema;
+
+    // TODO(ploubser): This doesn't fit well with the Data abstraction.
+    // Should this go in the object?
+
+    // TODO(ale): unit tests for the validation once we move its logic
+
+    valijson::SchemaParser parser;
+    rapidjson::Value input  { action.get<rapidjson::Value>("input") };
+    rapidjson::Value output { action.get<rapidjson::Value>("output") };
+
+    valijson::adapters::RapidJsonAdapter input_doc_schema(input);
+    valijson::adapters::RapidJsonAdapter output_doc_schema(output);
+
+    try {
+        parser.populateSchema(input_doc_schema, input_schema);
+    } catch (...) {
+        LOG_ERROR("Failed to parse input schema of %1%", action_name);
+        throw module_error { "invalid input schema of " + action_name };
+    }
+
+    std::string behaviour { action.get<std::string>("behaviour") };
+
+    if (!behaviour.empty()) {
+        if (behaviour.compare("interactive") == 0) {
+            LOG_DEBUG("Found interactive action: %1%", action_name);
+        } else if (behaviour.compare("delayed") == 0) {
+            LOG_DEBUG("Found delayed action: %1%", action_name);
+        } else {
+            LOG_ERROR("Invalid behaviour defined for action %1%: %2%",
+                      action_name, behaviour);
+            throw module_error { "invalid behavior of " + action_name };
+        }
+    } else {
+        LOG_DEBUG("Found no behaviour for action %1%; using 'interactive'",
+                  action_name);
+        behaviour = "interactive";
+    }
+
+    try {
+        parser.populateSchema(output_doc_schema, output_schema);
+    } catch (...) {
+        LOG_ERROR("Failed to parse output schema of %1%", action_name);
+        throw module_error { "invalid output schema of " + action_name };
+    }
+
+    LOG_INFO("Action %1% of external module %2%: validation OK",
+             action_name, module_name);
+    actions[action.get<std::string>("name")] = Action {
+        input_schema, output_schema, behaviour };
+}
+
 
 }  // namespace CthunAgent

--- a/src/external_module.h
+++ b/src/external_module.h
@@ -8,6 +8,8 @@
 
 #include <map>
 #include <string>
+#include <vector>
+#include <thread>
 
 namespace CthunAgent {
 
@@ -15,17 +17,29 @@ static const std::string RESULTS_ROOT_DIR { "/tmp/cthun_agent" };
 
 class ExternalModule : public Module {
   public:
-    // Throws a module_error in case if fails to load the external
-    // module or if its metadata is invalid.
+    /// Throw a module_error in case if fails to load the external
+    /// module or if its metadata is invalid.
     explicit ExternalModule(std::string path);
-    DataContainer call_action(std::string action_name,
-                              const Message& request);
 
-    void call_delayed_action(std::string action_name,
-                             const Message& request,
-                             std::string job_id);
+    DataContainer callAction(const std::string& action_name,
+                             const Message& request);
+
+    // This is public for test purposes
+    DataContainer callBlockingAction(const std::string& action_name,
+                                     const Message& request);
+
+    // Public (as above); also passing the job_id for the same reason;
+    //
+    DataContainer executeDelayedAction(const std::string& action_name,
+                                       const Message& request,
+                                       const std::string& job_id);
+
   private:
+    /// The path of the module file
     std::string path_;
+
+    const DataContainer validateModuleAndGetMetadata_();
+    void validateAndDeclareAction_(const DataContainer& action);
 };
 
 }  // namespace CthunAgent

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -9,49 +9,41 @@ LOG_DECLARE_NAMESPACE("module");
 
 namespace CthunAgent {
 
-// TODO(ale): change 'params' to 'input' for consistency
-
-DataContainer Module::validate_and_call_action(std::string action_name,
-                                               const Message& request,
-                                               std::string action_id) {
+DataContainer Module::validateAndCallAction(const std::string& action_name,
+                                            const Message& request) {
+    // Validate action name
     if (actions.find(action_name) == actions.end()) {
-        throw validation_error { "unknown action for module " + module_name
-                                 + ": '" + action_name + "'" };
+        throw validation_error { "unknown action '" + action_name
+                                 + "' for module " + module_name };
     }
 
-    const Action& action = actions[action_name];
-    DataContainer input { request.get<DataContainer>("data", "params") };
+    // Validate request input
+    auto action = actions[action_name];
+    DataContainer request_input { request.get<DataContainer>("data", "params") };
 
-    LOG_DEBUG("validating input for '%1%' '%2%'", module_name, action_name);
+    LOG_DEBUG("Validating input for '%1%' '%2%'", module_name, action_name);
     std::vector<std::string> errors;
-    if (!input.validate(action.input_schema, errors)) {
+    if (!request_input.validate(action.input_schema, errors)) {
         LOG_ERROR("action input validation failed '%1%' '%2%'",
                   module_name, action_name);
         for (auto error : errors) {
             LOG_ERROR("    %1%", error);
         }
 
-        throw validation_error { "Input schema mismatch" };
+        throw validation_error { "input schema mismatch" };
     }
 
-    DataContainer result;
+    // Execute action and validate the result output
+    auto result = callAction(action_name, request);
 
-    // TODO(ploubser): This still isn't great. I would like the logic in
-    // call_delayed_action to be moved to the Agent::delayedActionThread.
-    if (action_id.empty()) {
-        result = call_action(action_name, request);
-    } else {
-        call_delayed_action(action_name, request, action_id);
-    }
-
-    LOG_DEBUG("validating output for '%1%' '%2%'", module_name, action_name);
+    LOG_DEBUG("Validating output for '%1%' '%2%'", module_name, action_name);
     if (!result.validate(action.output_schema, errors)) {
-        LOG_ERROR("output validation failed '%1%' '%2%'", module_name, action_name);
+        LOG_ERROR("Output validation failed '%1%' '%2%'", module_name, action_name);
         for (auto error : errors) {
             LOG_ERROR("    %1%", error);
         }
 
-        throw validation_error { "Output schema mismatch" };
+        throw validation_error { "output schema mismatch" };
     }
 
     return result;

--- a/src/module.h
+++ b/src/module.h
@@ -14,20 +14,18 @@ class Module {
     std::string module_name;
     std::map<std::string, Action> actions;
 
-    virtual DataContainer call_action(std::string action_name,
-                                      const Message& request) = 0;
-
-    virtual void call_delayed_action(std::string action_name,
-                                     const Message& request,
-                                     std::string job_id) = 0;
+    /// Performs the requested action.
+    virtual DataContainer callAction(const std::string& action_name,
+                                     const Message& request) = 0;
 
     /// Validate the json schemas of input and output.
-    /// Execute the requested action for the particular module.
-    /// Sets an error response in the referred output json object
-    /// in case of unknown action or invalid schemas.
-    DataContainer validate_and_call_action(std::string action_name,
-                                           const Message& request,
-                                           std::string job_id = "");
+    /// Start the requested action for the particular module.
+    /// Return the output of the action as a DataContainer object.
+    /// Throw a validation error in case of unknown action,
+    /// invalid request input, or if the requested action provides an
+    /// invalid output.
+    DataContainer validateAndCallAction(const std::string& action_name,
+                                        const Message& request);
 };
 
 }  // namespace CthunAgent

--- a/src/modules/echo.cpp
+++ b/src/modules/echo.cpp
@@ -20,8 +20,8 @@ Echo::Echo() {
     actions["echo"] = Action { input_schema, output_schema, "interactive" };
 }
 
-DataContainer Echo::call_action(std::string action_name,
-                                const Message& request) {
+DataContainer Echo::callAction(const std::string& action_name,
+                               const Message& request) {
     return request.get<DataContainer>("data", "params");
 }
 

--- a/src/modules/echo.h
+++ b/src/modules/echo.h
@@ -9,12 +9,8 @@ namespace Modules {
 class Echo : public CthunAgent::Module {
   public:
     Echo();
-    DataContainer call_action(std::string action_name,
-                              const Message& request);
-
-    void call_delayed_action(std::string action_name,
-                             const Message& request,
-                             std::string job_idd) {}
+    DataContainer callAction(const std::string& action_name,
+                             const Message& request);
 };
 
 }  // namespace Modules

--- a/src/modules/inventory.cpp
+++ b/src/modules/inventory.cpp
@@ -28,8 +28,8 @@ Inventory::Inventory() {
     actions["inventory"] = Action { input_schema, output_schema, "interactive" };
 }
 
-DataContainer Inventory::call_action(std::string action_name,
-                                     const Message& request) {
+DataContainer Inventory::callAction(const std::string& action_name,
+                                    const Message& request) {
     std::ostringstream fact_stream;
     DataContainer data {};
 

--- a/src/modules/inventory.h
+++ b/src/modules/inventory.h
@@ -9,12 +9,8 @@ namespace Modules {
 class Inventory : public CthunAgent::Module {
   public:
     Inventory();
-    DataContainer call_action(std::string action_name,
-                              const Message& request);
-
-    void call_delayed_action(std::string action_name,
-                             const Message& request,
-                             std::string job_id) {}
+    DataContainer callAction(const std::string& action_name,
+                             const Message& request);
 };
 
 }  // namespace Modules

--- a/src/modules/ping.cpp
+++ b/src/modules/ping.cpp
@@ -37,7 +37,7 @@ Ping::Ping() {
     actions["ping"] = Action { input_schema, output_schema, "interactive" };
 }
 
-DataContainer Ping::ping_action(const Message& request) {
+DataContainer Ping::ping(const Message& request) {
     int sender_timestamp;
     DataContainer input { request.get<DataContainer>("data", "params") };
     std::istringstream(input.get<std::string>("sender_timestamp")) >>
@@ -60,9 +60,9 @@ DataContainer Ping::ping_action(const Message& request) {
     return data;
 }
 
-DataContainer Ping::call_action(std::string action_name,
-                                const Message& request) {
-   return ping_action(request);
+DataContainer Ping::callAction(const std::string& action_name,
+                               const Message& request) {
+   return ping(request);
 }
 
 }  // namespace Modules

--- a/src/modules/ping.h
+++ b/src/modules/ping.h
@@ -9,17 +9,13 @@ namespace Modules {
 class Ping : public CthunAgent::Module {
   public:
     Ping();
-    DataContainer call_action(std::string action_name,
-                              const Message& request);
+    DataContainer callAction(const std::string& action_name,
+                             const Message& request);
 
-    void call_delayed_action(std::string action_name,
-                             const Message& request,
-                             std::string job_id) {}
-
-    /// Ping action calculates the time it took for a message to travel from
-    /// the controller to the agent. It will then add that duration and the
-    /// current server time in milliseconds to the response.
-    DataContainer ping_action(const Message& request);
+    /// Ping calculates the time it took for a message to travel from
+    /// the controller to the agent. It will then add that duration
+    /// and the current server time in milliseconds to the response.
+    DataContainer ping(const Message& request);
 };
 
 }  // namespace Modules

--- a/src/modules/status.cpp
+++ b/src/modules/status.cpp
@@ -27,14 +27,14 @@ Status::Status() {
     actions["query"] = Action { input_schema, output_schema, "interactive" };
 }
 
-DataContainer Status::call_action(std::string action_name,
-                                  const Message& request) {
+DataContainer Status::callAction(const std::string& action_name,
+                                 const Message& request) {
     DataContainer output {};
     DataContainer input { request.get<DataContainer>("data", "params") };
     std::string job_id { input.get<std::string>("job_id") };
 
     if (!FileUtils::fileExists("/tmp/cthun_agent/" + job_id)) {
-        LOG_ERROR("No results for job id %1% found", job_id);
+        LOG_ERROR("Found no results for job %1%", job_id);
         output.set<std::string>("No job exists for id: " + job_id, "error");
         return output;
     }

--- a/src/modules/status.h
+++ b/src/modules/status.h
@@ -9,12 +9,8 @@ namespace Modules {
 class Status : public CthunAgent::Module {
   public:
     Status();
-    DataContainer call_action(std::string action_name,
-                              const Message& request);
-
-    void call_delayed_action(std::string action_name,
-                             const Message& request,
-                             std::string job_id) {}
+    DataContainer callAction(const std::string& action_name,
+                             const Message& request);
 };
 
 }  // namespace Modules

--- a/test/unit/configuration_test.cpp
+++ b/test/unit/configuration_test.cpp
@@ -19,7 +19,7 @@ void configure_test() {
     CthunAgent::Configuration::Instance().initialize(argc, const_cast<char**>(argv));
 }
 
-TEST_CASE("Configuration::setStartFunction", "[configuration") {
+TEST_CASE("Configuration::setStartFunction", "[configuration]") {
     std::string server = "wss://test_server/";
     std::string ca = ROOT_PATH + "/test/resources/config/ca_crt.pem";
     std::string cert = ROOT_PATH +  "/test/resources/config/test_crt.pem";
@@ -39,19 +39,19 @@ TEST_CASE("Configuration::setStartFunction", "[configuration") {
     REQUIRE(HorseWhisperer::Start() == 1);
 }
 
-TEST_CASE("Configuration::set", "[configuration") {
+TEST_CASE("Configuration::set", "[configuration]") {
     configure_test();
     CthunAgent::Configuration::Instance().set<std::string>("ca", "value");
     REQUIRE(HorseWhisperer::GetFlag<std::string>("ca") == "value");
 }
 
-TEST_CASE("Configuration::get", "[configuration") {
+TEST_CASE("Configuration::get", "[configuration]") {
     configure_test();
     HorseWhisperer::SetFlag<std::string>("ca", "value");
     REQUIRE(CthunAgent::Configuration::Instance().get<std::string>("ca") == "value");
 }
 
-TEST_CASE("Configuration::validateConfiguration", "[configuration") {
+TEST_CASE("Configuration::validateConfiguration", "[configuration]") {
     configure_test();
 
     SECTION("it fails when server is undefined") {
@@ -101,5 +101,4 @@ TEST_CASE("Configuration::validateConfiguration", "[configuration") {
         REQUIRE_THROWS_AS(CthunAgent::Configuration::Instance().validateConfiguration(0),
                           CthunAgent::required_not_set_error);
     }
-
 }

--- a/test/unit/module_test.cpp
+++ b/test/unit/module_test.cpp
@@ -24,22 +24,22 @@ static const std::string bad_echo =
     "    }"
     "}";
 
-TEST_CASE("Module::validate_and_call_action", "[modules]") {
+TEST_CASE("Module::validateAndCallAction", "[modules]") {
     Modules::Echo echo_module {};
 
     SECTION("it should correctly call echo") {
-        auto result = echo_module.validate_and_call_action(echo_action, msg);
+        auto result = echo_module.validateAndCallAction(echo_action, msg);
         REQUIRE(result.toString().find("maradona"));
     }
 
     SECTION("it should throw a validation_error if the action is unknown") {
-        REQUIRE_THROWS_AS(echo_module.validate_and_call_action(fake_action, msg),
+        REQUIRE_THROWS_AS(echo_module.validateAndCallAction(fake_action, msg),
                           validation_error);
     }
 
     SECTION("it should throw a validation_error if the message is invalid") {
         Message bad_msg { bad_echo };
-        REQUIRE_THROWS_AS(echo_module.validate_and_call_action(echo_action, bad_msg),
+        REQUIRE_THROWS_AS(echo_module.validateAndCallAction(echo_action, bad_msg),
                           validation_error);
     }
 }

--- a/test/unit/modules/inventory_test.cpp
+++ b/test/unit/modules/inventory_test.cpp
@@ -20,7 +20,7 @@ static const std::string inventory_txt =
     "}";
 static const Message msg { inventory_txt };
 
-TEST_CASE("Modules::Inventory::call_action", "[modules]") {
+TEST_CASE("Modules::Inventory::callAction", "[modules]") {
     Modules::Inventory inventory_module {};
 
     SECTION("the inventory module is correctly named") {
@@ -33,11 +33,11 @@ TEST_CASE("Modules::Inventory::call_action", "[modules]") {
     }
 
     SECTION("it can call the inventory action") {
-        REQUIRE_NOTHROW(inventory_module.call_action(inventory_action, msg));
+        REQUIRE_NOTHROW(inventory_module.callAction(inventory_action, msg));
     }
 
     SECTION("it should execute the inventory action correctly") {
-        auto result = inventory_module.call_action(inventory_action, msg);
+        auto result = inventory_module.callAction(inventory_action, msg);
         CHECK(result.toString().find("facts"));
     }
 }

--- a/test/unit/modules/ping_test.cpp
+++ b/test/unit/modules/ping_test.cpp
@@ -25,7 +25,7 @@ static const std::string ping_txt =
     "}";
 static const Message msg { ping_txt };
 
-TEST_CASE("Modules::Ping::call_action", "[modules]") {
+TEST_CASE("Modules::Ping::callAction", "[modules]") {
     Modules::Ping ping_module {};
 
     SECTION("the ping module is correctly named") {
@@ -37,17 +37,17 @@ TEST_CASE("Modules::Ping::call_action", "[modules]") {
     }
 
     SECTION("it can call the ping action") {
-        REQUIRE_NOTHROW(ping_module.call_action(ping_action, msg));
+        REQUIRE_NOTHROW(ping_module.callAction(ping_action, msg));
     }
 
     SECTION("it should execute the ping action correctly") {
-        auto result = ping_module.call_action(ping_action, msg);
+        auto result = ping_module.callAction(ping_action, msg);
         REQUIRE(result.toString().find("agent_timestamp"));
         REQUIRE(result.toString().find("time_to_agent"));
     }
 }
 
-TEST_CASE("Modules::Ping::ping_action", "[modules]") {
+TEST_CASE("Modules::Ping::ping", "[modules]") {
     Modules::Ping ping_module {};
 
     boost::format ping_format {
@@ -71,7 +71,7 @@ TEST_CASE("Modules::Ping::ping_action", "[modules]") {
 
         Message ping_msg { (ping_format % current_date_milliseconds % "[]").str() };
 
-        auto result = ping_module.ping_action(ping_msg);
+        auto result = ping_module.ping(ping_msg);
 
         REQUIRE(current_date_milliseconds
                 == result.get<std::string>("sender_timestamp"));
@@ -80,7 +80,7 @@ TEST_CASE("Modules::Ping::ping_action", "[modules]") {
 
     SECTION("it should copy an empty hops entry") {
         Message ping_msg { (ping_format % "" % "[]").str() };
-        auto result = ping_module.ping_action(ping_msg);
+        auto result = ping_module.ping(ping_msg);
         REQUIRE(result.get<std::vector<DataContainer>>("request_hops").empty());
     }
 
@@ -102,7 +102,7 @@ TEST_CASE("Modules::Ping::ping_action", "[modules]") {
 
         Message ping_msg { (ping_format % "" % hops_str).str() };
 
-        auto result = ping_module.ping_action(ping_msg);
+        auto result = ping_module.ping(ping_msg);
         auto hops = result.get<std::vector<DataContainer>>("request_hops");
 
         REQUIRE(hops.size() == 4);
@@ -119,7 +119,7 @@ TEST_CASE("Modules::Ping::ping_action", "[modules]") {
 
         Message ping_msg { (ping_format % "" % hops_str).str() };
 
-        auto result = ping_module.ping_action(ping_msg);
+        auto result = ping_module.ping(ping_msg);
         auto hops = result.get<std::vector<DataContainer>>("request_hops");
 
         REQUIRE(hops.size() == 8);

--- a/test/unit/modules/status_test.cpp
+++ b/test/unit/modules/status_test.cpp
@@ -32,7 +32,7 @@ boost::format status_format {
 
 static const Message msg { (status_format % "the-uuid-string").str() };
 
-TEST_CASE("Modules::Status::call_action", "[modules]") {
+TEST_CASE("Modules::Status::callAction", "[modules]") {
     Modules::Status status_module {};
 
     SECTION("the status module is correctly named") {
@@ -45,7 +45,7 @@ TEST_CASE("Modules::Status::call_action", "[modules]") {
     }
 
     SECTION("it can call the 'query' action") {
-        REQUIRE_NOTHROW(status_module.call_action(query_action, msg));
+        REQUIRE_NOTHROW(status_module.callAction(query_action, msg));
     }
 
     SECTION("it works properly when an unknown job id is provided") {
@@ -53,11 +53,11 @@ TEST_CASE("Modules::Status::call_action", "[modules]") {
         Message unknown_msg { (status_format % job_id).str() };
 
         SECTION("it doesn't throw") {
-            REQUIRE_NOTHROW(status_module.call_action(query_action, unknown_msg));
+            REQUIRE_NOTHROW(status_module.callAction(query_action, unknown_msg));
         }
 
         SECTION("it returns an error") {
-            auto result = status_module.call_action(query_action, unknown_msg);
+            auto result = status_module.callAction(query_action, unknown_msg);
             REQUIRE(result.includes("error"));
         }
     }
@@ -79,21 +79,21 @@ TEST_CASE("Modules::Status::call_action", "[modules]") {
         }
 
         SECTION("it doesn't throw") {
-            REQUIRE_NOTHROW(status_module.call_action(query_action, known_msg));
+            REQUIRE_NOTHROW(status_module.callAction(query_action, known_msg));
         }
 
         SECTION("it returns the action status") {
-            auto result = status_module.call_action(query_action, known_msg);
+            auto result = status_module.callAction(query_action, known_msg);
             REQUIRE(result.get<std::string>("status") == "Completed");
         }
 
         SECTION("it returns the action output") {
-            auto result = status_module.call_action(query_action, known_msg);
+            auto result = status_module.callAction(query_action, known_msg);
             REQUIRE(result.get<std::string>("stdout") == "***OUTPUT\n");
         }
 
         SECTION("it returns the action error string") {
-            auto result = status_module.call_action(query_action, known_msg);
+            auto result = status_module.callAction(query_action, known_msg);
             REQUIRE(result.get<std::string>("stderr") == "***ERROR\n");
         }
 


### PR DESCRIPTION
ExternalModule is now in charge of creating the thread for the execution
of delayed tasks. Single path of execution for action invocation.

Delayed tasks now run in background; this will prevent cthun-agent to
immediately exit in case a task is still running. We'll fix that in
separate commit.

A possible invalid action output is now reported in the result files; we
should add a specific field for the action 'success' in the related data
schema.

An external_module_test.cpp test case now refers to the new async
ExternalModule::executeDelayedAction(), which spawns the delayed action
thread; this test requires a usleep() pause.
