### PR TITLE
(maint) Improve set-up of pcp-broker in acceptance tests

### DIFF
--- a/acceptance/setup/common/010_Setup_Broker.rb
+++ b/acceptance/setup/common/010_Setup_Broker.rb
@@ -1,3 +1,6 @@
+pcp_broker_port = 8142
+pcp_broker_minutes_to_start = 2
+
 step 'Clone pcp-broker to master'
 on master, puppet('resource package git ensure=present')
 on master, 'git clone https://github.com/puppetlabs/pcp-broker.git'
@@ -10,5 +13,13 @@ on master, 'cd /usr/bin && '\
 step 'Run lein once so it sets itself up'
 on master, 'chmod a+x /usr/bin/lein && export LEIN_ROOT=ok && /usr/bin/lein'
 
-step 'Run pcp-broker in trapperkeeper in background (return immediately)'
-on master, 'cd ~/pcp-broker; export LEIN_ROOT=ok; lein tk </dev/null >/dev/null 2>&1 &'
+step 'Run lein deps to download dependencies'
+# 'lein tk' will download dependencies automatically, but downloading them will take
+# some time and will eat into the polling period we allow for the broker to start
+on master, 'cd ~/pcp-broker; export LEIN_ROOT=ok; lein deps'
+
+step "Run pcp-broker in trapperkeeper in background and wait for port #{pcp_broker_port.to_s}"
+on master, 'cd ~/pcp-broker; export LEIN_ROOT=ok; lein tk </dev/null >/var/log/pcp-broker.log 2>&1 &'
+assert(port_open_within?(master, pcp_broker_port, 60 * pcp_broker_minutes_to_start),
+       "pcp-broker port #{pcp_broker_port.to_s} not open within " \
+       "#{pcp_broker_minutes_to_start.to_s} minutes of starting the broker")


### PR DESCRIPTION
Add polling of port 8142 to confirm the broker has started up.
Send broker's output to /var/log/pcp-broker.log instead of /dev/null so we have output for troubleshooting.
Before starting the broker, run 'lein deps' as a separate command so that time-consuming downloading of dependencies is separated from start-up time.