### PR TITLE
(maint) Fix symlink creation in status unit test

### DIFF
--- a/lib/tests/unit/modules/status_test.cc
+++ b/lib/tests/unit/modules/status_test.cc
@@ -85,6 +85,11 @@ TEST_CASE("Modules::Status::executeAction", "[modules]") {
                                   + "/lib/tests/resources/delayed_result" };
         boost::filesystem::path to { result_path };
 
+        if (!FileUtils::fileExists(DEFAULT_ACTION_RESULTS_DIR)
+            && !FileUtils::createDirectory(DEFAULT_ACTION_RESULTS_DIR)) {
+            FAIL("Failed to create the results directory");
+        }
+
         auto symlink_name = UUID::getUUID();
         std::string symlink_path { DEFAULT_ACTION_RESULTS_DIR + symlink_name };
         boost::filesystem::path symlink { symlink_path };


### PR DESCRIPTION
We now create the results directory for storing the outcome of
non-blocking actions only if necessary; that was causing a failure for a
status test that was assuming the existence of such directory. The fix
consists in creating the directory if necessary.
