### PR TITLE
(PCP-69) Update service configs for daemonization by default

### DIFF
--- a/ext/debian/pxp-agent.init
+++ b/ext/debian/pxp-agent.init
@@ -29,7 +29,7 @@ reload_pxp_agent() {
 
 start_pxp_agent() {
     mkdir -p $piddir
-    start-stop-daemon --start --quiet --pidfile $pidfile --startas $exec -- --daemonize $PXP_AGENT_OPTIONS
+    start-stop-daemon --start --quiet --pidfile $pidfile --startas $exec -- $PXP_AGENT_OPTIONS
 }
 
 stop_pxp_agent() {

--- a/ext/osx/pxp-agent.plist
+++ b/ext/osx/pxp-agent.plist
@@ -15,7 +15,7 @@
         <true/>
         <key>ProgramArguments</key>
         <array>
-                <string>/opt/puppetlabs/puppet/bin/pxp-agent</string>
+                <string>/opt/puppetlabs/puppet/bin/pxp-agent --foreground</string>
         </array>
         <key>RunAtLoad</key>
         <true/>

--- a/ext/redhat/pxp-agent.init
+++ b/ext/redhat/pxp-agent.init
@@ -39,7 +39,7 @@ fi
 start() {
     echo -n $"Starting PXP agent: "
     mkdir -p $piddir
-    daemon $daemonopts $exec --daemonize ${PXP_AGENT_OPTIONS}
+    daemon $daemonopts $exec ${PXP_AGENT_OPTIONS}
     RETVAL=$?
     echo
     [ $RETVAL = 0 ] && touch ${lockfile}

--- a/ext/solaris/smf/pxp-agent.xml
+++ b/ext/solaris/smf/pxp-agent.xml
@@ -23,7 +23,7 @@
       <service_fmri value="svc:/system/filesystem/local"/>
     </dependency>
 
-    <exec_method type="method" name="start" exec="/opt/puppetlabs/puppet/bin/pxp-agent" timeout_seconds="60"/>
+    <exec_method type="method" name="start" exec="/opt/puppetlabs/puppet/bin/pxp-agent --foreground" timeout_seconds="60"/>
 
     <exec_method type="method" name="stop" exec=":kill" timeout_seconds="60"/>
 

--- a/ext/suse/pxp-agent.init
+++ b/ext/suse/pxp-agent.init
@@ -76,7 +76,7 @@ case "$1" in
             fi
         fi
         mkdir -p $piddir
-        startproc -f -w -p "${pidfile}" "${exec}" --daemonize ${PXP_AGENT_OPTIONS} && touch "${lockfile}"
+        startproc -f -w -p "${pidfile}" "${exec}" ${PXP_AGENT_OPTIONS} && touch "${lockfile}"
         # Remember status and be verbose
         rc_status -v
         ;;

--- a/ext/systemd/pxp-agent.service
+++ b/ext/systemd/pxp-agent.service
@@ -5,7 +5,7 @@ After=syslog.target network.target
 [Service]
 EnvironmentFile=-/etc/sysconfig/pxp-agent
 EnvironmentFile=-/etc/default/pxp-agent
-ExecStart=/opt/puppetlabs/puppet/bin/pxp-agent $PXP_AGENT_OPTIONS
+ExecStart=/opt/puppetlabs/puppet/bin/pxp-agent $PXP_AGENT_OPTIONS --foreground
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
By default, pxp-agent now daemonizes if unconfigured, and runs as
a foreground process if invoked with --foreground.

This commit removes the unsupported --daemonize argument from the
pxp-agent SYSV init scripts and adds the --foreground argument for
the platforms where daemonization is not needed.