### PR TITLE
Update PXP readme example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ single JSON object. Example:
 
 ```
 {
-    "server" : "wss://127.0.0.1:8090/pxp/",
-    "ca" : "/Users/psy/work/pxp-agent/test-resources/ssl/ca/ca_crt.pem",
-    "cert" : "/Users/psy/work/pxp-agent/test-resources/ssl/certs/0005_agent_crt.pem",
-    "key" : "/Users/psy/work/pxp-agent/test-resources/ssl/certs/0005_agent_key.pem"
+    "server" : "wss://127.0.0.1:8090/pcp/",
+    "key" : "/etc/puppetlabs/puppet/ssl/private_keys/myhost.net.pem",
+    "ca" : "/etc/puppetlabs/puppet/ssl/certs/ca.pem",
+    "cert" : "/etc/puppetlabs/puppet/ssl/certs/myhost.net.pem"
 }
 ```
 


### PR DESCRIPTION
Prior to this commit, the pxp readme said to connect to the pcp-broker
with the ending url pxp, however the example config files in pxp-broker
define the url entrypoint with pcp. To avoid confusion, this commit
updates that by changing the example config to have the server url end
in pcp.

It also updates the example cert files to match what you would expect to
find after installing puppet-agent on a system.
