### PR TITLE
(maint) remove not-quite-used test.hpp

### DIFF
--- a/lib/tests/main.cc
+++ b/lib/tests/main.cc
@@ -2,7 +2,6 @@
 // for providing our own main function to Catch
 #define CATCH_CONFIG_RUNNER
 
-#include "test.hpp"
 #include <catch.hpp>
 
 #include <boost/filesystem/operations.hpp>

--- a/lib/tests/test.hpp
+++ b/lib/tests/test.hpp
@@ -1,8 +1,0 @@
-#include <string>
-
-#ifndef TEST_TEST_H_
-#define TEST_TEST_H_
-
-extern std::string ROOT_PATH;
-
-#endif  // TEST_TEST_H_

--- a/lib/tests/unit/agent_test.cc
+++ b/lib/tests/unit/agent_test.cc
@@ -1,4 +1,3 @@
-#include "test/test.hpp"
 #include <catch.hpp>
 
 #include <cthun-agent/agent.hpp>

--- a/lib/tests/unit/configuration_test.cc
+++ b/lib/tests/unit/configuration_test.cc
@@ -1,4 +1,3 @@
-#include "test/test.hpp"
 #include <catch.hpp>
 
 #include <cthun-agent/configuration.hpp>

--- a/lib/tests/unit/external_module_test.cc
+++ b/lib/tests/unit/external_module_test.cc
@@ -1,4 +1,3 @@
-#include "test/test.hpp"
 #include <catch.hpp>
 
 #include <cthun-agent/errors.hpp>

--- a/lib/tests/unit/file_utils_test.cc
+++ b/lib/tests/unit/file_utils_test.cc
@@ -1,4 +1,3 @@
-#include "test/test.hpp"
 #include <catch.hpp>
 
 #include <cthun-agent/file_utils.hpp>

--- a/lib/tests/unit/module_test.cc
+++ b/lib/tests/unit/module_test.cc
@@ -1,4 +1,3 @@
-#include "test/test.hpp"
 #include <catch.hpp>
 
 #include <cthun-agent/errors.hpp>

--- a/lib/tests/unit/modules/inventory_test.cc
+++ b/lib/tests/unit/modules/inventory_test.cc
@@ -1,5 +1,3 @@
-#include "test/test.hpp"
-
 #include <catch.hpp>
 
 #include <cthun-agent/modules/inventory.hpp>

--- a/lib/tests/unit/modules/ping_test.cc
+++ b/lib/tests/unit/modules/ping_test.cc
@@ -1,4 +1,3 @@
-#include "test/test.hpp"
 #include <catch.hpp>
 
 #include <cthun-agent/modules/ping.hpp>

--- a/lib/tests/unit/modules/status_test.cc
+++ b/lib/tests/unit/modules/status_test.cc
@@ -1,7 +1,5 @@
 #include <cstdio>
 
-#include "test/test.hpp"
-
 #include <catch.hpp>
 
 #include <cthun-agent/errors.hpp>

--- a/lib/tests/unit/thread_container_test.cc
+++ b/lib/tests/unit/thread_container_test.cc
@@ -1,4 +1,3 @@
-#include "test/test.hpp"
 #include <catch.hpp>
 
 #include <cthun-agent/thread_container.hpp>


### PR DESCRIPTION
Over mutations, test.h -> tests/test.hpp but we were including using
test/test.hpp which must have been resolved via one of the leatherman
submodule headers as we still have these test/test.hpp files:

```
$ find . | grep test/test.hpp
./vendor/cthun-client/vendor/leatherman/vendor/boost-nowide/libs/nowide/test/test.hpp
./vendor/cthun-client/vendor/leatherman/vendor/boost-nowide/test/test.hpp
./vendor/leatherman/vendor/boost-nowide/libs/nowide/test/test.hpp
./vendor/leatherman/vendor/boost-nowide/test/test.hpp
```
