### PR TITLE
(PCP-5) Avoid duplicate error message when connecting

### DIFF
--- a/lib/src/agent.cc
+++ b/lib/src/agent.cc
@@ -34,13 +34,11 @@ void Agent::start() {
     try {
         connector_ptr_->connect();
     } catch (PCPClient::connection_config_error& e) {
-        LOG_ERROR("Failed to configure the underlying communications layer: %1%",
-                  e.what());
-        throw Agent::Error { "failed to configure the underlying communications"
-                             "layer" };
+        // Failed to configure WebSocket on our end
+        throw Agent::Error { std::string { "WebSocket error: " } + e.what() };
     } catch (PCPClient::connection_fatal_error& e) {
-        LOG_ERROR("Failed to connect: %1%", e.what());
-        throw Agent::Error { "failed to connect" };
+        // Failed to establish a WebSocket connection
+        throw Agent::Error { "failed to connect to the pcp-broker" };
     }
 
     // The agent is now connected and the request handlers are set;


### PR DESCRIPTION
In case of an error during WebSocket connection, don't log it in Agent class,
just propagate the error which will be logged by the main function.