### PR TITLE
(PCP-53) Port agent to boost::thread

### DIFF
--- a/lib/inc/pxp-agent/external_module.hpp
+++ b/lib/inc/pxp-agent/external_module.hpp
@@ -7,7 +7,6 @@
 #include <map>
 #include <string>
 #include <vector>
-#include <thread>
 
 namespace PXPAgent {
 

--- a/lib/inc/pxp-agent/thread_container.hpp
+++ b/lib/inc/pxp-agent/thread_container.hpp
@@ -1,11 +1,11 @@
 #ifndef SRC_THREAD_CONTAINER_H_
 #define SRC_THREAD_CONTAINER_H_
 
-#include <thread>
+#include <cpp-pcp-client/util/thread.hpp>
+
 #include <vector>
 #include <memory>   // shared_ptr
 #include <atomic>
-#include <condition_variable>
 #include <string>
 
 namespace PXPAgent {
@@ -17,7 +17,7 @@ static const uint32_t THREADS_THRESHOLD { 10 };
 
 struct ManagedThread {
     /// Thread object
-    std::thread the_instance;
+    PCPClient::Util::thread the_instance;
 
     /// Flag that indicates whether or not the thread has finished its
     /// execution
@@ -47,7 +47,7 @@ class ThreadContainer {
     /// Add the specified thread instance to the container together
     /// with the pointer to the atomic boolean that will tell when
     /// it has completed its execution
-    void add(std::thread task, std::shared_ptr<std::atomic<bool>> done);
+    void add(PCPClient::Util::thread task, std::shared_ptr<std::atomic<bool>> done);
 
     /// Return true if the monitoring thread is actually executing,
     /// false otherwise
@@ -61,10 +61,10 @@ class ThreadContainer {
   private:
     std::string name_;
     std::vector<std::shared_ptr<ManagedThread>> threads_;
-    std::unique_ptr<std::thread> monitoring_thread_ptr_;
+    std::unique_ptr<PCPClient::Util::thread> monitoring_thread_ptr_;
     bool destructing_;
-    std::mutex mutex_;
-    std::condition_variable cond_var_;
+    PCPClient::Util::mutex mutex_;
+    PCPClient::Util::condition_variable cond_var_;
     bool is_monitoring_;
     uint32_t num_added_threads_;
     uint32_t num_erased_threads_;

--- a/lib/tests/unit/thread_container_test.cc
+++ b/lib/tests/unit/thread_container_test.cc
@@ -1,5 +1,7 @@
 #include <pxp-agent/thread_container.hpp>
 
+#include <cpp-pcp-client/util/chrono.hpp>
+
 #include <catch.hpp>
 
 #include <memory>
@@ -17,7 +19,7 @@ TEST_CASE("ThreadContainer::ThreadContainer", "[utils]") {
 
 void testTask(std::shared_ptr<std::atomic<bool>> a,
               const uint32_t task_duration_us) {
-    std::this_thread::sleep_for(std::chrono::microseconds(task_duration_us));
+    PCPClient::Util::this_thread::sleep_for(PCPClient::Util::chrono::microseconds(task_duration_us));
     *a = true;
 }
 
@@ -28,7 +30,7 @@ void addTasksTo(ThreadContainer& container,
     uint32_t idx;
     for (idx = 0; idx < num_tasks; idx++) {
         std::shared_ptr<std::atomic<bool>> a { new  std::atomic<bool> { false } };
-        auto t = std::thread(testTask, a, task_duration_us);
+        auto t = PCPClient::Util::thread(testTask, a, task_duration_us);
         container.add(std::move(t), a);
     }
 
@@ -37,10 +39,10 @@ void addTasksTo(ThreadContainer& container,
         // when it's suppose to finish immediately (that could happen
         // due to thread processing ovehead for the OS), otherwise a
         // terminate call will abort the tests... See below
-        std::this_thread::sleep_for(std::chrono::microseconds(10000));
+        PCPClient::Util::this_thread::sleep_for(PCPClient::Util::chrono::microseconds(10000));
     }
 
-    std::this_thread::sleep_for(std::chrono::microseconds(caller_duration_us));
+    PCPClient::Util::this_thread::sleep_for(PCPClient::Util::chrono::microseconds(caller_duration_us));
 }
 
 TEST_CASE("ThreadContainer::add, ~ThreadContainer", "[async]") {
@@ -93,7 +95,7 @@ TEST_CASE("ThreadContainer::monitoringTask", "[async]") {
 
         // Wait for two monitoring intervals plus the task duration;
         // all threads should be done by then
-        std::this_thread::sleep_for(std::chrono::microseconds(2 * monitoring_interval_us + task_duration_us));
+        PCPClient::Util::this_thread::sleep_for(PCPClient::Util::chrono::microseconds(2 * monitoring_interval_us + task_duration_us));
         INFO("should be stopped");
         REQUIRE_FALSE(container.isMonitoring());
 
@@ -106,7 +108,7 @@ TEST_CASE("ThreadContainer::monitoringTask", "[async]") {
         // Threads can't outlive the caller otherwise std::terminate()
         // will be invoked; sleep for an interval greater than the
         // duration
-        std::this_thread::sleep_for(std::chrono::microseconds(2 * task_duration_us));
+        PCPClient::Util::this_thread::sleep_for(PCPClient::Util::chrono::microseconds(2 * task_duration_us));
     }
 
     SECTION("the monitoring thread can delete threads") {
@@ -117,7 +119,7 @@ TEST_CASE("ThreadContainer::monitoringTask", "[async]") {
         REQUIRE(container.getNumAddedThreads() == THREADS_THRESHOLD + 4);
 
         // Pause, to let the monitoring thread erase
-        std::this_thread::sleep_for(std::chrono::microseconds(2 * monitoring_interval_us));
+        PCPClient::Util::this_thread::sleep_for(PCPClient::Util::chrono::microseconds(2 * monitoring_interval_us));
         REQUIRE_FALSE(container.isMonitoring());
 
         // NB: we cannot be certain about the number of erased threads
@@ -137,7 +139,7 @@ TEST_CASE("ThreadContainer::monitoringTask", "[async]") {
 
         REQUIRE_NOTHROW(addTasksTo(container, 10, 0, 0));
         REQUIRE(container.getNumAddedThreads() == THREADS_THRESHOLD + 4 + 10);
-        std::this_thread::sleep_for(std::chrono::microseconds(2 * task_duration_us));
+        PCPClient::Util::this_thread::sleep_for(PCPClient::Util::chrono::microseconds(2 * task_duration_us));
     }
 }
 


### PR DESCRIPTION
Here we use the thread and chrono headers in cpp-pcp-client to move from
std::thread to boost::thread.