### PR TITLE
(maint) Disable detailed exitcodes

### DIFF
--- a/modules/puppet
+++ b/modules/puppet
@@ -42,7 +42,7 @@ def make_command_string(config, params)
     dev_null = "nul"
   end
 
-  return "#{env} #{config["puppet_bin"]} agent -t #{flags} > #{dev_null} 2>&1".lstrip
+  return "#{env} #{config["puppet_bin"]} agent --no-usecacheonfailure --no-splay --show_diff --no-daemonize --onetime --verbose #{flags} > #{dev_null} 2>&1".lstrip
 end
 
 def get_result_from_report(exitcode, config, error = "")

--- a/modules/spec/unit/modules/puppet_spec.rb
+++ b/modules/spec/unit/modules/puppet_spec.rb
@@ -45,14 +45,14 @@ describe "pxp-module-puppet" do
       params = default_params
       params["env"] = ["FOO=bar", "BAR=foo"]
       expect(make_command_string(default_config, params)).to be ==
-        "FOO=bar BAR=foo puppet agent -t  > /dev/null 2>&1"
+        "FOO=bar BAR=foo puppet agent --no-usecacheonfailure --no-splay --show_diff --no-daemonize --onetime --verbose  > /dev/null 2>&1"
     end
 
     it "should correctly append any flags" do
       params = default_params
       params["flags"] = ["--noop", "--foo=bar"]
       expect(make_command_string(default_config, params)).to be ==
-        "puppet agent -t --noop --foo=bar > /dev/null 2>&1"
+        "puppet agent --no-usecacheonfailure --no-splay --show_diff --no-daemonize --onetime --verbose --noop --foo=bar > /dev/null 2>&1"
     end
 
     it "should correctly join both flags and env variables" do
@@ -61,13 +61,13 @@ describe "pxp-module-puppet" do
       params["flags"] = ["--noop", "--foo=bar"]
 
       expect(make_command_string(default_config, params)).to be ==
-        "FOO=bar BAR=foo puppet agent -t --noop --foo=bar > /dev/null 2>&1"
+        "FOO=bar BAR=foo puppet agent --no-usecacheonfailure --no-splay --show_diff --no-daemonize --onetime --verbose --noop --foo=bar > /dev/null 2>&1"
     end
 
     it "uses the correct 'dev/null' on Windows" do
       allow_any_instance_of(Object).to receive(:is_win?).and_return("true")
       expect(make_command_string(default_config, default_params)).to be ==
-        "puppet agent -t  > nul 2>&1"
+        "puppet agent --no-usecacheonfailure --no-splay --show_diff --no-daemonize --onetime --verbose  > nul 2>&1"
     end
   end
 


### PR DESCRIPTION
This replaces -t (--test) with its implied command line flags except for
--detailed-exitcodes (also without --ignorecache which does literally
nothing). This is because, with detailed exitcodes enabled, puppet
doesn't distinguish between a failure to execute a puppet run and
resource failures during the run. Also, puppet exits 2 with detailed
exitcodes if there are resource changes, which was previously being
dealt with as a failure case.

With detailed exitcodes disabled, we can rely on the fact that an exit
code of 1 means that the puppet run failed to execute, while an exit
code of 0 means we should expect a report to be available that will
allow us to determine whether everything that happened _during_ the run
was successful.
