### PR TITLE
(PCP-79) Replace --logdir with --logfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,10 +119,7 @@ console by using an hyphen instead of a file path: `--logfile -`.
 
 By default, log messages are written to the stdout stream.
 
-You can specify a log file with `--logfile` option. In that case, no
-file rotation will take place.
-
-Note that it is not possible to have log messages displayed only on console.
+You can specify a log file with `--logfile` option.
 
 ## Log level
 

--- a/README.md
+++ b/README.md
@@ -105,23 +105,14 @@ During its execution, the daemon PID will be stored in:
 
 ### Logging
 
-## *nix
-
-By default, log messages will be written to
-*/var/log/puppetlabs/pxp-agent/pxp-agent.log*.
+By default, log messages will be written to:
+ - \*nix: */var/log/puppetlabs/pxp-agent/pxp-agent.log*
+ - Windows: *C:\ProgramData\PuppetLabs\pxp-agent\var\log\pxp-agent.log*.
 
 You can specify a different file with the `--logfile` option.
 
 When running in foreground mode, it is possible to display log messages on
 console by using an hyphen instead of a file path: `--logfile -`.
-
-## Windows
-
-By default, log messages are written to the stdout stream.
-
-You can specify a log file with `--logfile` option.
-
-## Log level
 
 The default log level is `info`. You can specify a different log level by
 using the `--loglevel` option with one of the following strings: `none`,

--- a/README.md
+++ b/README.md
@@ -95,11 +95,26 @@ During its execution, the daemon PID will be stored in:
 
 ### Logging
 
-By default, log messages will be writted to the pxp-agent.log file in:
- - \*nix: */var/log/puppetlabs/pxp-agent*
- - Windows: *C:\ProgramData\PuppetLabs\pxp-agent\var\log*
+## *nix
 
-You can specify a different directory with the `--logdir` flag.
+By default, log messages will be written to
+*/var/log/puppetlabs/pxp-agent/pxp-agent.log*.
+
+You can specify a different file with the `--logfile` option.
+
+When running in foreground mode, it is possible to display log messages on
+console by using an hyphen instead of a file path: `--logfile -`.
+
+## Windows
+
+By default, log messages are written to the stdout stream.
+
+You can specify a log file with `--logfile` option. In that case, no
+file rotation will take place.
+
+Note that it is not possible to have log messages displayed only on console.
+
+## Log level
 
 The default log level is `info`. You can specify a different log level by
 using the `--loglevel` option with one of the following strings: `none`,
@@ -131,19 +146,14 @@ The location of the pxp-agent SSL certificate, example /etc/puppet/ssl/certs/bob
 
 The location of the pxp-agent's SSL private key, example /etc/puppet/ssl/certs/bob_key.pem
 
-**logdir (optional)**
+**logfile (optional)**
 
-Directory where the `pxp-agent.log` file will be stored. This option must be set
-to a valid directory in case pxp-agent is executed as a daemon.
+The path of the log file.
 
 **loglevel (optional)**
 
 Specify one of the following logging levels: *none*, *trace*, *debug*, *info*,
 *warning*, *error*, or *fatal*; the default one is *info*
-
-**console-logger (optional flag)**
-
-Display logging messages on the associated terminal; requires `--foreground`
 
 **modules-dir (optional)**
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 This is the agent for the PCP Execution Protocol [(PXP)][1], based on the
 the Puppet Communications Protocol [(PCP)][2]. It enables the execution of
-[actions][3] on remote nodes, via PXP.
+[actions][3] on remote nodes, via PXP. The pxp-agent needs to be connected to a
+[PCP broker][8] in order to be used; please refer to the documentation below
+for how to do that.
 
 ## Building from source
 
@@ -14,6 +16,10 @@ the Puppet Communications Protocol [(PCP)][2]. It enables the execution of
  - ruby (2.0 and newer)
 
 Build with make and make install
+
+## Configuring
+ To do that, you
+need to specify the secure WebSocket URL of
 
 ## Modules
 
@@ -79,6 +85,10 @@ single JSON object. Example:
     "cert" : "/etc/puppetlabs/puppet/ssl/certs/myhost.net.pem"
 }
 ```
+
+Note that you have to specify the WebSocket secure URL of the [PCP broker][8]
+in order to establish the WebSocket connection on top of which the PCP
+communication will take place.
 
 ### Starting unconfigured
 
@@ -193,3 +203,4 @@ in the ./build/bin directory
 [5]: https://github.com/puppetlabs/pxp-agent/blob/master/lib/tests/resources/modules/reverse_valid
 [6]: https://github.com/puppetlabs/pcp-specifications/blob/master/pxp/request_response.md
 [7]: https://github.com/puppetlabs/pcp-specifications/blob/master/pxp/transaction_status.md
+[8]: https://github.com/puppetlabs/pcp-broker

--- a/lib/inc/pxp-agent/configuration.hpp
+++ b/lib/inc/pxp-agent/configuration.hpp
@@ -22,7 +22,6 @@ namespace HW = HorseWhisperer;
 //
 
 extern const std::string DEFAULT_SPOOL_DIR;     // used by unit tests
-extern const std::string LOGFILE_NAME;          // not configurable
 
 //
 // Types

--- a/lib/src/configuration.cc
+++ b/lib/src/configuration.cc
@@ -47,7 +47,8 @@ namespace lth_loc = leatherman::locale;
 
     static const fs::path DEFAULT_CONF_DIR { DATA_DIR / "etc" };
     const std::string DEFAULT_SPOOL_DIR { (DATA_DIR / "var" / "spool").string() };
-    static const std::string DEFAULT_LOG_FILE { "-" };
+    static const std::string DEFAULT_LOG_FILE {
+        (DATA_DIR / "var" / "log" / "pxp-agent.log").string() };
 
     static const std::string DEFAULT_MODULES_DIR = []() {
         wchar_t szPath[MAX_PATH];
@@ -307,11 +308,7 @@ void Configuration::defineDefaultValues() {
                  Base_ptr { new Entry<std::string>(
                     "logfile",
                     "",
-#ifdef _WIN32
                     { "Log file, default: " + DEFAULT_LOG_FILE },
-#else
-                    { "Log file, default: '-' (log to stdout)" },
-#endif
                     Types::String,
                     DEFAULT_LOG_FILE) } });
 

--- a/lib/src/configuration.cc
+++ b/lib/src/configuration.cc
@@ -47,7 +47,7 @@ namespace lth_loc = leatherman::locale;
 
     static const fs::path DEFAULT_CONF_DIR { DATA_DIR / "etc" };
     const std::string DEFAULT_SPOOL_DIR { (DATA_DIR / "var" / "spool").string() };
-    static const std::string DEFAULT_LOG_DIR { (DATA_DIR / "var" / "log").string() };
+    static const std::string DEFAULT_LOG_FILE { "-" };
 
     static const std::string DEFAULT_MODULES_DIR = []() {
         wchar_t szPath[MAX_PATH];
@@ -72,7 +72,7 @@ namespace lth_loc = leatherman::locale;
     static const fs::path DEFAULT_CONF_DIR { "/etc/puppetlabs/pxp-agent" };
     const std::string DEFAULT_SPOOL_DIR { "/opt/puppetlabs/pxp-agent/spool" };
     static const std::string DEFAULT_PID_FILE { "/var/run/puppetlabs/pxp-agent.pid" };
-    static const std::string DEFAULT_LOG_DIR { "/var/log/puppetlabs/pxp-agent" };
+    static const std::string DEFAULT_LOG_FILE { "/var/log/puppetlabs/pxp-agent/pxp-agent.log" };
     static const std::string DEFAULT_MODULES_DIR { "/opt/puppetlabs/pxp-agent/modules" };
 #endif
 
@@ -82,7 +82,6 @@ static const std::string DEFAULT_CONFIG_FILE {
     (DEFAULT_CONF_DIR / "pxp-agent.conf").string() };
 
 static const std::string AGENT_CLIENT_TYPE { "agent" };
-const std::string LOGFILE_NAME { "pxp-agent.log" };
 
 //
 // Public interface
@@ -201,12 +200,16 @@ void Configuration::validateAndNormalizeConfiguration() {
         }
     }
 
-    if (!HW::GetFlag<bool>("foreground")) {
-        if (HW::GetFlag<bool>("console-logger")) {
-            throw Configuration::Error { "must log to file when executing "
-                                         "as a daemon" };
-        }
+#ifndef _WIN32
+    // NOTE(ale): util/posix/daemonize.cc will ensure that the daemon
+    // is not associated with any controlling terminal. It will also
+    // redirect stdout to /dev/null, together with the other standard
+    // files. Setting log_level to none to reduce useless overhead.
+    if (!HW::GetFlag<bool>("foreground")
+            && HW::GetFlag<std::string>("logfile") == "-") {
+        lth_log::set_level(lth_log::log_level::none);
     }
+#endif
 
     // NOTE(ale): we validate pidfile in util/posix/pid_file.cc to
     // enable testing in pid_file_test.cc
@@ -300,13 +303,17 @@ void Configuration::defineDefaultValues() {
                     "") } });
 
     defaults_.insert(
-        Option { "logdir",
+        Option { "logfile",
                  Base_ptr { new Entry<std::string>(
-                    "logdir",
+                    "logfile",
                     "",
-                    { "Log directory, default: " + DEFAULT_LOG_DIR },
+#ifdef _WIN32
+                    { "Log file, default: " + DEFAULT_LOG_FILE },
+#else
+                    { "Log file, default: '-' (log to stdout)" },
+#endif
                     Types::String,
-                    DEFAULT_LOG_DIR) } });
+                    DEFAULT_LOG_FILE) } });
 
     defaults_.insert(
         Option { "loglevel",
@@ -317,16 +324,6 @@ void Configuration::defineDefaultValues() {
                     "'warning', 'error' and 'fatal'. Defaults to 'info'",
                     Types::String,
                     "info") } });
-
-    defaults_.insert(
-        Option { "console-logger",
-                 Base_ptr { new Entry<bool>(
-                    "console-logger",
-                    "",
-                    "Show log messages only on console, default: false "
-                    "(log to file)",
-                    Types::Bool,
-                    false) } });
 
     defaults_.insert(
         Option { "modules-dir",
@@ -517,32 +514,26 @@ static void validateLogDirPath(fs::path logdir_path) {
             throw Configuration::Error { "log directory is not a directory" };
         }
     } else {
-        throw Configuration::Error { "--logdir '" + logdir_path.string() +
-                                     "' doesn't exist" };
+        throw Configuration::Error { "the log directory '" + logdir_path.string()
+                                     + "' doesn't exist" };
     }
 }
 
 void Configuration::setupLogging() {
-    auto console_logger = HW::GetFlag<bool>("console-logger");
+    logfile_ = HW::GetFlag<std::string>("logfile");
+    auto log_on_stdout = (logfile_ == "-");
     auto loglevel = HW::GetFlag<std::string>("loglevel");
     std::ostream *stream = nullptr;
 
-    if (!console_logger) {
+    if (!log_on_stdout) {
         // We should log on file
-        auto logdir = HW::GetFlag<std::string>("logdir");
-
-        if (logdir.empty()) {
-            throw Configuration::Error { "must specify either log directory or "
-                                         "console-logger flag" };
-        }
-
-        fs::path logdir_path { lth_file::tilde_expand(logdir) };
+        logfile_ = lth_file::tilde_expand(logfile_);
+        auto logdir_path = fs::path(logfile_).parent_path();
 
         // NOTE(ale): we must validate the logifle path since we set
         // up logging before calling validateAndNormalizeConfiguration
         validateLogDirPath(logdir_path);
 
-        logfile_ = (logdir_path / LOGFILE_NAME).string();
         logfile_fstream_.open(logfile_.c_str(), std::ios_base::app);
         stream = &logfile_fstream_;
     } else {
@@ -585,7 +576,7 @@ void Configuration::setupLogging() {
     // Configure logging for cpp-pcp-client
     PCPClient::Util::setupLogging(*stream, force_colorization, loglevel);
 
-    if (!console_logger) {
+    if (!log_on_stdout) {
         // Configure platform-specific things for file logging
         // NB: we do that after setting up lth_log in order to log in
         //     case of failure

--- a/lib/tests/unit/configuration_test.cc
+++ b/lib/tests/unit/configuration_test.cc
@@ -6,6 +6,9 @@
 
 #include "horsewhisperer/horsewhisperer.h"
 
+#define LEATHERMAN_LOGGING_NAMESPACE "puppetlabs.pxp_agent.configuration_test"
+#include <leatherman/logging/logging.hpp>
+
 #include <catch.hpp>
 
 #include <string>
@@ -13,6 +16,7 @@
 namespace PXPAgent {
 
 namespace HW = HorseWhisperer;
+namespace lth_log = leatherman::logging;
 
 const std::string CONFIG { std::string { PXP_AGENT_ROOT_PATH }
                            + "/lib/tests/resources/config/empty-pxp-agent.cfg" };
@@ -230,11 +234,11 @@ TEST_CASE("Configuration::validateAndNormalizeConfiguration", "[configuration]")
                           Configuration::Error);
     }
 
-    SECTION("it fails when foreground is unflagged and log is set to console") {
+    SECTION("it sets log level to none if foreground is unflagged and logfile is set to stdout") {
         Configuration::Instance().set<bool>("foreground", false);
-        Configuration::Instance().set<bool>("console-logger", true);
-        REQUIRE_THROWS_AS(Configuration::Instance().validateAndNormalizeConfiguration(),
-                          Configuration::Error);
+        Configuration::Instance().set<std::string>("logfile", "-");
+
+        REQUIRE(lth_log::get_level() == lth_log::log_level::none);
     }
 
     resetTest();


### PR DESCRIPTION
Removing --logdir option and --console-logger flag.
Introducing the new --logfile option.
README improvements.

Logging to stdout can be specified by using "--logfile -".

Changing default logging settings to continue logging on file by
default, but in case --foreground is flagged we don't error;
instead, we set the log level to none.