### PR TITLE
(PCP-92) Add missing logrotate postrotate parameter

### DIFF
--- a/ext/systemd/pxp-agent.logrotate
+++ b/ext/systemd/pxp-agent.logrotate
@@ -6,6 +6,6 @@
     notifempty
     sharedscripts
     postrotate
-        /usr/bin/systemctl kill --signal=USR2 --kill-who=main
+        /usr/bin/systemctl kill --signal=USR2 --kill-who=main pxp-agent.service
     endscript
 }


### PR DESCRIPTION
Prior to this commit, the systemd logrotate config's
postrotate snippet was missing the target service
parameter. This commit adds the target service.