### PR TITLE
(CTH-160) Improve Configuration class and tests

### DIFF
--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -3,11 +3,24 @@
 
 namespace CthunAgent {
 
-Configuration::Configuration() {
+//
+// Private
+//
+
+Configuration::Configuration() : initialized_ { false },
+                                 defaults_ {},
+                                 config_file_ { "" },
+                                 start_function_ {} {
+    defineDefaultValues();
+}
+
+void Configuration::defineDefaultValues() {
     HW::SetAppName("cthun-agent");
     HW::SetHelpBanner("Usage: cthun-agent [options]");
     HW::SetVersion(VERSION_STRING);
 
+    // start setting the config file path to known existent locations;
+    // HW will overwrite it with the one parsed from CLI, if specified
     if (FileUtils::fileExists(FileUtils::shellExpand("~/.cthun-agent"))) {
         config_file_ = FileUtils::shellExpand("~/.cthun-agent");
     // TODO(ploubser): This will have to changed when the AIO agent is done
@@ -15,7 +28,6 @@ Configuration::Configuration() {
         config_file_ = "/etc/puppetlabs/agent/cthun.cfg";
     }
 
-    // configure the default values
     defaults_.insert(std::pair<std::string, Base_ptr>("server", Base_ptr(
         new Entry<std::string>("server",
                                "s",
@@ -56,7 +68,8 @@ Configuration::Configuration() {
                                "",
                                "Specify a non default config file to use",
                                Types::String,
-                               ""))));
+                               config_file_))));
+
     defaults_.insert(std::pair<std::string, Base_ptr>("spool-dir", Base_ptr(
         new Entry<std::string>("spool-dir",
                                "",
@@ -65,7 +78,7 @@ Configuration::Configuration() {
                                DEFAULT_ACTION_RESULTS_DIR))));
 }
 
-int Configuration::initialize(int argc, char *argv[]) {
+void Configuration::setDefaultValues() {
     for (const auto& entry : defaults_) {
         std::string flag_names = entry.second->name;
 
@@ -78,7 +91,8 @@ int Configuration::initialize(int argc, char *argv[]) {
                 {
                     Entry<int>* entry_ptr = (Entry<int>*) entry.second.get();
                     HW::DefineGlobalFlag<int>(flag_names, entry_ptr->help,
-                                              entry_ptr->value, [entry_ptr] (int v) -> bool{
+                                              entry_ptr->value,
+                                              [entry_ptr] (int v) -> bool{
                         entry_ptr->configured = true;
                         return true;
                     });
@@ -88,7 +102,8 @@ int Configuration::initialize(int argc, char *argv[]) {
                 {
                     Entry<bool>* entry_ptr = (Entry<bool>*) entry.second.get();
                     HW::DefineGlobalFlag<bool>(flag_names, entry_ptr->help,
-                                               entry_ptr->value, [entry_ptr] (bool v) -> bool{
+                                               entry_ptr->value,
+                                               [entry_ptr] (bool v) -> bool{
                         entry_ptr->configured = true;
                         return true;
                     });
@@ -98,7 +113,8 @@ int Configuration::initialize(int argc, char *argv[]) {
                 {
                     Entry<double>* entry_ptr = (Entry<double>*) entry.second.get();
                     HW::DefineGlobalFlag<double>(flag_names, entry_ptr->help,
-                                                 entry_ptr->value, [entry_ptr] (double v) -> bool{
+                                                 entry_ptr->value,
+                                                 [entry_ptr] (double v) -> bool{
                         entry_ptr->configured = true;
                         return true;
                     });
@@ -108,89 +124,21 @@ int Configuration::initialize(int argc, char *argv[]) {
                 {
                     Entry<std::string>* entry_ptr = (Entry<std::string>*) entry.second.get();
                     HW::DefineGlobalFlag<std::string>(flag_names, entry_ptr->help,
-                                                      entry_ptr->value, [entry_ptr] (std::string v) -> bool {
+                                                      entry_ptr->value,
+                                                      [entry_ptr] (std::string v) -> bool {
                         entry_ptr->configured = true;
                         return true;
                     });
                 }
         }
     }
-
-    HW::DefineAction("start", 0, false, "Start the agent (Default)", "Start the agent", start_function_);
-    HW::DefineActionFlag<std::string>("start", "module-dir", "External module directory",
-                                      "", nullptr);
-
-    // manipulate argc and v to make start the default action.
-    // TODO(ploubser): Add ability to specify default action to HorseWhisperer
-    int modified_argc = argc + 1;
-    char* modified_argv[modified_argc];
-    char action[] = "start";
-
-    for (int i = 0; i < argc; i++) {
-        modified_argv[i] = argv[i];
-    }
-    modified_argv[modified_argc - 1] = action;
-
-    int parse_result { HW::Parse(modified_argc, modified_argv) };
-
-    if (!HW::GetFlag<std::string>("config-file").empty()) {
-        config_file_ = HW::GetFlag<std::string>("config-file");
-    }
-
-    if (!config_file_.empty()) {
-        parseConfigFile();
-    }
-
-    validateConfiguration(parse_result);
-    initialized_ = true;
-
-    return parse_result;
-}
-
-void Configuration::setStartFunction(std::function<int(std::vector<std::string>)> start_function) {
-    start_function_ = start_function;
-}
-
-
-void Configuration::validateConfiguration(int parse_result) {
-    if (parse_result == HW::PARSE_ERROR || parse_result == HW::PARSE_INVALID_FLAG) {
-        throw cli_parse_error { "An error occurred while parsing cli options"};
-    }
-
-    // determine which of your values must be initalised
-    if (HW::GetFlag<std::string>("server").empty()) {
-        throw required_not_set_error { "server value must be defined" };
-    } else if (HW::GetFlag<std::string>("server").find("wss://") != 0) {
-        throw required_not_set_error { "server value must start with wss://" };
-    }
-
-    if (HW::GetFlag<std::string>("ca").empty()) {
-        throw required_not_set_error { "ca value must be defined" };
-    } else if (!FileUtils::fileExists(HW::GetFlag<std::string>("ca"))) {
-        throw required_not_set_error { "ca file not found" };
-    }
-
-    if (HW::GetFlag<std::string>("cert").empty()) {
-        throw required_not_set_error { "cert value must be defined" };
-    } else if (!FileUtils::fileExists(HW::GetFlag<std::string>("cert"))) {
-        throw required_not_set_error { "cert file not found" };
-    }
-
-    if (HW::GetFlag<std::string>("key").empty()) {
-        throw required_not_set_error { "key value must be defined" };
-    } else if (!FileUtils::fileExists(HW::GetFlag<std::string>("key"))) {
-        throw required_not_set_error { "key file not found" };
-    }
-
-    if (!HW::GetFlag<std::string>("spool-dir").empty()) {
-        std::string spool_dir = FileUtils::shellExpand(HW::GetFlag<std::string>("spool-dir"));
-        if (spool_dir[-1] != '/') {
-            HW::SetFlag<std::string>("spool-dir", spool_dir + "/");
-        }
-    }
 }
 
 void Configuration::parseConfigFile() {
+    if (!FileUtils::fileExists(config_file_)) {
+        throw configuration_entry_error { config_file_ + " does not exist" };
+    }
+
     INIReader reader { config_file_ };
 
     for (const auto& entry : defaults_) {
@@ -238,5 +186,89 @@ void Configuration::parseConfigFile() {
         }
     }
 }
+
+//
+// Public interface
+//
+
+void Configuration::reset() {
+    setDefaultValues();
+    initialized_ = false;
+}
+
+int Configuration::initialize(int argc, char *argv[]) {
+    setDefaultValues();
+
+    HW::DefineAction("start", 0, false, "Start the agent (Default)",
+                     "Start the agent", start_function_);
+    HW::DefineActionFlag<std::string>("start", "module-dir", "External module directory",
+                                      "", nullptr);
+
+    // manipulate argc and v to make start the default action.
+    // TODO(ploubser): Add ability to specify default action to HorseWhisperer
+    int modified_argc = argc + 1;
+    char* modified_argv[modified_argc];
+    char action[] = "start";
+
+    for (int i = 0; i < argc; i++) {
+        modified_argv[i] = argv[i];
+    }
+    modified_argv[modified_argc - 1] = action;
+
+    int parse_result { HW::Parse(modified_argc, modified_argv) };
+
+    if (parse_result == HW::PARSE_ERROR || parse_result == HW::PARSE_INVALID_FLAG) {
+        throw cli_parse_error { "An error occurred while parsing cli options"};
+    }
+
+    config_file_ = HW::GetFlag<std::string>("config-file");
+    if (!config_file_.empty()) {
+        parseConfigFile();
+    }
+
+    validateAndNormalizeConfiguration();
+    initialized_ = true;
+
+    return parse_result;
+}
+
+void Configuration::setStartFunction(std::function<int(std::vector<std::string>)> start_function) {
+    start_function_ = start_function;
+}
+
+void Configuration::validateAndNormalizeConfiguration() {
+    // determine which of your values must be initalised
+    if (HW::GetFlag<std::string>("server").empty()) {
+        throw required_not_set_error { "server value must be defined" };
+    } else if (HW::GetFlag<std::string>("server").find("wss://") != 0) {
+        throw configuration_entry_error { "server value must start with wss://" };
+    }
+
+    if (HW::GetFlag<std::string>("ca").empty()) {
+        throw required_not_set_error { "ca value must be defined" };
+    } else if (!FileUtils::fileExists(HW::GetFlag<std::string>("ca"))) {
+        throw configuration_entry_error { "ca file not found" };
+    }
+
+    if (HW::GetFlag<std::string>("cert").empty()) {
+        throw required_not_set_error { "cert value must be defined" };
+    } else if (!FileUtils::fileExists(HW::GetFlag<std::string>("cert"))) {
+        throw configuration_entry_error { "cert file not found" };
+    }
+
+    if (HW::GetFlag<std::string>("key").empty()) {
+        throw required_not_set_error { "key value must be defined" };
+    } else if (!FileUtils::fileExists(HW::GetFlag<std::string>("key"))) {
+        throw configuration_entry_error { "key file not found" };
+    }
+
+    if (!HW::GetFlag<std::string>("spool-dir").empty()) {
+        std::string spool_dir = FileUtils::shellExpand(HW::GetFlag<std::string>("spool-dir"));
+        if (spool_dir.back() != '/') {
+            HW::SetFlag<std::string>("spool-dir", spool_dir + "/");
+        }
+    }
+}
+
 
 }  // namespace CthunAgent

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -47,14 +47,30 @@ using Base_ptr = std::unique_ptr<EntryBase>;
 
 class Configuration {
   public:
-    // TODO(ale): implement reset method (change singleton structure)
     static Configuration& Instance() {
         static Configuration instance;
         return instance;
     }
 
+    /// Set the configuration entries to their default values.
+    /// Unset the initialized_ flag.
+    void reset();
+
+    /// Parse the command line arguments and, if specified, the
+    /// configuration file in order to obtain the configuration
+    /// values; validate and normalize them.
+    /// Return a numeric code indicating the parsing outcome (refer to
+    /// HorseWhisperer).
+    /// Throw a cli_parse_error in case it fails to parse the CLI
+    /// arguments.
+    /// Throw a required_not_set_error in case of a missing or invalid
+    /// configuration value.
+    /// Throw a configuration_entry_error if the specified config file
+    /// does not exist.
     int initialize(int argc, char *argv[]);
 
+    /// Set the start function that will be executed when calling
+    /// HorseWhisperer::Start().
     void setStartFunction(std::function<int(std::vector<std::string>)> start_function);
 
     // TODO(ale): HW::GetFlag should use boost::optional or make
@@ -103,16 +119,22 @@ class Configuration {
         }
     }
 
-    void validateConfiguration(int parse_result);
+    /// Ensure all required values are valid. If necessary, expand
+    /// file paths to the expected format.
+    /// Throw a required_not_set_error if any required file path is
+    /// missing; a configuration_entry_error in case of invalid values.
+    void validateAndNormalizeConfiguration();
 
   private:
-    bool initialized_ = false;
+    bool initialized_;
     std::map<std::string, Base_ptr> defaults_;
-    std::string config_file_ = "";
+    std::string config_file_;
     std::function<int(std::vector<std::string>)> start_function_;
 
     Configuration();
     void parseConfigFile();
+    void defineDefaultValues();
+    void setDefaultValues();
 };
 
 }  // namespace CthunAgent

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -81,7 +81,7 @@ int main(int argc, char *argv[]) {
 
     try {
         parse_result = Configuration::Instance().initialize(argc, argv);
-    } catch(configuration_error e ) {
+    } catch(configuration_error e) {
         std::cout << "An error occurred while parsing your configuration." << std::endl;
         std::cout << e.what() << std::endl;
         return 1;

--- a/test/unit/configuration_test.cpp
+++ b/test/unit/configuration_test.cpp
@@ -7,7 +7,9 @@
 
 extern std::string ROOT_PATH;
 
-void configure_test() {
+namespace CthunAgent {
+
+void configureTest() {
     std::string server = "wss://test_server/";
     std::string ca = ROOT_PATH + "/test/resources/config/ca_crt.pem";
     std::string cert = ROOT_PATH +  "/test/resources/config/test_crt.pem";
@@ -17,7 +19,11 @@ void configure_test() {
                            "--cert", cert.data(), "--key", key.data() };
     int argc= 9;
 
-    CthunAgent::Configuration::Instance().initialize(argc, const_cast<char**>(argv));
+    Configuration::Instance().initialize(argc, const_cast<char**>(argv));
+}
+
+void resetTest() {
+    Configuration::Instance().reset();
 }
 
 TEST_CASE("Configuration::setStartFunction", "[configuration]") {
@@ -31,32 +37,32 @@ TEST_CASE("Configuration::setStartFunction", "[configuration]") {
     int argc= 9;
     int test_val = 0;
 
-    CthunAgent::Configuration::Instance().setStartFunction([&test_val] (std::vector<std::string> arg) -> int {
+    Configuration::Instance().setStartFunction([&test_val] (std::vector<std::string> arg) -> int {
         return 1;
     });
 
-    CthunAgent::Configuration::Instance().initialize(argc, const_cast<char**>(argv));
+    Configuration::Instance().initialize(argc, const_cast<char**>(argv));
 
     REQUIRE(HorseWhisperer::Start() == 1);
 }
 
 TEST_CASE("Configuration::set", "[configuration]") {
-    configure_test();
+    configureTest();
 
     SECTION("can set a known flag to a valid value") {
-        REQUIRE_NOTHROW(CthunAgent::Configuration::Instance()
+        REQUIRE_NOTHROW(Configuration::Instance()
                             .set<std::string>("ca", "value"));
     }
 
     SECTION("set a flag correctly") {
-        CthunAgent::Configuration::Instance().set<std::string>("ca", "value");
+        Configuration::Instance().set<std::string>("ca", "value");
         REQUIRE(HorseWhisperer::GetFlag<std::string>("ca") == "value");
     }
 
     SECTION("throw when setting an unknown flag") {
-        REQUIRE_THROWS_AS(CthunAgent::Configuration::Instance()
-                            .set<int>("tentacle_spawning_interval_s", 45),
-                          CthunAgent::configuration_entry_error);
+        REQUIRE_THROWS_AS(Configuration::Instance()
+                                .set<int>("tentacle_spawning_interval_s", 45),
+                          configuration_entry_error);
     }
 
     SECTION("throw when setting a known flag to an invalid value") {
@@ -65,70 +71,116 @@ TEST_CASE("Configuration::set", "[configuration]") {
                                               8,
                                               [](int v) -> bool{return v == 8;});
 
-        REQUIRE_THROWS_AS(CthunAgent::Configuration::Instance()
-                            .set<int>("num_tentacles", 42),
-                          CthunAgent::configuration_entry_error);
-        REQUIRE_NOTHROW(CthunAgent::Configuration::Instance()
-                            .set<int>("num_tentacles", 8));
+        // The only valid number of tentacles is 8
+        REQUIRE_THROWS_AS(Configuration::Instance().set<int>("num_tentacles", 42),
+                          configuration_entry_error);
+        REQUIRE_NOTHROW(Configuration::Instance().set<int>("num_tentacles", 8));
     }
+
+    resetTest();
 }
 
 TEST_CASE("Configuration::get", "[configuration]") {
-    // TODO(ale): test Configuration before its initialization (we
-    // would need to add a reset hook to the Configuration singleton)
+    SECTION("Configuration was not initialized yet") {
+        SECTION("can get a defined flag") {
+            REQUIRE_NOTHROW(Configuration::Instance().get<std::string>("ca"));
+        }
 
-    HorseWhisperer::SetFlag<std::string>("ca", "value");
-    REQUIRE(CthunAgent::Configuration::Instance().get<std::string>("ca") == "value");
+        SECTION("return the default value correctly") {
+            REQUIRE(Configuration::Instance().get<std::string>("spool-dir")
+                    == DEFAULT_ACTION_RESULTS_DIR);
+        }
+
+        SECTION("throw a configuration_entry_error if the flag is unknown") {
+            REQUIRE_THROWS_AS(
+                Configuration::Instance().get<std::string>("dont_exist"),
+                configuration_entry_error);
+        }
+    }
+
+    SECTION("Configuration was initialized") {
+        configureTest();
+
+        SECTION("can get a defined flag") {
+            REQUIRE_NOTHROW(Configuration::Instance().get<std::string>("ca"));
+        }
+
+        SECTION("return the default value if the flag was not set") {
+            REQUIRE(Configuration::Instance().get<std::string>("spool-dir")
+                    == DEFAULT_ACTION_RESULTS_DIR);
+        }
+
+        SECTION("return the correct value after the flag has been set") {
+            Configuration::Instance().set<std::string>("spool-dir", "/fake/dir");
+            REQUIRE(Configuration::Instance().get<std::string>("spool-dir")
+                    == "/fake/dir");
+        }
+
+        SECTION("dont throw if the flag is unknown") {
+            REQUIRE_NOTHROW(Configuration::Instance()
+                                .get<std::string>("still_dont_exist"));
+        }
+
+        SECTION("return a default value if the flag is unknown") {
+            REQUIRE(Configuration::Instance().get<std::string>("nada") == "");
+        }
+
+        resetTest();
+    }
 }
 
-TEST_CASE("Configuration::validateConfiguration", "[configuration]") {
-    configure_test();
+TEST_CASE("Configuration::validateAndNormalizeConfiguration", "[configuration]") {
+    configureTest();
 
     SECTION("it fails when server is undefined") {
-        CthunAgent::Configuration::Instance().set<std::string>("server", "");
-        REQUIRE_THROWS_AS(CthunAgent::Configuration::Instance().validateConfiguration(0),
-                          CthunAgent::required_not_set_error);
+        Configuration::Instance().set<std::string>("server", "");
+        REQUIRE_THROWS_AS(Configuration::Instance().validateAndNormalizeConfiguration(),
+                          required_not_set_error);
     }
 
     SECTION("it fails when server is invlaid") {
-        CthunAgent::Configuration::Instance().set<std::string>("server", "ws://");
-        REQUIRE_THROWS_AS(CthunAgent::Configuration::Instance().validateConfiguration(0),
-                          CthunAgent::required_not_set_error);
+        Configuration::Instance().set<std::string>("server", "ws://");
+        REQUIRE_THROWS_AS(Configuration::Instance().validateAndNormalizeConfiguration(),
+                          configuration_entry_error);
     }
 
     SECTION("it fails when ca is undefined") {
-        CthunAgent::Configuration::Instance().set<std::string>("ca", "");
-        REQUIRE_THROWS_AS(CthunAgent::Configuration::Instance().validateConfiguration(0),
-                          CthunAgent::required_not_set_error);
+        Configuration::Instance().set<std::string>("ca", "");
+        REQUIRE_THROWS_AS(Configuration::Instance().validateAndNormalizeConfiguration(),
+                          required_not_set_error);
     }
 
     SECTION("it fails when ca file cannot be found") {
-        CthunAgent::Configuration::Instance().set<std::string>("ca", "/fake/file");
-        REQUIRE_THROWS_AS(CthunAgent::Configuration::Instance().validateConfiguration(0),
-                          CthunAgent::required_not_set_error);
+        Configuration::Instance().set<std::string>("ca", "/fake/file");
+        REQUIRE_THROWS_AS(Configuration::Instance().validateAndNormalizeConfiguration(),
+                          configuration_entry_error);
     }
 
     SECTION("it fails when cert is undefined") {
-        CthunAgent::Configuration::Instance().set<std::string>("cert", "");
-        REQUIRE_THROWS_AS(CthunAgent::Configuration::Instance().validateConfiguration(0),
-                          CthunAgent::required_not_set_error);
+        Configuration::Instance().set<std::string>("cert", "");
+        REQUIRE_THROWS_AS(Configuration::Instance().validateAndNormalizeConfiguration(),
+                          required_not_set_error);
     }
 
     SECTION("it fails when cert file cannot be found") {
-        CthunAgent::Configuration::Instance().set<std::string>("cert", "/fake/file");
-        REQUIRE_THROWS_AS(CthunAgent::Configuration::Instance().validateConfiguration(0),
-                          CthunAgent::required_not_set_error);
+        Configuration::Instance().set<std::string>("cert", "/fake/file");
+        REQUIRE_THROWS_AS(Configuration::Instance().validateAndNormalizeConfiguration(),
+                          configuration_entry_error);
     }
 
     SECTION("it fails when key is undefined") {
-        CthunAgent::Configuration::Instance().set<std::string>("key", "");
-        REQUIRE_THROWS_AS(CthunAgent::Configuration::Instance().validateConfiguration(0),
-                          CthunAgent::required_not_set_error);
+        Configuration::Instance().set<std::string>("key", "");
+        REQUIRE_THROWS_AS(Configuration::Instance().validateAndNormalizeConfiguration(),
+                          required_not_set_error);
     }
 
     SECTION("it fails when key file cannot be found") {
-        CthunAgent::Configuration::Instance().set<std::string>("key", "/fake/file");
-        REQUIRE_THROWS_AS(CthunAgent::Configuration::Instance().validateConfiguration(0),
-                          CthunAgent::required_not_set_error);
+        Configuration::Instance().set<std::string>("key", "/fake/file");
+        REQUIRE_THROWS_AS(Configuration::Instance().validateAndNormalizeConfiguration(),
+                          configuration_entry_error);
     }
+
+    resetTest();
 }
+
+}  // namespace CthunAgent


### PR DESCRIPTION
Add reset method. Refactor logic to define and set default values. Fix
spool-dir normalization. Add unit tests for get method.

Raising a configuration_entry_error in case of invalid values.

Rasising a specific error message in case the user provides a non
existent config file from CLI.
