### PR TITLE
(PCP-122) Don't set PATH in pxp-agent service scripts

### DIFF
--- a/ext/debian/pxp-agent.init
+++ b/ext/debian/pxp-agent.init
@@ -8,8 +8,6 @@
 # Default-Stop:      0 1 6
 ### END INIT INFO
 
-PATH=/opt/puppetlabs/puppet/bin:/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-
 exec=/opt/puppetlabs/puppet/bin/pxp-agent
 prog="pxp-agent"
 desc="PXP agent"

--- a/ext/osx/pxp-agent.plist
+++ b/ext/osx/pxp-agent.plist
@@ -4,8 +4,6 @@
 <dict>
         <key>EnvironmentVariables</key>
         <dict>
-                <key>PATH</key>
-                <string>/opt/puppetlabs/puppet/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
                 <key>LANG</key>
                 <string>en_US.UTF-8</string>
         </dict>

--- a/ext/redhat/pxp-agent.init
+++ b/ext/redhat/pxp-agent.init
@@ -11,9 +11,6 @@
 # Source function library.
 . /etc/rc.d/init.d/functions
 
-PATH=/opt/puppetlabs/puppet/bin:/usr/bin:/sbin:/bin:/usr/sbin
-export PATH
-
 [ -f /etc/sysconfig/pxp-agent ] && . /etc/sysconfig/pxp-agent
 
 exec=/opt/puppetlabs/puppet/bin/pxp-agent


### PR DESCRIPTION
Prior to this commit, some of the pxp-agent service
scripts were setting PATH. This appears to be
unneccesary. Additionally, the specific PATH that
was being set could lead to unexpected use of the
puppet-agent's "private" utilities, such as gem.

This commit removes PATH where it was set in the
pxp-agent service scripts.