### PR TITLE
(CTH-240) Make modules configurable

### DIFF
--- a/exe/main.cc
+++ b/exe/main.cc
@@ -74,6 +74,12 @@ int main(int argc, char *argv[]) {
     HW::ParseResult parse_result;
     std::string err_msg {};
 
+    // Enable logging to stdout at info so that our config class can log
+    // if it needs to. This way we can make it very clear if something odd
+    // happens during startup.
+    leatherman::logging::setup_logging(std::cout);
+    leatherman::logging::set_level(leatherman::logging::log_level::info);
+
     try {
         parse_result = Configuration::Instance().initialize(argc, argv);
     } catch (HW::horsewhisperer_error& e) {

--- a/lib/inc/cthun-agent/action_request.hpp
+++ b/lib/inc/cthun-agent/action_request.hpp
@@ -39,6 +39,8 @@ class ActionRequest {
 
     // The following accessors perform lazy initialization
     const lth_jc::JsonContainer& params() const;
+    const lth_jc::JsonContainer& config() const;
+    const std::string& requestTxt() const;
     const std::string& paramsTxt() const;
 
   private:
@@ -53,6 +55,8 @@ class ActionRequest {
 
     // Lazy initialized
     mutable lth_jc::JsonContainer params_;
+    mutable lth_jc::JsonContainer config_;
+    mutable std::string request_txt_;
     mutable std::string params_txt_;
 
     void init();

--- a/lib/inc/cthun-agent/configuration.hpp
+++ b/lib/inc/cthun-agent/configuration.hpp
@@ -5,12 +5,14 @@
 
 #include <horsewhisperer/horsewhisperer.h>
 #include <INIReader.h>
+#include <leatherman/json_container/json_container.hpp>
 
 #include <map>
 
 namespace CthunAgent {
 
 namespace HW = HorseWhisperer;
+namespace lth_jc = leatherman::json_container;
 
 static const std::string DEFAULT_ACTION_RESULTS_DIR = "/tmp/cthun-agent/";
 
@@ -129,11 +131,18 @@ class Configuration {
     /// missing; a configuration_entry_error in case of invalid values.
     void validateAndNormalizeConfiguration();
 
+    /// Load and store all configuration options for individual modules
+    void loadModuleConfiguration();
+
+    /// Retrieve module specific config options
+    const lth_jc::JsonContainer& getModuleConfig(const std::string& module);
+
   private:
     bool initialized_;
     std::map<std::string, Base_ptr> defaults_;
     std::string config_file_;
     std::function<int(std::vector<std::string>)> start_function_;
+    std::map<std::string, lth_jc::JsonContainer> module_config_;
 
     Configuration();
     void parseConfigFile();

--- a/lib/src/action_request.cc
+++ b/lib/src/action_request.cc
@@ -1,5 +1,6 @@
 #include <cthun-agent/action_request.hpp>
 #include <cthun-agent/errors.hpp>
+#include <cthun-agent/configuration.hpp>
 
 #define LEATHERMAN_LOGGING_NAMESPACE "puppetlabs.cthun_agent.action_request"
 #include <leatherman/logging/logging.hpp>
@@ -14,6 +15,8 @@ ActionRequest::ActionRequest(RequestType type,
           notify_outcome_ { true },
           parsed_chunks_ { parsed_chunks },
           params_ { "{}" },
+          config_ { "{}" },
+          request_txt_ { "" },
           params_txt_ { "" } {
     init();
 }
@@ -24,6 +27,8 @@ ActionRequest::ActionRequest(RequestType type,
           notify_outcome_ { true },
           parsed_chunks_ { parsed_chunks },
           params_ { "{}" },
+          config_ { "{}" },
+          request_txt_ { "" },
           params_txt_ { "" } {
     init();
 }
@@ -47,11 +52,28 @@ const lth_jc::JsonContainer& ActionRequest::params() const {
     return params_;
 }
 
+const lth_jc::JsonContainer& ActionRequest::config() const {
+    if (config_.empty()) {
+        config_ = Configuration::Instance().getModuleConfig(module_);
+    }
+    return config_;
+}
+
 const std::string& ActionRequest::paramsTxt() const {
     if (params_txt_.empty()) {
         params_txt_ = params().toString();
     }
     return params_txt_;
+}
+
+const std::string& ActionRequest::requestTxt() const {
+    if (request_txt_.empty()) {
+        lth_jc::JsonContainer tmp {};
+        tmp.set<lth_jc::JsonContainer>("params", params());
+        tmp.set<lth_jc::JsonContainer>("config", config());
+        request_txt_ = tmp.toString();
+    }
+    return request_txt_;
 }
 
 // Private interface

--- a/lib/src/external_module.cc
+++ b/lib/src/external_module.cc
@@ -1,8 +1,6 @@
 #include <cthun-agent/external_module.hpp>
 #include <cthun-agent/errors.hpp>
 
-#include <leatherman/file_util/file.hpp>
-
 #define LEATHERMAN_LOGGING_NAMESPACE "puppetlabs.cthun_agent.external_module"
 #include <leatherman/logging/logging.hpp>
 
@@ -166,9 +164,10 @@ ActionOutcome ExternalModule::callAction(const ActionRequest& request) {
     auto& action_name = request.action();
 
     LOG_INFO("About to execute '%1% %2%' - request input: %3%",
-             module_name, action_name, request.paramsTxt());
+             module_name, action_name, request.requestTxt());
 
-    runCommand(path_, { path_, action_name }, request.paramsTxt(), stdout, stderr);
+    runCommand(path_, { path_, action_name }, request.requestTxt(),
+               stdout, stderr);
 
     if (stdout.empty()) {
         LOG_DEBUG("'%1% %2%' produced no output", module_name, action_name);

--- a/modules/reverse
+++ b/modules/reverse
@@ -57,13 +57,13 @@ def action_metadata
 end
 
 def action_string
-  params = JSON.load($stdin)
+  params = JSON.load($stdin)["params"]
   output = { :output => params['argument'].reverse }
   puts output.to_json
 end
 
 def action_hash
-  hash = JSON.load($stdin)
+  hash = JSON.load($stdin)["params"]
   hash['output'] = hash['input'].reverse
   puts hash.to_json
 end


### PR DESCRIPTION
Here we add the cli flag --modules-config-dir which specifies a location
for a collection of .cfg files, named after a module, which can be used
to configure.

Each file in the config dir will be read as a JsonContainer and stored
in the config singleton. The config dir will default to
/etc/puppetlabs/cthun-agent/modules.d as recommended by UX. 

Here we also configure leatherman::logging to start up pointing at cout
and at info level. This allows us to warn about badly configured
module-conf-dirs at startup which is useful for now. We will have to
change this as we become closer to running as a service. I suspect there
are going to be a lot of changes to the Configuration class in the 
future so we need to keep a close eye on this.
