### PR TITLE
(maint) facter API changed between 0.x and 3.0

### DIFF
--- a/lib/src/modules/inventory.cc
+++ b/lib/src/modules/inventory.cc
@@ -1,6 +1,7 @@
 #include <cthun-agent/modules/inventory.hpp>
 #include <cthun-agent/errors.hpp>
 
+#include <facter/version.h>
 #include <facter/facts/collection.hpp>
 
 #include <sstream>
@@ -29,7 +30,11 @@ ActionOutcome Inventory::callAction(const ActionRequest& request) {
     LTH_JC::JsonContainer results {};
 
     facter::facts::collection facts;
+#if LIBFACTER_VERSION_MAJOR >= 3
+    facts.add_default_facts(false);
+#else
     facts.add_default_facts();
+#endif
     facts.write(fact_stream, facter::facts::format::json);
 
     LOG_TRACE("facts: %1%", fact_stream.str());


### PR DESCRIPTION
The facter api changed a little since the inventory module was written.

The change was made with
https://github.com/puppetlabs/facter/commit/d0100a47c4099b35195f9d91b190f542087ee863
so the closest version we can pin on is 3.0.0
