### PR TITLE
Make travis tests work again

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "vendor/leatherman"]
 	path = vendor/leatherman
-	url = git@github.com:puppetlabs/leatherman.git
+	url = https://github.com/puppetlabs/leatherman.git
 [submodule "vendor/cpp-pcp-client"]
 	path = vendor/cpp-pcp-client
-	url = git@github.com:puppetlabs/cpp-pcp-client.git
+	url = https://github.com/puppetlabs/cpp-pcp-client.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 sudo: false
 script:
-  - cd modules && bundle exec rspec spec
+  - cd modules && bundle install && bundle exec rspec spec
 notifications:
   email: false
 rvm:


### PR DESCRIPTION
In order to allow travis to check out the submodules, use https urls which
allow cloning with no authentication.  Committers may need to update remotes.

Fix the travis script to install gems before doing a bundle exec