### PR TITLE
DO NOT MERGE (maint) update API to be compatible with facter 3.0.0

### DIFF
--- a/lib/src/modules/inventory.cc
+++ b/lib/src/modules/inventory.cc
@@ -29,7 +29,7 @@ ActionOutcome Inventory::callAction(const ActionRequest& request) {
     CthunClient::DataContainer results {};
 
     facter::facts::collection facts;
-    facts.add_default_facts();
+    facts.add_default_facts(false);
     facts.write(fact_stream, facter::facts::format::json);
 
     LOG_TRACE("facts: %1%", fact_stream.str());


### PR DESCRIPTION
This will be needed to use facter 3.0.0 as the add_default_facts method gained a boolean parameter.  We should not merge this without also specifying we need facter >= 3.0.0 in the Findfacter
