### PR TITLE
(maint) Fix running of ssh-agent for acceptance tests

### DIFF
--- a/acceptance/Rakefile
+++ b/acceptance/Rakefile
@@ -2,7 +2,14 @@ namespace :ci do
 
   namespace :test do
     task :packages do
-      `eval "$(ssh-agent -t 24h -s)"`
+      # Start ssh-agent, parse the env variables from its output and add them to ENV
+      # The usual `eval $(ssh-agent)` does not work because
+      # the exported values will not persist after the statement completes 
+      `ssh-agent -t 24h -s`
+        .split.map{|e| e.tr(';', '')}
+        .map{|e| e.split('=') }
+        .select{|e| e.length == 2 && e[0] =~ /[A-Z]+$/ }
+        .each {|e| ENV[e[0]] = e[1] }
       `ssh-add "${HOME}/.ssh/id_rsa"`
       sh('beaker -h config/nodes/centos7-64mdc-centos7-64a-nodefaultrole.yaml '\
          '--tests tests '\


### PR DESCRIPTION
Previous commit was starting ssh-agent but its SSH_AGENT_PID and SSH_AUTH_SOCK
values were not being properly exported and ssh-add was not finding the ssh-agent instance.
This fix has Rake parse the output of ssh-agent and add its values to ENV
