### PR TITLE
(maint) Fix Windows x86 builds

### DIFF
--- a/lib/src/util/windows/daemonize.cc
+++ b/lib/src/util/windows/daemonize.cc
@@ -14,7 +14,7 @@ namespace Util {
 
 namespace lth_win = leatherman::windows;
 
-BOOL ctrl_handler(DWORD sig)
+BOOL WINAPI ctrl_handler(DWORD sig)
 {
     switch (sig) {
         case CTRL_C_EVENT:


### PR DESCRIPTION
Without this change x86 builds fail with a static_cast error.