### PR TITLE
(maint) Improve set-up of pcp-broker in acceptance tests

### DIFF
--- a/acceptance/setup/common/010_Setup_Broker.rb
+++ b/acceptance/setup/common/010_Setup_Broker.rb
@@ -10,5 +10,11 @@ on master, 'cd /usr/bin && '\
 step 'Run lein once so it sets itself up'
 on master, 'chmod a+x /usr/bin/lein && export LEIN_ROOT=ok && /usr/bin/lein'
 
-step 'Run pcp-broker in trapperkeeper in background (return immediately)'
-on master, 'cd ~/pcp-broker; export LEIN_ROOT=ok; lein tk </dev/null >/dev/null 2>&1 &'
+step 'Run lein deps to download dependencies'
+# 'lein tk' will download dependencies automatically, but downloading them will take
+# some time and will eat into the polling period we allow for the broker to start
+on master, 'cd ~/pcp-broker; export LEIN_ROOT=ok; lein deps'
+
+step 'Run pcp-broker in trapperkeeper in background and wait for port 8142'
+on master, 'cd ~/pcp-broker; export LEIN_ROOT=ok; lein tk </dev/null >/var/log/pcp-broker.log 2>&1 &'
+retry_on(master, "ss -nap | grep 'LISTEN.*8142'", {:max_retries => 60})


### PR DESCRIPTION
Add polling of port 8142 to confirm the broker has started up.
Send broker's output to /var/log/pcp-broker.log instead of /dev/null so we have output for troubleshooting.
Before starting the broker, run 'lein deps' as a separate command so that time-consuming downloading of dependencies is separated from start-up time.