### PR TITLE
(PCP-49) Use fcntl-based file locking

### DIFF
--- a/lib/inc/pxp-agent/configuration.hpp
+++ b/lib/inc/pxp-agent/configuration.hpp
@@ -48,6 +48,7 @@ class Configuration {
     struct Error : public std::runtime_error {
         explicit Error(std::string const& msg) : std::runtime_error(msg) {}
     };
+
     struct UnconfiguredError : public Error {
         explicit UnconfiguredError(std::string const& msg) : Error(msg) {}
     };

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -36,7 +36,7 @@ set (PXP-AGENT_TEST_LIBS
     libpxp-agent
 )
 
-add_executable(${test_BIN} ${COMMON_TEST_SOURCES})
+add_executable(${test_BIN} ${COMMON_TEST_SOURCES} ${STANDARD_TEST_SOURCES})
 target_link_libraries(${test_BIN} ${PXP-AGENT_TEST_LIBS})
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")


### PR DESCRIPTION
In PIDFile, we now replace the flock() system call with fcntl() for
extending portability to Solaris. The resulting lock entity has
fundamentally different semantics.

Adding read / write locking calls, that can be blocking or not.
Adding lock status check calls.
Crating log file with PIDFile ctor.
Acquiring read lock in each spawned process; file locks are not
inherited anymore with fcntl.
Using SIGUSR1-based synchronization to mantain file lock accross fork()
calls.
Adding unit tests for new functions.