### PR TITLE
(PCP-91) pxp-module-puppet default Windows puppet

### DIFF
--- a/modules/pxp-module-puppet
+++ b/modules/pxp-module-puppet
@@ -172,8 +172,14 @@ def run(params_and_config)
   config = params_and_config["config"]
 
   if config["puppet_bin"].nil? || config["puppet_bin"].empty?
-    return get_result_from_report(DEFAULT_ERROR_CODE, config,
+    if !is_win?
+      return get_result_from_report(DEFAULT_ERROR_CODE, config,
                                   "puppet_bin configuration value not set")
+    else
+      module_path = File.expand_path(File.dirname(__FILE__))
+      puppet_bin = File.join(module_path, '..', '..', 'bin', 'puppet.bat')
+      config["puppet_bin"] = File.expand_path(puppet_bin)
+    end
   end
 
   if !File.exist?(config["puppet_bin"])


### PR DESCRIPTION
 - Use relative path structure to default the value of Windows
   puppet.bat file used to trigger Puppet runs


Per the specification at https://github.com/puppetlabs/puppet-specifications/blob/master/file_paths.md#puppet-agent-windows

```
C:\Program Files\Puppet Labs\Puppet\bin *
    environment.bat *                     # setup LOAD_PATH
    puppet.bat *

C:\Program Files\Puppet Labs\Puppet\pxp-agent *
    bin *
        pxp-agent.exe *
    modules *
        pxp-module-puppet *
```

Given `__FILE__` inside of `pxp-module-puppet`:

* Up one directory is `C:\Program Files\Puppet Labs\Puppet\pxp-agent`
* Up two directories is `C:\Program Files\Puppet Labs\Puppet\`
* Then `puppet.bat` is found at `bin\puppet.bat` from that point