### PR TITLE
(PCP-62) Remmove internal pid-dir option

### DIFF
--- a/lib/inc/pxp-agent/configuration.hpp
+++ b/lib/inc/pxp-agent/configuration.hpp
@@ -12,6 +12,7 @@ namespace HW = HorseWhisperer;
 
 extern const std::string DEFAULT_SPOOL_DIR;     // used by unit tests
 extern const std::string LOGFILE_NAME;          // not configurable
+extern const std::string PID_DIR;               // not configurable
 
 enum Types { Integer, String, Bool, Double };
 
@@ -167,7 +168,6 @@ class Configuration {
     void parseConfigFile();
     void setupLogging();
     void setAgentConfiguration();
-    void setNonExposedOptions();
 };
 
 }  // namespace PXPAgent

--- a/lib/src/configuration.cc
+++ b/lib/src/configuration.cc
@@ -42,12 +42,12 @@ namespace lth_log = leatherman::logging;
 
     static const fs::path DEFAULT_CONF_DIR { DATA_DIR / "etc" };
     const std::string DEFAULT_SPOOL_DIR { (DATA_DIR / "var" / "spool").string() };
-    static const std::string PID_DIR { (DATA_DIR / "var" / "run").string() };
+    const std::string PID_DIR { (DATA_DIR / "var" / "run").string() };
     static const std::string DEFAULT_LOG_DIR { (DATA_DIR / "var" / "log").string() };
 #else
     static const fs::path DEFAULT_CONF_DIR { "/etc/puppetlabs/pxp-agent" };
     const std::string DEFAULT_SPOOL_DIR { "/opt/puppetlabs/pxp-agent/spool" };
-    static const std::string PID_DIR { "/var/run/puppetlabs" };
+    const std::string PID_DIR { "/var/run/puppetlabs" };
     static const std::string DEFAULT_LOG_DIR { "/var/log/puppetlabs/pxp-agent" };
 #endif
 
@@ -99,8 +99,6 @@ HW::ParseResult Configuration::initialize(int argc, char *argv[],
         || parse_result == HW::ParseResult::INVALID_FLAG) {
         throw Configuration::Error { "An error occurred while parsing cli options"};
     }
-
-    setNonExposedOptions();
 
     if (parse_result == HW::ParseResult::OK) {
         // No further processing or user interaction are required if
@@ -513,13 +511,6 @@ void Configuration::setAgentConfiguration() {
         HW::GetFlag<std::string>("spool-dir"),
         HW::GetFlag<std::string>("modules-config-dir"),
         AGENT_CLIENT_TYPE };
-}
-
-void Configuration::setNonExposedOptions() {
-    HW::DefineGlobalFlag<std::string>("pid-dir",
-                                      "",
-                                      PID_DIR,
-                                      nullptr);
 }
 
 }  // namespace PXPAgent


### PR DESCRIPTION
Removing unnecessary option.
Removing unnecessary Configuration::setNonExposedOptions().