### PR TITLE
(PCP-92) Add systemd-specific logrotate config

### DIFF
--- a/ext/systemd/pxp-agent.logrotate
+++ b/ext/systemd/pxp-agent.logrotate
@@ -1,0 +1,11 @@
+/var/log/puppetlabs/pxp-agent/*.log {
+    daily
+    missingok
+    rotate 30
+    compress
+    notifempty
+    sharedscripts
+    postrotate
+        /usr/bin/systemctl kill --signal=USR2 --kill-who=main
+    endscript
+}


### PR DESCRIPTION
Since the pxp-agent does not write a pid file
unless daemonized, we need to use "native"
systemd facilities to signal pxp-agent.

This commit adds a systemd-specific logrotate
config that uses a systemctl facility to do
postrotate signalling of pxp-agent.