### PR TITLE
CTH-242 allow cthun-client to be already installed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,14 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(cthun-agent)
 
+if (NOT CMAKE_BUILD_TYPE)
+    message(STATUS "Defaulting to a release build.")
+    set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel." FORCE)
+endif()
+
+# define further options
+option(EXTERNAL_CTHUN_CLIENT "ON - use an installed version of cthun-client. OFF - use the git submodule" ON)
+
 # Project Output Paths
 
 set(MAINFOLDER ${PROJECT_SOURCE_DIR})
@@ -9,6 +17,8 @@ set(LIBRARY_OUTPUT_PATH "${MAINFOLDER}/bin")
 set(EXECUTABLE_OUTPUT_PATH "${MAINFOLDER}/bin")
 set(VENDOR_DIRECTORY "${PROJECT_SOURCE_DIR}/vendor")
 list(APPEND CMAKE_MODULE_PATH ${VENDOR_DIRECTORY})
+
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
 # set a version
 set(APPLICATION_VERSION_STRING "0.0.1")
@@ -62,7 +72,12 @@ find_package(facter REQUIRED)
 include(${VENDOR_DIRECTORY}/boost-process.cmake)
 include(${VENDOR_DIRECTORY}/horsewhisperer.cmake)
 include(${VENDOR_DIRECTORY}/inih.cmake)
-include(${VENDOR_DIRECTORY}/cthun-client.cmake)
+
+if(EXTERNAL_CTHUN_CLIENT)
+    find_package(cthun-client REQUIRED)
+else()
+    include(${VENDOR_DIRECTORY}/cthun-client.cmake)
+endif()
 
 # Add the main binary
 

--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,9 @@ all: ./build/Makefile
 	@ $(MAKE) -C build
 	@ $(MAKE) test ARGS="-V"
 
-build:
-	@ mkdir build
-
-./build/Makefile: build
-	@ (cd build >/dev/null 2>&1 && cmake ..)
+./build/Makefile: Makefile CMakeLists.txt exe/CMakeLists.txt lib/CMakeLists.txt lib/tests/CMakeLists.txt
+	@ mkdir build || true
+	@ (cd build >/dev/null 2>&1 && cmake -DCMAKE_BUILD_TYPE=Debug -DEXTERNAL_CTHUN_CLIENT=OFF ..)
 
 distclean:
 	@- (cd build >/dev/null 2>&1 && cmake .. >/dev/null 2>&1)

--- a/cmake/Findcthun-client.cmake
+++ b/cmake/Findcthun-client.cmake
@@ -1,0 +1,11 @@
+find_library(cthun-client_LIBRARY
+             NAMES cthun-client)
+
+include(FindDependency)
+find_dependency(cthun-client 
+    DISPLAY "cthun-client"
+    HEADERS "cthun-client/connector/connection.hpp"
+    LIBRARY "cthun-client")
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(cthun-client DEFAULT_MSG cthun-client_LIBRARY cthun-client_INCLUDE_DIR)

--- a/exe/CMakeLists.txt
+++ b/exe/CMakeLists.txt
@@ -10,16 +10,11 @@ include_directories(
     ${Boost_INCLUDE_DIRS}
     ${HORSEWHISPERER_INCLUDE_DIRS}
     ${INIH_INCLUDE_DIRS}
-    ${CTHUN_CLIENT_INCLUDE_DIRS}
+    ${cthun-client_INCLUDE_DIR}
 )
 
 set (CTHUN-AGENT_BIN_LIBS
-    ${Boost_LIBRARIES}
-    ${OPENSSL_SSL_LIBRARY}
-    ${OPENSSL_CRYPTO_LIBRARY}
-    ${PTHREADS}
-    ${facter_LIBRARY}
-    ${CTHUN_CLIENT_LIB}
+    ${CMAKE_THREAD_LIBS_INIT}
     libcthun-agent
 )
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -8,7 +8,7 @@ include_directories(
     SYSTEM ${Boost_Process_INCLUDE_DIRS}
     SYSTEM ${HORSEWHISPERER_INCLUDE_DIRS}
     SYSTEM ${INIH_INCLUDE_DIRS}
-    SYSTEM ${CTHUN_CLIENT_INCLUDE_DIRS}
+    SYSTEM ${cthun-client_INCLUDE_DIR}
     SYSTEM ${LEATHERMAN_INCLUDE_DIRS}
     SYSTEM ${facter_INCLUDE_DIR}
 )
@@ -47,7 +47,7 @@ SET(LIBS
     ${OPENSSL_CRYPTO_LIBRARY}
     ${PTHREADS}
     ${facter_LIBRARY}
-    ${CTHUN_CLIENT_LIB}
+    ${cthun-client_LIBRARY}
 )
 
 add_library(libcthun-agent ${LIBRARY_SOURCES})

--- a/vendor/cthun-client.cmake
+++ b/vendor/cthun-client.cmake
@@ -12,5 +12,5 @@ externalproject_add(
     INSTALL_COMMAND ""
 )
 externalproject_get_property(cthun-client SOURCE_DIR)
-set(CTHUN_CLIENT_INCLUDE_DIRS "${SOURCE_DIR}/lib/inc")
-set(CTHUN_CLIENT_LIB "${SOURCE_DIR}/build/lib/libcthun-client.so")
+set(cthun-client_INCLUDE_DIR "${SOURCE_DIR}/lib/inc")
+set(cthun-client_LIBRARY "${SOURCE_DIR}/build/lib/libcthun-client.so")


### PR DESCRIPTION
Our use of cthun-client via an ExternalProject, though convenient,
causes issues when building in a more restricted environment as
provided when doing a cthun-agent-vanagon build via the vmpooler.
The -DCMAKE_TOOLCHAIN_FILE and additional configuration parameters
are not passed to the sub-cmake that the ExternalProject invokes,
so the build of cthun-client can fail to find build dependencies
like the C++ compiler.

Here we allow for the cthun-client library and headers to be already
installed and findable via `find_package(cthun-client REQUIRED)`
when -DEXTERNAL_CTHUN_CLIENT=ON is specified (the default), and
update the existing vendor/cthun-client.cmake to advance the same
`cthun-client_LIBRARY` and `cthun-client_INCLUDE_DIR` symbols that
the new cmake/Findcthun-client.cmake does.

Also we change the default build to be a Release build, but keep
the developer Makefile using a Debug build with the submodule version
of cthun-client.
