### PR TITLE
(maint) Don't pass the logging prefix to cpp-pcp-client

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,9 +36,6 @@ if ("${CMAKE_SYSTEM_NAME}" MATCHES "Darwin")
     set(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH} /opt/local/include)
 endif()
 
-# Set the client library's logging prefix
-set(CPP_PCP_CLIENT_LOGGING_PREFIX "puppetlabs.pxp_agent")
-
 # Leatherman it up
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/vendor/leatherman/cmake")
 include(options)


### PR DESCRIPTION
The logging prefix is used only when building cpp-pcp-client, making it
inconsistent to whenever the installed libcpp-pcp-client is used.