### PR TITLE
(maint) Move the identity member to the Agent class

### DIFF
--- a/src/agent.h
+++ b/src/agent.h
@@ -6,6 +6,9 @@
 #include "src/data_container.h"
 #include "src/websocket/endpoint.h"
 
+#include <boost/filesystem/operations.hpp>
+#include <boost/filesystem/path.hpp>
+
 #include <map>
 #include <memory>
 #include <string>
@@ -14,47 +17,69 @@ namespace CthunAgent {
 
 class Agent {
   public:
-    explicit Agent(std::string bin_path);
+    Agent() = delete;
+
+    // Throw a fatal_error in case it fails to open the client
+    // certificate file to load its identity.
+    Agent(std::string bin_path,
+          std::string ca_crt_path,
+          std::string client_crt_path,
+          std::string client_key_path);
+
     ~Agent();
 
     // Daemon entry point.
-    void startAgent(std::string url,
-                    std::string ca_crt_path,
-                    std::string client_crt_path,
-                    std::string client_key_path);
+    void startAgent(std::string server_url);
+
+    // Identity getter.
+    std::string getIdentity() const;
 
   private:
+    // Certificate paths.
+    std::string ca_crt_path_;
+    std::string client_crt_path_;
+    std::string client_key_path_;
+
+    // Cthun agent identity, as in the cert.
+    std::string identity_;
+
+    // Modules
     std::map<std::string, std::shared_ptr<Module>> modules_;
+
+    // Pointer to the ransport layer endpoint instance.
     std::unique_ptr<WebSocket::Endpoint> ws_endpoint_ptr_;
 
+    // Load the external modules contained in the specified directory.
+    void loadExternalModules_(boost::filesystem::path modules_dir_path);
+
     // Log the loaded modules.
-    void listModules();
+    void listModules_() const;
 
     // Set the event callbacks for the connection.
-    void setConnectionCallbacks();
+    void setConnectionCallbacks_();
 
     // Callback for the transport layer triggered when  connection .
     // Send a login message.
-    void sendLogin();
+    void sendLogin_();
 
     // Add the common envelope entries to the specified container.
-    void addCommonEnvelopeEntries(DataContainer& envelope_entries);
+    void addCommonEnvelopeEntries_(DataContainer& envelope_entries);
 
     // Send a response message with specified request ID and output
     // to the receiver endpoint.
-    void sendResponse(std::string receiver_endpoint,
-                      std::string request_id,
-                      DataContainer output,
-                      std::vector<MessageChunk> debug_chunks);
+    void sendResponse_(std::string receiver_endpoint,
+                       std::string request_id,
+                       DataContainer output,
+                       std::vector<MessageChunk> debug_chunks);
 
     // Callback for the transport layer to handle incoming messages.
     // Parse and validate the passed message; reply to the sender
     // with the requested output.
-    void processMessageAndSendResponse(std::string message_txt);
+    void processMessageAndSendResponse_(std::string message_txt);
 
     // Periodically check the connection state; reconnect the agent
     // in case the connection is not open
-    void monitorConnectionState();
+    void monitorConnectionState_();
 };
 
 }  // namespace CthunAgent

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -43,12 +43,12 @@ int startAgent(std::vector<std::string> arguments   ) {
     }
 
     try {
-        Agent agent { HW::GetFlag<std::string>("module-dir") };
+        Agent agent { HW::GetFlag<std::string>("module-dir"),
+                      FileUtils::shellExpand(HW::GetFlag<std::string>("ca")),
+                      FileUtils::shellExpand(HW::GetFlag<std::string>("cert")),
+                      FileUtils::shellExpand(HW::GetFlag<std::string>("key")) };
 
-        agent.startAgent(HW::GetFlag<std::string>("server"),
-                         FileUtils::shellExpand(HW::GetFlag<std::string>("ca")),
-                         FileUtils::shellExpand(HW::GetFlag<std::string>("cert")),
-                         FileUtils::shellExpand(HW::GetFlag<std::string>("key")));
+        agent.startAgent(HW::GetFlag<std::string>("server"));
     } catch (fatal_error& e) {
         LOG_ERROR("fatal error: %1%", e.what());
         return 1;
@@ -82,7 +82,7 @@ int main(int argc, char *argv[]) {
     try {
         parse_result = Configuration::Instance().initialize(argc, argv);
     } catch(configuration_error e) {
-        std::cout << "An error occurred while parsing your configuration." << std::endl;
+        std::cout << "An error occurred while parsing your configuration.\n";
         std::cout << e.what() << std::endl;
         return 1;
     }
@@ -98,8 +98,8 @@ int main(int argc, char *argv[]) {
             return 0;
         default:
             std::cout << "An unexpected code was returned when trying to parse"
-                      << "command line arguments - " << parse_result << ". Aborting"
-                      << std::endl;
+                      << "command line arguments - " << parse_result
+                      << ". Aborting" << std::endl;
             return 1;
     }
 }

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -190,7 +190,7 @@ ParsedContent Message::getParsedContent() const {
     DataContainer data_content {};
     if (hasData()) {
         auto schema = envelope_content.get<std::string>("data_schema");
-        // assert(SchemaFormat.find(schema) != SchemaFormat.end());
+        assert(SchemaFormat.find(schema) != SchemaFormat.end());
         data_content = DataParser::parseAndValidateChunk(data_chunk_,
                                                          SchemaFormat[schema]);
     }

--- a/src/websocket/endpoint.h
+++ b/src/websocket/endpoint.h
@@ -112,11 +112,6 @@ class Endpoint {
     void close(Close_Code code = Close_Code_Values::normal,
                const std::string& reason = DEFAULT_CLOSE_REASON);
 
-    // TODO(ale): move this to the Agent
-
-    /// Returns the agent identity
-    std::string identity();
-
   private:
     // Cthun server url
     std::string server_url_;
@@ -125,8 +120,6 @@ class Endpoint {
     std::string ca_crt_path_;
     std::string client_crt_path_;
     std::string client_key_path_;
-
-    std::string identity_ { "unknown" };
 
     // Transport layer connection handle
     Connection_Handle connection_handle_;

--- a/test/unit/agent_test.cpp
+++ b/test/unit/agent_test.cpp
@@ -8,36 +8,57 @@ extern std::string ROOT_PATH;
 
 namespace CthunAgent {
 
+const std::string TEST_AGENT_IDENTITY { "cth://cthun-client/cthun-agent" };
+
+std::string getCa() {
+    static const std::string ca {
+        ROOT_PATH + "/test-resources/ssl/ca/ca_crt.pem" };
+    return ca;
+}
+
+std::string getCert() {
+    static const std::string cert {
+        ROOT_PATH + "/test-resources/ssl/certs/cthun-client.pem" };
+    return cert;
+}
+
+std::string getKey() {
+    static const std::string key {
+        ROOT_PATH + "/test-resources/ssl/private_keys/cthun-client.pem" };
+    return key;
+}
+
+std::string getBin() {
+    static const std::string bin {
+        ROOT_PATH + "/bin" };
+    return bin;
+}
+
 TEST_CASE("Agent::Agent", "[agent]") {
-    SECTION("it should not throw if it fails to find the modules directory") {
-        REQUIRE_NOTHROW(Agent agent { ROOT_PATH + "/bin/fake_dir" });
+    SECTION("does not throw if it fails to find the modules directory") {
+        REQUIRE_NOTHROW(Agent(getBin() + "/fake_dir", getCa(), getCert(),
+                              getKey()));
     }
 
-    SECTION("it should correctly instantiate") {
-        REQUIRE_NOTHROW(Agent agent { ROOT_PATH + "/bin" });
+    SECTION("should throw a fatal_error if client cert path is invalid") {
+        REQUIRE_THROWS_AS(Agent(getBin(), getCa(), "spam", getKey()),
+                          fatal_error);
+    }
+
+    SECTION("successfully instantiates with valid arguments") {
+        REQUIRE_NOTHROW(Agent(getBin(), getCa(), getCert(), getKey()));
+    }
+
+    SECTION("retrieves the identity from the client certificate") {
+        Agent agent { getBin(), getCa(), getCert(), getKey() };
+        REQUIRE(agent.getIdentity() == TEST_AGENT_IDENTITY);
     }
 }
 
-static const std::string DEFAULT_SERVER_URL { "wss://127.0.0.1:8090/cthun/" };
-static std::string DEFAULT_CA { ROOT_PATH + "/test-resources/ssl/ca/ca_crt.pem" };
-static std::string DEFAULT_CERT {
-    ROOT_PATH + "/test-resources/ssl/certs/cthun-client.pem" };
-static std::string DEFAULT_KEY {
-    ROOT_PATH + "/test-resources/ssl/private_keys/cthun-client.pem" };
-
 TEST_CASE("Agent::startAgent", "[agent]") {
-    Agent agent { ROOT_PATH + "/bin" };
-
-    SECTION("should throw a fatal_error if client cert is invalid") {
-        REQUIRE_THROWS_AS(agent.startAgent(DEFAULT_SERVER_URL, DEFAULT_CA,
-                                           "spam", DEFAULT_KEY),
-                          fatal_error);
-    }
-
     SECTION("should throw a fatal_error if the server url is invalid") {
-        REQUIRE_THROWS_AS(agent.startAgent("foo", DEFAULT_CA, DEFAULT_CERT,
-                                           DEFAULT_KEY),
-                          fatal_error);
+        Agent agent { getBin(), getCa(), getCert(), getKey() };
+        REQUIRE_THROWS_AS(agent.startAgent("foo"), fatal_error);
     }
 }
 


### PR DESCRIPTION
Moving the logic to retrieve the Cthun Agent identity from endpoint.cpp
to agent.cpp. Changing the Agent ctor. Other trivial changes.

Enabling assertion in message.cpp.

Using final underscores for the names of private methods in Agent.

Factoring out the logic to retrieve external modules from the Agent
ctor.

Adding unit tests for the Agent identity.
