### PR TITLE
(PCP-96) Remove unneeded config options and set correct defaults

### DIFF
--- a/modules/pxp-module-puppet
+++ b/modules/pxp-module-puppet
@@ -172,8 +172,13 @@ def run(params_and_config)
   config = params_and_config["config"]
 
   if config["puppet_bin"].nil? || config["puppet_bin"].empty?
-    return get_result_from_report(DEFAULT_ERROR_CODE, config,
-                                  "puppet_bin configuration value not set")
+    if !is_win?
+      config["puppet_bin"] = "/opt/puppetlabs/bin/puppet"
+    else
+      module_path = File.expand_path(File.dirname(__FILE__))
+      puppet_bin = File.join(module_path, '..', '..', 'bin', 'puppet.bat')
+      config["puppet_bin"] = File.expand_path(puppet_bin)
+    end
   end
 
   if !File.exist?(config["puppet_bin"])

--- a/modules/pxp-module-puppet.bat
+++ b/modules/pxp-module-puppet.bat
@@ -1,0 +1,6 @@
+@echo off
+SETLOCAL
+
+call "%~dp0..\..\bin\environment.bat" %0 %*
+
+ruby -S -- "%~dp0%SCRIPT_NAME%" %*


### PR DESCRIPTION
- Remove interpreter module config parameter
- Set correct defaults for `puppet_bin` in pxp-module-puppet
- Add .bat file required to execute pxp-module-puppet on Windows.