### PR TITLE
(PCP-69) Fix OSX launchd plist formatting

### DIFF
--- a/ext/osx/pxp-agent.plist
+++ b/ext/osx/pxp-agent.plist
@@ -15,7 +15,8 @@
         <true/>
         <key>ProgramArguments</key>
         <array>
-                <string>/opt/puppetlabs/puppet/bin/pxp-agent --foreground</string>
+                <string>/opt/puppetlabs/puppet/bin/pxp-agent</string>
+                <string>--foreground</string>
         </array>
         <key>RunAtLoad</key>
         <true/>


### PR DESCRIPTION
This commit updates the OSX launchd plist configuration to
move "--foreground" to its own element in the ProgramArguments
array.