### PR TITLE
(PCP-6) Reopen log file after SIGUSR2 on *nix

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -31,10 +31,17 @@ if (UNIX)
     set(LIBRARY_STANDARD_SOURCES
         src/util/posix/pid_file.cc
         src/util/posix/daemonize.cc
+        src/configuration/posix/configuration.cc
     )
 endif()
 
-SET(LIBS
+if (WIN32)
+    set(LIBRARY_STANDARD_SOURCES
+        src/configuration/windows/configuration.cc
+    )
+endif()
+
+set(LIBS
     ${cpp-pcp-client_LIBRARY}
     ${Boost_LIBRARIES}
     ${OPENSSL_SSL_LIBRARY}

--- a/lib/src/configuration/posix/configuration.cc
+++ b/lib/src/configuration/posix/configuration.cc
@@ -1,0 +1,30 @@
+#include <pxp-agent/configuration.hpp>
+
+#define LEATHERMAN_LOGGING_NAMESPACE "puppetlabs.pxp_agent.configuration.posix.configuration"
+#include <leatherman/logging/logging.hpp>
+
+#include <stdexcept>
+
+namespace PXPAgent {
+
+static void sigLogfileReopen(int signal) {
+    LOG_DEBUG("Caught SIGUSR2 signal - reopening log file");
+    try {
+        Configuration::Instance().reopenLogfile();
+    } catch (const std::exception& e) {
+        LOG_ERROR("Failed to reopen logfile: %1%", e.what());
+    }
+}
+
+void configure_platform_file_logging() {
+    // Add the SIGUSR2 handler
+    // HERE(ale): we expect that daemonize() will not touch this
+    if (signal(SIGUSR2, sigLogfileReopen) == SIG_ERR) {
+        throw Configuration::Error { "failed to set the SIGUSR2 handler" };
+    } else {
+        LOG_DEBUG("Successfully registered the SIGUSR2 handler to reopen "
+                  "the logfile");
+    }
+}
+
+}  // namespace PXPAgent

--- a/lib/src/configuration/windows/configuration.cc
+++ b/lib/src/configuration/windows/configuration.cc
@@ -1,0 +1,9 @@
+#include <pxp-agent/configuration.hpp>
+
+namespace PXPAgent {
+
+void configure_platform_file_logging() {
+    // pass
+}
+
+}  // namespace PXPAgent


### PR DESCRIPTION
Registering a handler for SIGUSR2 that will reopen the file associated
with the log file stream (new class var of Configuration), in case we
log on file on *nix platforms.

Adding new platform specific section on configuration.hpp and related
implementation files in src/configuration/posix  and /windows.
Adding reopenLogFile() method to Configuration.