### PR TITLE
(maint) Trivial fixes to constants and log messages

### DIFF
--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -62,7 +62,7 @@ Configuration::Configuration() {
                                "",
                                "specify directory to spool delayed results to",
                                Types::String,
-                               "/tmp/cthun-agent/")));
+                               DEFAULT_ACTION_RESULTS_DIR)));
 }
 
 int Configuration::initialize(int argc, char *argv[]) {
@@ -183,7 +183,7 @@ void Configuration::validateConfiguration(int parse_result) {
     }
 
     if (!HW::GetFlag<std::string>("spool-dir").empty()) {
-        std::string spool_dir = HW::GetFlag<std::string>("spool-dir");
+        std::string spool_dir = FileUtils::shellExpand(HW::GetFlag<std::string>("spool-dir"));
         if (spool_dir[-1] != '/') {
             HW::SetFlag<std::string>("spool-dir", spool_dir + "/");
         }

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -11,6 +11,7 @@ namespace CthunAgent {
 namespace HW = HorseWhisperer;
 
 static const std::string VERSION_STRING = "cthun-agent version - 0.0.1\n";
+static const std::string DEFAULT_ACTION_RESULTS_DIR = "/tmp/cthun-agent/";
 
 enum Types { Integer, String, Bool, Double};
 

--- a/src/external_module.cpp
+++ b/src/external_module.cpp
@@ -25,7 +25,7 @@ namespace CthunAgent {
 
 // Execute binaries and get output and errors
 
-void runCommand(std::string exec, std::vector<std::string> args,
+void runCommand(const std::string& exec, std::vector<std::string> args,
                 std::string stdin, std::string &stdout, std::string &stderr) {
     boost::process::context context;
     context.stdin_behavior = boost::process::capture_stream();
@@ -117,7 +117,7 @@ void delayedAction(Message request,
 // ExternalModule
 //
 
-ExternalModule::ExternalModule(std::string path) : path_(path) {
+ExternalModule::ExternalModule(const std::string& path) : path_(path) {
     boost::filesystem::path module_path { path };
     module_name = module_path.filename().string();
 
@@ -148,7 +148,8 @@ DataContainer ExternalModule::callBlockingAction(const std::string& action_name,
     std::string stdin = request.get<DataContainer>("data", "params").toString();
     std::string stdout;
     std::string stderr;
-    LOG_INFO(stdin);
+    LOG_INFO("About to execute '%1% %2%' - stdin: %3%",
+             module_name, action_name, stdin);
 
     runCommand(path_, { path_, action_name }, stdin, stdout, stderr);
 

--- a/src/external_module.h
+++ b/src/external_module.h
@@ -18,7 +18,7 @@ class ExternalModule : public Module {
   public:
     /// Throw a module_error in case if fails to load the external
     /// module or if its metadata is invalid.
-    explicit ExternalModule(std::string path);
+    explicit ExternalModule(const std::string& path);
 
     DataContainer callAction(const std::string& action_name,
                              const Message& request);
@@ -27,8 +27,7 @@ class ExternalModule : public Module {
     DataContainer callBlockingAction(const std::string& action_name,
                                      const Message& request);
 
-    // Public (as above); also passing the job_id for the same reason;
-    //
+    // Public (as above); also passing the job_id for the same reason
     DataContainer executeDelayedAction(const std::string& action_name,
                                        const Message& request,
                                        const std::string& job_id);
@@ -36,7 +35,7 @@ class ExternalModule : public Module {
   private:
     std::string spool_dir_ = Configuration::Instance().get<std::string>("spool-dir");
     /// The path of the module file
-    std::string path_;
+    const std::string path_;
 
     const DataContainer validateModuleAndGetMetadata_();
     void validateAndDeclareAction_(const DataContainer& action);

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -21,7 +21,7 @@ DataContainer Module::validateAndCallAction(const std::string& action_name,
     auto action = actions[action_name];
     DataContainer request_input { request.get<DataContainer>("data", "params") };
 
-    LOG_DEBUG("Validating input for '%1%' '%2%'", module_name, action_name);
+    LOG_DEBUG("Validating input for '%1% %2%'", module_name, action_name);
     std::vector<std::string> errors;
     if (!request_input.validate(action.input_schema, errors)) {
         LOG_ERROR("action input validation failed '%1%' '%2%'",
@@ -36,9 +36,9 @@ DataContainer Module::validateAndCallAction(const std::string& action_name,
     // Execute action and validate the result output
     auto result = callAction(action_name, request);
 
-    LOG_DEBUG("Validating output for '%1%' '%2%'", module_name, action_name);
+    LOG_DEBUG("Validating output for '%1% %2%'", module_name, action_name);
     if (!result.validate(action.output_schema, errors)) {
-        LOG_ERROR("Output validation failed '%1%' '%2%'", module_name, action_name);
+        LOG_ERROR("Output validation failed '%1% %2%'", module_name, action_name);
         for (auto error : errors) {
             LOG_ERROR("    %1%", error);
         }

--- a/test/unit/external_module_test.cpp
+++ b/test/unit/external_module_test.cpp
@@ -31,7 +31,7 @@ TEST_CASE("ExternalModule::ExternalModule", "[modules]") {
 
     SECTION("throws an error in case of invalid overall metadata schema") {
         REQUIRE_THROWS_AS(
-            ExternalModule(ROOT_PATH + "/test/resources/reverse_broken_01"),
+            ExternalModule(ROOT_PATH + "/test/resources/reverse_broken"),
             module_error);
     }
 }

--- a/test/unit/modules/status_test.cpp
+++ b/test/unit/modules/status_test.cpp
@@ -7,9 +7,7 @@
 #include "src/uuid.h"
 #include "src/file_utils.h"
 #include "src/modules/status.h"
-
-// TODO(ale): required for RESULTS_ROOT_DIR; change to configuration.h
-#include "src/external_module.h"
+#include "src/configuration.h"
 
 #include <boost/format.hpp>
 #include <boost/filesystem/operations.hpp>
@@ -31,7 +29,6 @@ boost::format status_format {
 };
 
 static const Message msg { (status_format % "the-uuid-string").str() };
-const std::string RESULTS_ROOT_DIR = "/tmp/cthun-agent";
 
 TEST_CASE("Modules::Status::callAction", "[modules]") {
     Modules::Status status_module {};
@@ -68,7 +65,7 @@ TEST_CASE("Modules::Status::callAction", "[modules]") {
         boost::filesystem::path to { result_path };
 
         auto symlink_name = UUID::getUUID();
-        std::string symlink_path { RESULTS_ROOT_DIR + "/" + symlink_name };
+        std::string symlink_path { DEFAULT_ACTION_RESULTS_DIR + symlink_name };
         boost::filesystem::path symlink { symlink_path };
 
         Message known_msg { (status_format % symlink_name).str() };
@@ -98,8 +95,7 @@ TEST_CASE("Modules::Status::callAction", "[modules]") {
             REQUIRE(result.get<std::string>("stderr") == "***ERROR\n");
         }
 
-        std::cout << symlink_path << std::endl;
-        //FileUtils::removeFile(symlink_path);
+        FileUtils::removeFile(symlink_path);
     }
 }
 


### PR DESCRIPTION
Improving log messages. Using constant for default result directory.
Deleting symlinks used by status_test.cpp.
