### PR TITLE
(PCP-28) Add interpreter field to module config options

### DIFF
--- a/lib/inc/pxp-agent/external_module.hpp
+++ b/lib/inc/pxp-agent/external_module.hpp
@@ -30,11 +30,14 @@ class ExternalModule : public Module {
     /// invalid input or output schemas.
     explicit ExternalModule(const std::string& exec_path);
 
-    /// In case a configuration schema has been registered fot this
-    /// module, validate and set the passed configuration data.
+    explicit ExternalModule(const std::string& path,
+                            const lth_jc::JsonContainer& config);
+
+    /// In case a configuration schema has been registered for this
+    /// module, validate configuration data.
     /// Throw a validation_error in case the configuration schema was
     /// not registered or in case of an invalid configuration data.
-    void validateAndSetConfiguration(const lth_jc::JsonContainer& config);
+    void validateConfiguration();
 
   private:
     /// The path of the module file
@@ -49,6 +52,8 @@ class ExternalModule : public Module {
     const lth_jc::JsonContainer getMetadata();
 
     void registerConfiguration(const lth_jc::JsonContainer& config);
+
+    void registerActions(const lth_jc::JsonContainer& metadata);
 
     void registerAction(const lth_jc::JsonContainer& action);
 

--- a/lib/src/request_processor.cc
+++ b/lib/src/request_processor.cc
@@ -360,14 +360,18 @@ void RequestProcessor::loadExternalModulesFrom(fs::path dir_path) {
                 auto f_p = f->path().string();
 
                 try {
-                    ExternalModule* e_m = new ExternalModule(f_p);
-                    auto config_itr = modules_config_.find(e_m->module_name);
+                    ExternalModule* e_m;
+                    auto config_itr = modules_config_.find(
+                        fs::path(f_p).filename().string());
 
                     if (config_itr != modules_config_.end()) {
-                        e_m->validateAndSetConfiguration(config_itr->second);
+                        e_m = new ExternalModule(f_p, config_itr->second);
+                        e_m->validateConfiguration();
                         LOG_DEBUG("The '%1%' module configuration has been "
                                   "validated: %2%", e_m->module_name,
                                   config_itr->second.toString());
+                    } else {
+                        e_m = new ExternalModule(f_p);
                     }
 
                     modules_[e_m->module_name] = std::shared_ptr<Module>(e_m);


### PR DESCRIPTION
Here we allow modules to specify an "interpreter" field in their config
files. If this field is set, the agent will use it to execute a module
action instead of assuming that the script is executable. This allows us
to get around having to use bat files and shebang lines on different
platforms.

We do this by slightly changing the api of ExternalModule. A second
ctor is added with the config as a parameter so we can check for the
interpreter field before validating the rest of the config.
validateAndSetConfiguration becomes validateConfiguration, since
configuration is set before the method is called.