### PR TITLE
(PCP-78) New --pidfile option

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,11 +156,17 @@ Specify the directory containing the configuration files of modules
 **spool-dir (optional)**
 
 The location where the outcome of non-blocking requests will be stored; the
-default location is */tmp/pxp-agent/*
+default location is:
+ - \*nix: */opt/puppetlabs/pxp-agent/spool*
+ - Windows: *C:\ProgramData\PuppetLabs\pxp-agent\var\spool*
 
 **foreground (optional flag)**
 
 Don't become a daemon and execute on foreground on the associated terminal.
+
+**pidfile (optional; only on *nix platforms)**
+
+The path of the PID file; the default is */var/run/puppetlabs/pxp-agent.pid*
 
 ## Starting the agent
 

--- a/lib/inc/pxp-agent/configuration.hpp
+++ b/lib/inc/pxp-agent/configuration.hpp
@@ -23,7 +23,6 @@ namespace HW = HorseWhisperer;
 
 extern const std::string DEFAULT_SPOOL_DIR;     // used by unit tests
 extern const std::string LOGFILE_NAME;          // not configurable
-extern const std::string PID_DIR;               // not configurable
 
 //
 // Types

--- a/lib/inc/pxp-agent/util/posix/pid_file.hpp
+++ b/lib/inc/pxp-agent/util/posix/pid_file.hpp
@@ -14,15 +14,14 @@ class PIDFile {
         explicit Error(std::string const& msg) : std::runtime_error(msg) {}
     };
 
-    static const std::string FILENAME;
-
     // Create the PID file directory if necessary.
     // Open the PID file.
-    // Throw a PIDFile::Error if dir_path is not a directory or in
-    // case of a failure when opening the PID file.
-    // NB: we pass dir_path to enable testing; DIR_PATH is hardcoded
-    // in Configuration
-    PIDFile(const std::string& dir_path);
+    // Throw a PIDFile::Error: if file_path exists but is not a
+    // regular file or in case of a failure when opening it; if its
+    // parent directory is not a directory.
+    // NB: we pass the file path to enable testing, even if it is
+    // accessible via Configuration
+    PIDFile(const std::string& file_path);
 
     // Perform clean up if previously requested by cleanUpWhenDone().
     ~PIDFile();

--- a/lib/src/configuration.cc
+++ b/lib/src/configuration.cc
@@ -47,7 +47,6 @@ namespace lth_loc = leatherman::locale;
 
     static const fs::path DEFAULT_CONF_DIR { DATA_DIR / "etc" };
     const std::string DEFAULT_SPOOL_DIR { (DATA_DIR / "var" / "spool").string() };
-    const std::string PID_DIR { (DATA_DIR / "var" / "run").string() };
     static const std::string DEFAULT_LOG_DIR { (DATA_DIR / "var" / "log").string() };
 
     static const std::string DEFAULT_MODULES_DIR = []() {

--- a/lib/src/util/posix/pid_file.cc
+++ b/lib/src/util/posix/pid_file.cc
@@ -10,7 +10,6 @@
 
 #include <cstdio>           // remove()
 #include <cassert>
-
 #include <sys/file.h>       // open()
 #include <sys/stat.h>
 #include <fcntl.h>          // fcntl(), open() flags
@@ -23,13 +22,16 @@ namespace Util {
 namespace fs = boost::filesystem;
 namespace lth_file = leatherman::file_util;
 
-const std::string PIDFile::FILENAME { "pxp-agent.pid" };
-
-PIDFile::PIDFile(const std::string& dir_path_)
-        : dir_path { dir_path_ },
-          file_path { dir_path + "/" + FILENAME },
+PIDFile::PIDFile(const std::string& file_path_)
+        : dir_path { fs::path(file_path_).parent_path().string() },
+          file_path { file_path_ },
           pidfile_fd {},
           cleanup_when_done { false } {
+    if (fs::exists(file_path) && !(fs::is_regular_file(file_path))) {
+        throw PIDFile::Error { "the PID file '" + file_path
+                               + "' is not a regular file" };
+    }
+
     if (fs::exists(dir_path)) {
         if (!fs::is_directory(dir_path)) {
             throw PIDFile::Error { "the PID directory '" + dir_path


### PR DESCRIPTION
Here we allow specifying the path of the PID file on *nix.
Note that on Windows we don't write the PID to file; we ensure that only
one instance of pxp-agent is running at time by using a mutex.

Modifying the PIDFile interface.
Checking the pidfile path.
Updating unit tests.