### PR TITLE
(CTH-390) Add PXP agent init scripts

### DIFF
--- a/ext/debian/pxp-agent.default
+++ b/ext/debian/pxp-agent.default
@@ -1,0 +1,4 @@
+# Defaults for pxp-agent - sourced by /etc/init.d/pxp-agent
+
+# Startup options
+#PXP_AGENT_OPTIONS=--loglevel=debug

--- a/ext/debian/pxp-agent.init
+++ b/ext/debian/pxp-agent.init
@@ -1,0 +1,115 @@
+#! /bin/sh
+### BEGIN INIT INFO
+# Provides:          pxp-agent
+# Required-Start:    $network $named $remote_fs $syslog
+# Required-Stop:     $network $named $remote_fs $syslog
+# Should-Start:      pxp-agent
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+### END INIT INFO
+
+PATH=/opt/puppetlabs/puppet/bin:/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+
+exec=/opt/puppetlabs/puppet/bin/pxp-agent
+prog="pxp-agent"
+desc="PXP agent"
+
+piddir=/var/run/puppetlabs
+pidfile="${piddir}/${prog}.pid"
+
+[ -x $exec ] || exit 5
+
+[ -r /etc/default/pxp-agent ] && . /etc/default/pxp-agent
+
+. /lib/lsb/init-functions
+
+reload_pxp_agent() {
+    start-stop-daemon --stop --quiet --signal HUP --pidfile $pidfile --name $prog
+}
+
+start_pxp_agent() {
+    mkdir -p $piddir
+    start-stop-daemon --start --quiet --pidfile $pidfile --startas $exec -- --daemonize $PXP_AGENT_OPTIONS
+}
+
+stop_pxp_agent() {
+    start-stop-daemon --stop --retry TERM/10/KILL/5 --quiet --oknodo --pidfile $pidfile --name $prog && rm -f "${pidfile}"
+}
+
+restart_pxp_agent() {
+    log_begin_msg "Restarting $desc"
+    stop_pxp_agent
+    start_pxp_agent
+    log_end_msg $?
+}
+
+status_pxp_agent() {
+    if (type status_of_proc > /dev/null 2>&1) ; then
+        status_of_proc -p "${pidfile}" "${exec}" "${prog}"
+    else
+        status_of_proc() {
+            local pidfile daemon name status
+
+            pidfile=
+            OPTIND=1
+            while getopts p: opt ; do
+                case "$opt" in
+                    p)  pidfile="$OPTARG";;
+                esac
+            done
+            shift $(($OPTIND - 1))
+
+            if [ -n "$pidfile" ]; then
+                pidfile="-p $pidfile"
+            fi
+            daemon="$1"
+            name="$2"
+            status="0"
+            pidofproc $pidfile $daemon >/dev/null || status="$?"
+            if [ "$status" = 0 ]; then
+                log_success_msg "$name is running"
+                return 0
+            elif [ "$status" = 4 ]; then
+                log_failure_msg "could not access PID file for $name"
+                return $status
+            else
+                log_failure_msg "$name is not running"
+                return $status
+            fi
+        }
+        status_of_proc -p "${pidfile}" "${exec}"
+    fi
+}
+
+case "$1" in
+    start)
+        log_begin_msg "Starting $desc"
+        start_pxp_agent
+        log_end_msg $?
+    ;;
+    stop)
+        log_begin_msg "Stopping $desc"
+        stop_pxp_agent
+        log_end_msg $?
+    ;;
+    reload)
+        log_begin_msg "Reloading $desc"
+        reload_pxp_agent
+        log_end_msg $?
+    ;;
+    status)
+        status_pxp_agent
+    ;;
+    restart|force-reload)
+        restart_pxp_agent
+    ;;
+    condrestart)
+        if status_pxp_agent >/dev/null 2>&1; then
+            restart_pxp_agent
+        fi
+    ;;
+    *)
+        echo "Usage: $0 {start|stop|status|restart|condrestart}" >&2
+        exit 1
+    ;;
+esac

--- a/ext/osx/pxp-agent.plist
+++ b/ext/osx/pxp-agent.plist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>EnvironmentVariables</key>
+        <dict>
+                <key>PATH</key>
+                <string>/opt/puppetlabs/puppet/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+                <key>LANG</key>
+                <string>en_US.UTF-8</string>
+        </dict>
+        <key>Label</key>
+        <string>pxp-agent</string>
+        <key>KeepAlive</key>
+        <true/>
+        <key>ProgramArguments</key>
+        <array>
+                <string>/opt/puppetlabs/puppet/bin/pxp-agent</string>
+        </array>
+        <key>RunAtLoad</key>
+        <true/>
+        <key>StandardErrorPath</key>
+        <string>/var/log/puppetlabs/pxp-agent/pxp-agent.log</string>
+        <key>StandardOutPath</key>
+        <string>/var/log/puppetlabs/pxp-agent/pxp-agent.log</string>
+</dict>
+</plist>

--- a/ext/redhat/pxp-agent.init
+++ b/ext/redhat/pxp-agent.init
@@ -1,0 +1,145 @@
+#!/bin/bash
+# pxp-agent        Init script for running the PCP Execution Protocol (PXP) agent daemon
+#
+# chkconfig: - 98 02
+#
+# description: Agent for the PCP Execution Protocol (PXP), based on
+#              the Puppet Communications Protocol (PCP).
+# processname: pxp-agent
+# config: /etc/sysconfig/pxp-agent
+
+# Source function library.
+. /etc/rc.d/init.d/functions
+
+PATH=/opt/puppetlabs/puppet/bin:/usr/bin:/sbin:/bin:/usr/sbin
+export PATH
+
+[ -f /etc/sysconfig/pxp-agent ] && . /etc/sysconfig/pxp-agent
+
+exec=/opt/puppetlabs/puppet/bin/pxp-agent
+prog="pxp-agent"
+desc="PXP agent"
+
+lockfile=/var/lock/subsys/$prog
+piddir=/var/run/puppetlabs
+pidfile="${piddir}/${prog}.pid"
+pid=$(cat $pidfile 2> /dev/null)
+RETVAL=0
+
+[ -x $exec ] || exit 5
+
+# Determine if we can use the -p option to daemon, killproc, and status.
+# RHEL < 5 can't.
+if status | grep -q -- '-p' 2>/dev/null; then
+    daemonopts="--pidfile $pidfile"
+    pidopts="-p $pidfile"
+    USEINITFUNCTIONS=true
+fi
+
+start() {
+    echo -n $"Starting PXP agent: "
+    mkdir -p $piddir
+    daemon $daemonopts $exec --daemonize ${PXP_AGENT_OPTIONS}
+    RETVAL=$?
+    echo
+    [ $RETVAL = 0 ] && touch ${lockfile}
+    return $RETVAL
+}
+
+stop() {
+    echo -n $"Stopping PXP agent: "
+    if [ "$USEINITFUNCTIONS" = "true" ]; then
+        killproc $pidopts $exec
+        RETVAL=$?
+    else
+        if [ -n "${pid}" ]; then
+            kill -TERM $pid >/dev/null 2>&1
+            RETVAL=$?
+        fi
+    fi
+    echo
+    [ $RETVAL = 0 ] && rm -f ${lockfile} ${pidfile}
+    return $RETVAL
+}
+
+reload() {
+    echo -n $"Reloading PXP agent: "
+    if [ "$USEINITFUNCTIONS" = "true" ]; then
+        killproc $pidopts $exec -HUP
+        RETVAL=$?
+    else
+        if [ -n "${pid}" ]; then
+            kill -HUP $pid >/dev/null 2>&1
+            RETVAL=$?
+        else
+            RETVAL=0
+        fi
+    fi
+    echo
+    return $RETVAL
+}
+
+restart() {
+    stop
+    start
+}
+
+rh_status() {
+    if [ "$USEINITFUNCTIONS" = "true" ]; then
+        status $pidopts $exec
+        RETVAL=$?
+        return $RETVAL
+    else
+        if [ -n "${pid}" ]; then
+            if `ps -p $pid | grep $pid > /dev/null 2>&1`; then
+                echo "${desc} (pid ${pid}) is running..."
+                RETVAL=0
+                return $RETVAL
+            fi
+        fi
+        if [ -f "${pidfile}" ] ; then
+            echo "${desc} dead but pid file exists"
+            RETVAL=1
+            return $RETVAL
+        fi
+        if [ -f "${lockfile}" ]; then
+            echo "${desc} dead but subsys locked"
+            RETVAL=2
+            return $RETVAL
+        fi
+        echo "${desc} is stopped"
+        RETVAL=3
+        return $RETVAL
+    fi
+}
+
+rh_status_q() {
+    rh_status >/dev/null 2>&1
+}
+
+case "$1" in
+    start)
+        start
+    ;;
+    stop)
+        stop
+    ;;
+    restart)
+        restart
+    ;;
+    reload|force-reload)
+        reload
+    ;;
+    condrestart|try-restart)
+        rh_status_q || exit 0
+        restart
+    ;;
+    status)
+        rh_status
+    ;;
+    *)
+        echo $"Usage: $0 {start|stop|status|restart|condrestart}"
+        exit 1
+esac
+
+exit $RETVAL

--- a/ext/redhat/pxp-agent.sysconfig
+++ b/ext/redhat/pxp-agent.sysconfig
@@ -1,0 +1,2 @@
+# You may specify parameters to the PXP Agent here
+#PXP_AGENT_OPTIONS=--loglevel=debug

--- a/ext/solaris/smf/pxp-agent.xml
+++ b/ext/solaris/smf/pxp-agent.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+<service_bundle type="manifest" name="pxp-agent">
+
+  <service name="network/pxp-agent" type="service" version="1">
+
+    <create_default_instance enabled="false"/>
+    <single_instance/>
+
+    <dependency name="config-file" grouping="require_all" restart_on="none" type="path">
+      <service_fmri value="file:///etc/puppetlabs/pxp-agent/pxp-agent.conf"/>
+    </dependency>
+
+    <dependency name="loopback" grouping="require_all" restart_on="error" type="service">
+      <service_fmri value="svc:/network/loopback:default"/>
+    </dependency>
+
+    <dependency name="physical" grouping="require_all" restart_on="error" type="service">
+      <service_fmri value="svc:/network/physical:default"/>
+    </dependency>
+
+    <dependency name="fs-local" grouping="require_all" restart_on="none" type="service">
+      <service_fmri value="svc:/system/filesystem/local"/>
+    </dependency>
+
+    <exec_method type="method" name="start" exec="/opt/puppetlabs/puppet/bin/pxp-agent" timeout_seconds="60"/>
+
+    <exec_method type="method" name="stop" exec=":kill" timeout_seconds="60"/>
+
+    <stability value="Evolving"/>
+
+    <template>
+      <common_name>
+        <loctext xml:lang="C">PCP Execution Protocol (PXP) Agent</loctext>
+      </common_name>
+      <documentation>
+        <manpage title="" section="1"/>
+        <doc_link name="puppetlabs.com" uri="http://puppetlabs.com/puppet/introduction"/>
+      </documentation>
+    </template>
+  </service>
+
+</service_bundle>

--- a/ext/suse/pxp-agent.init
+++ b/ext/suse/pxp-agent.init
@@ -1,0 +1,153 @@
+#!/bin/bash
+# pxp-agent        Init script for running the PCP Execution Protocol (PXP) agent daemon
+#
+# chkconfig: - 98 02
+#
+# description: Agent for the PCP Execution Protocol (PXP), based on
+#              the Puppet Communications Protocol (PCP).
+# processname: pxp-agent
+# config: /etc/sysconfig/pxp-agent
+
+### BEGIN INIT INFO
+# Provides: pxp-agent
+# Required-Start: $local_fs $remote_fs $network $syslog
+# Should-Start: pxp-agent
+# Required-Stop: $local_fs $remote_fs $network $syslog
+# Should-Stop: pxp-agent
+# Default-Start: 3 5
+# Default-Stop: 0 1 2 6
+# Short-Description: pxp-agent
+# Description: Agent daemon for the PCP Execution Protocol (PXP)
+### END INIT INFO
+
+# Shell functions sourced from /etc/rc.status:
+#      rc_check         check and set local and overall rc status
+#      rc_status        check and set local and overall rc status
+#      rc_status -v     ditto but be verbose in local rc status
+#      rc_status -v -r  ditto and clear the local rc status
+#      rc_failed        set local and overall rc status to failed
+#      rc_reset         clear local rc status (overall remains)
+#      rc_exit          exit appropriate to overall rc status
+[ -f /etc/rc.status ] && . /etc/rc.status
+[ -f /etc/sysconfig/pxp-agent ] && . /etc/sysconfig/pxp-agent
+
+exec=/opt/puppetlabs/puppet/bin/pxp-agent
+prog="pxp-agent"
+desc="PXP agent"
+
+lockfile=/var/lock/subsys/pxp-agent
+piddir=/var/run/puppetlabs
+pidfile="${piddir}/${prog}.pid"
+
+[ -x $exec ] || exit 5
+
+# First reset status of this service
+rc_reset
+
+# Return values acc. to LSB for all commands but status:
+# 0 - success
+# 1 - misc error
+# 2 - invalid or excess args
+# 3 - unimplemented feature (e.g. reload)
+# 4 - insufficient privilege
+# 5 - program not installed
+# 6 - program not configured
+#
+# Note that starting an already running service, stopping
+# or restarting a not-running service as well as the restart
+# with force-reload (in case signalling is not supported) are
+# considered a success.
+
+case "$1" in
+    start)
+        echo -n "Starting $desc"
+        ## Start daemon with startproc(8). If this fails
+        ## the echo return value is set appropriate.
+
+        ## This accounts for the behavior of startproc on sles 10.
+        ## Check to see if a running process matches the contents
+        ## of the pidfile, and do nothing if true. Otherwise
+        ## force a process start
+        if [ -f "${pidfile}" ]; then
+            PID=$(cat "$pidfile")
+            if [ "$PID" -eq $(pgrep -f "$exec") ] ; then
+                rc_status -v
+                rc_exit
+            fi
+        fi
+        mkdir -p $piddir
+        startproc -f -w -p "${pidfile}" "${exec}" --daemonize ${PXP_AGENT_OPTIONS} && touch "${lockfile}"
+        # Remember status and be verbose
+        rc_status -v
+        ;;
+    stop)
+        echo -n "Stopping $desc"
+        ## Stop daemon with killproc(8) and if this fails
+        ## set echo the echo return value.
+
+        killproc -QUIT -p "${pidfile}" "${exec}" && rm -f "${lockfile}" "${pidfile}"
+
+        # Remember status and be verbose
+        rc_status -v
+        ;;
+    try-restart|condrestart)
+        ## Stop the service and if this succeeds (i.e. the
+        ## service was running before), start it again.
+        $0 status >/dev/null &&  $0 restart
+
+        # Remember status and be quiet
+        rc_status
+        ;;
+    restart)
+        ## Stop the service and regardless of whether it was
+        ## running or not, start it again.
+        $0 stop
+        $0 start
+
+        # Remember status and be quiet
+        rc_status
+        ;;
+    force-reload)
+        ## Signal the daemon to reload its config. Most daemons
+        ## do this on signal 1 (SIGHUP).
+        ## If it does not support it, restart.
+
+        echo -n "Reloading $desc"
+        ## if it supports it:
+        killproc -HUP -p "${pidfile}" "${exec}"
+        rc_status -v
+        ;;
+    reload)
+        ## Like force-reload, but if daemon does not support
+        ## signalling, do nothing (!)
+
+        # If it supports signalling:
+        echo -n "Reloading $desc"
+        killproc -HUP -p "${pidfile}" "${exec}"
+        rc_status -v
+        ;;
+    status)
+        echo -n "Checking for $desc service: "
+        ## Check status with checkproc(8), if process is running
+        ## checkproc will return with exit status 0.
+
+        # Status has a slightly different for the status command:
+        # 0 - service running
+        # 1 - service dead, but /var/run/  pid  file exists
+        # 2 - service dead, but /var/lock/ lock file exists
+        # 3 - service not running
+
+        # NOTE: checkproc returns LSB compliant status values.
+        if [ -f "${pidfile}" ]; then
+            checkproc -p "${pidfile}" "${exec}"
+            rc_status -v
+        else
+            rc_failed 3
+            rc_status -v
+        fi
+        ;;
+    *)
+        echo "Usage: $0 {start|stop|status|try-restart|condrestart|restart}"
+        exit 1
+esac
+rc_exit

--- a/ext/systemd/pxp-agent.service
+++ b/ext/systemd/pxp-agent.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=PCP Execution Protocol (PXP) Agent
+After=syslog.target network.target
+
+[Service]
+EnvironmentFile=-/etc/sysconfig/pxp-agent
+EnvironmentFile=-/etc/default/pxp-agent
+ExecStart=/opt/puppetlabs/puppet/bin/pxp-agent $PXP_AGENT_OPTIONS
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This commit adds init scripts and service config
files for initialization of the PXP agent service.

These are derived as wholly as possible from the
facilities currently used for Puppet in the AIO
puppet-agent.