### PR TITLE
(PCP-123) Add default flags to puppet agent run

### DIFF
--- a/modules/pxp-module-puppet
+++ b/modules/pxp-module-puppet
@@ -173,6 +173,7 @@ def run(params_and_config)
 
   params = params_and_config["params"]
   config = params_and_config["config"]
+  params["flags"] = params["flags"] | ["--onetime", "--no-daemonize", "--verbose"]
 
   if config["puppet_bin"].nil? || config["puppet_bin"].empty?
     if !is_win?

--- a/modules/spec/unit/modules/puppet_spec.rb
+++ b/modules/spec/unit/modules/puppet_spec.rb
@@ -293,6 +293,30 @@ describe "pxp-module-puppet" do
           "Invalid json parsed on STDIN. Cannot start run action"
     end
 
+    it "populates flags with the correct defaults" do
+      expected_params = {"env" => [],
+                         "flags" => ["--onetime", "--no-daemonize", "--verbose"]}
+      allow(File).to receive(:exist?).and_return(true)
+      allow_any_instance_of(Object).to receive(:running?).and_return(false)
+      allow_any_instance_of(Object).to receive(:disabled?).and_return(false)
+      expect_any_instance_of(Object).to receive(:start_run).with(default_config,
+                                                                 expected_params)
+      run({"config" => default_config, "params" => default_params})
+    end
+
+    it "does not add flag defaults if they have been passed" do
+      expected_params = {"env" => [],
+                         "flags" => ["--squirrels", "--onetime", "--no-daemonize", "--verbose"]}
+      passed_params = {"env" => [],
+                       "flags" => ["--squirrels", "--onetime", "--no-daemonize"]}
+      allow(File).to receive(:exist?).and_return(true)
+      allow_any_instance_of(Object).to receive(:running?).and_return(false)
+      allow_any_instance_of(Object).to receive(:disabled?).and_return(false)
+      expect_any_instance_of(Object).to receive(:start_run).with(default_config,
+                                                                 expected_params)
+      run({"config" => default_config, "params" => passed_params})
+    end
+
     it "starts the run" do
       allow(File).to receive(:exist?).and_return(true)
       allow_any_instance_of(Object).to receive(:running?).and_return(false)


### PR DESCRIPTION
Here we add the flags `--onetime`, `--no-daemonize` and `--verbose` to
all puppet agent runs by default. This is done by calculating the union
between the set of passed flags and the set of default flags so that if
a default flag was set by the caller, we do not set it again.