### PR TITLE
(WIP) Run Puppet with --onetime and --no-daemonize

### DIFF
--- a/modules/pxp-module-puppet
+++ b/modules/pxp-module-puppet
@@ -169,6 +169,7 @@ def run(params_and_config)
   end
 
   params = params_and_config["params"]
+  params.merge!({'flags' => ['--onetime', '--no-daemonize']})
   config = params_and_config["config"]
 
   if config["puppet_bin"].nil? || config["puppet_bin"].empty?


### PR DESCRIPTION
 - If an agent run is not triggered with --onetime, it might not exit
   if, for instance, the master hostname is not resolvable or the master
   is not reachable.

   Ensure that the process exits right away by running puppet with
   --onetime