### PR TITLE
(PCP-49) Removing PIDFile lock functionality temporarily

### DIFF
--- a/lib/inc/pxp-agent/util/posix/pid_file.hpp
+++ b/lib/inc/pxp-agent/util/posix/pid_file.hpp
@@ -50,12 +50,6 @@ class PIDFile {
     // Sets the flag that will trigger a cleanup() call by the dtor.
     void cleanupWhenDone();
 
-    // Lock exclusively the specified file descriptor; non blocking.
-    static void exclusivelyLockFile(int fd);
-
-    // Unlock the specified file descriptor.
-    static void unlockFile(int fd);
-
     // Checks the PID by sending NULL SIGNAL WITH kill().
     // NB: does not consider recycled PIDs nor zombie processes.
     static bool isProcessExecuting(pid_t pid);

--- a/lib/src/util/posix/daemonize.cc
+++ b/lib/src/util/posix/daemonize.cc
@@ -52,23 +52,16 @@ std::unique_ptr<PIDFile> daemonize() {
     // Set umask; child processes will inherit
     umask(UMASK_FLAGS);
 
-    // Lock the PID file
     // We use HW instead of Config because we may demonize without a valid
     // configuration. Outcome of CTH-380
     auto pid_dir = HW::GetFlag<std::string>("pid-dir");
+
+    // Lock the PID file
     std::unique_ptr<PIDFile> pidf_ptr { new PIDFile(pid_dir) };
 
     if (pidf_ptr->isExecuting()) {
         auto pid = pidf_ptr->read();
         LOG_ERROR("Already running with PID=%1%", pid);
-        exit(EXIT_FAILURE);
-    }
-
-    try {
-        pidf_ptr->lock();
-        LOG_DEBUG("Locked the PID file; no other daemon should be executing");
-    } catch (const PIDFile::Error& e) {
-        LOG_ERROR("Failed to lock the PID file: %1%", e.what());
         exit(EXIT_FAILURE);
     }
 

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -36,7 +36,7 @@ set (PXP-AGENT_TEST_LIBS
     libpxp-agent
 )
 
-add_executable(${test_BIN} ${COMMON_TEST_SOURCES} ${STANDARD_TEST_SOURCES})
+add_executable(${test_BIN} ${COMMON_TEST_SOURCES})
 target_link_libraries(${test_BIN} ${PXP-AGENT_TEST_LIBS})
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")


### PR DESCRIPTION
Removing the file locking functionality based on flock(); temporary fix.