### PR TITLE
(PCP-119) Add machine readable error_type to response

### DIFF
--- a/modules/README.md
+++ b/modules/README.md
@@ -63,26 +63,27 @@ stdout. The JSON document will have the following fields.
 - `transaction_uuid` : The value of `transaction_uuid` in last_run_report.yaml
 - `environment` : The value of `environment` in last_run_report.yaml
 - `status` : The value of `status` in last_run_report.yaml
+- `error_type` : A string containing the machine readable error type
 - `error` : A string containing an error description if one occurred when trying to run Puppet
 - `exitcode` : The exitcode of the Puppet run
 
-### Error cases
+## Error cases
 
-### `puppet_bin` configuration value hasn't been set
+### Error Types
 
-Output will be
+If a run fails the `"error_type"` field will be set to one of the following values:
 
-```
-{
-    "kind" : "unknown",
-    "time" : "unknown",
-    "transaction_uuid" : "unknown",
-    "environment" : "unknown",
-    "status" : "unknown",
-    "error" : "puppet_bin configuration value not set",
-    "exitcode" : -1
-}
-```
+- `"invalid_json"` pxp-module-puppet was called with invalid json on stdin
+- `"no_puppet_bin"` The executable specified by `puppet_bin` doesn't exist
+- `"no_last_run_report"` last_run_report.yaml doesn't exist
+- `"invalid_last_run_report"` last_run_report.yaml could not be parsed
+- `"agent_already_running"` Puppet agent is already performing a run
+- `"agent_disabled"` Puppet agent is disabled
+- `"agent_failed_to_start"` Puppet agent failed to start
+- `"agent_exit_non_zero"` Puppet agent exited with a non-zero exitcode
+
+### Example error responses
+
 
 ### The `puppet_bin` file does not exist
 
@@ -93,6 +94,7 @@ Output will be
     "transaction_uuid" : "unknown",
     "environment" : "unknown",
     "status" : "unknown",
+    "error_type" : "no_puppet_bin",
     "error" : "Puppet executable '$puppet_bin' does not exist",
     "exitcode" : -1
 }
@@ -107,6 +109,7 @@ Output will be
     "transaction_uuid" : "unknown",
     "environment" : "unknown",
     "status" : "unknown",
+    "error_type" : "agent_already_running",
     "error" : "Puppet is already running",
     "exitcode" : -1
 }
@@ -121,6 +124,7 @@ Output will be
     "transaction_uuid" : "unknown",
     "environment" : "unknown",
     "status" : "unknown",
+    "error_type" : "agent_disabled",
     "error" : "Puppet is disabled",
     "exitcode" : -1
 }
@@ -135,6 +139,7 @@ Output will be
     "transaction_uuid" : "unknown",
     "environment" : "unknown",
     "status" : "unknown",
+    "error_type" : "invalid_json",
     "error" : "Invalid json parsed on STDIN",
     "exitcode" : -1
 }
@@ -149,6 +154,7 @@ Output will be
     "transaction_uuid" : "unknown",
     "environment" : "unknown",
     "status" : "unknown",
+    "error_type" : "agent_failed_to_start",
     "error" : "Failed to start Puppet",
     "exitcode" : -1
 }
@@ -163,6 +169,7 @@ Output will be
     "transaction_uuid" : "unknown",
     "environment" : "unknown",
     "status" : "unknown",
+    "error_type" : "agent_exit_non_zero",
     "error" : "Puppet exited with a non 0 exitcode",
     "exitcode" : $exitcode
 }
@@ -177,6 +184,7 @@ Output will be
     "transaction_uuid" : "unknown",
     "environment" : "unknown",
     "status" : "unknown",
+    "error_type" : "no_last_run_report",
     "error" : "$last_run_report.yaml doesn't exist",
     "exitcode" : $exitcode
 }
@@ -192,6 +200,7 @@ Output will be
     "transaction_uuid" : "unknown",
     "environment" : "unknown",
     "status" : "unknown",
+    "error_type" : "invalid_last_run_report",
     "error" : "$last_run_report.yaml isn't valid yaml",
     "exitcode" : exitcode
 }

--- a/modules/pxp-module-puppet
+++ b/modules/pxp-module-puppet
@@ -4,6 +4,19 @@ require 'json'
 require 'yaml'
 require 'puppet'
 
+module Errors
+  InvalidJson = "invalid_json"
+  NoPuppetBin = "no_puppet_bin"
+  NoLastRunReport = "no_last_run_report"
+  InvalidLastRunReport = "invalid_last_run_report"
+  AlreadyRunning = "agent_already_running"
+  Disabled = "agent_disabled"
+  FailedToStart = "agent_failed_to_start"
+  NonZeroExit = "agent_exit_non_zero"
+end
+
+DEFAULT_EXITCODE = -1
+
 # This method exists to facilitate testing
 def last_child_exit_status
   return $?
@@ -14,7 +27,16 @@ def is_win?
   return !!File::ALT_SEPARATOR
 end
 
-DEFAULT_ERROR_CODE = -1
+def last_run_result(exitcode)
+  return {"kind"             => "unknown",
+          "time"             => "unknown",
+          "transaction_uuid" => "unknown",
+          "environment"      => "unknown",
+          "status"           => "unknown",
+          "error_type"       => "",
+          "error"            => "",
+          "exitcode"         => exitcode}
+end
 
 def check_config_print(cli_arg, config)
   command = "#{config["puppet_bin"]} agent --configprint #{cli_arg}"
@@ -45,25 +67,20 @@ def make_command_string(config, params)
   return "#{env} #{config["puppet_bin"]} agent #{flags} > #{dev_null} 2>&1".lstrip
 end
 
-def get_result_from_report(exitcode, config, start_time, error = "", fail_hard = false)
-  run_result = {"kind"             => "unknown",
-                "time"             => "unknown",
-                "transaction_uuid" => "unknown",
-                "environment"      => "unknown",
-                "status"           => "unknown",
-                "error"            => error,
-                "exitcode"         => exitcode}
+def make_error_result(exitcode, error_type, error_message)
+  result = last_run_result(exitcode)
+  result["error_type"] = error_type
+  result["error"] = error_message
+  return result
+end
 
-  if (fail_hard)
-    return run_result
-  end
-
+def get_result_from_report(exitcode, config, start_time)
   last_run_report = File.join(check_config_print("statedir",config),
                               "last_run_report.yaml")
 
   if !File.exist?(last_run_report)
-    run_result["error"] = "#{last_run_report} doesn't exist"
-    return run_result
+    return make_error_result(exitcode, Errors::NoLastRunReport,
+                             "#{last_run_report} doesn't exist")
   end
 
   last_run_report_yaml = {}
@@ -71,8 +88,15 @@ def get_result_from_report(exitcode, config, start_time, error = "", fail_hard =
   begin
     last_run_report_yaml = YAML.load_file(last_run_report)
   rescue => e
-    run_result["error"] = "#{last_run_report} could not be loaded: #{e}"
-    return run_result
+    return make_error_result(exitcode, Errors::InvalidLastRunReport,
+                             "#{last_run_report} could not be loaded: #{e}")
+  end
+
+  run_result = last_run_result(exitcode)
+
+  if exitcode != 0
+    run_result = make_error_result(exitcode, Errors::NonZeroExit,
+                                   "Puppet agent exited with a non 0 exitcode")
   end
 
   if start_time.to_i < last_run_report_yaml.time.to_i
@@ -87,23 +111,19 @@ def get_result_from_report(exitcode, config, start_time, error = "", fail_hard =
 end
 
 def start_run(config, params)
-  exitcode = DEFAULT_ERROR_CODE
+  exitcode = DEFAULT_EXITCODE
   cmd = make_command_string(config, params)
   start_time = Time.now
 
   run_result = Puppet::Util::Execution.execute(cmd, {:failonfail => false})
 
   if !run_result
-     return get_result_from_report(exitcode, config, start_time, "Failed to start Puppet agent")
+    return make_error_result(exitcode, Errors::FailedToStart,
+                             "Failed to start Puppet agent")
   end
 
   exitcode = run_result.exitstatus
-
-  if exitcode != 0
-    return get_result_from_report(exitcode, config, start_time, "Puppet agent exited with a non 0 exitcode")
-  else
-    return get_result_from_report(exitcode, config, start_time)
-  end
+  get_result_from_report(exitcode, config, start_time)
 end
 
 def metadata()
@@ -167,8 +187,8 @@ end
 
 def run(params_and_config)
   if !params_and_config
-    return get_result_from_report(DEFAULT_ERROR_CODE, {}, nil,
-                                  "Invalid json parsed on STDIN. Cannot start run action", true)
+    return make_error_result(DEFAULT_EXITCODE, Errors::InvalidJson,
+                             "Invalid json parsed on STDIN. Cannot start run action")
   end
 
   params = params_and_config["params"]
@@ -186,21 +206,21 @@ def run(params_and_config)
   end
 
   if !File.exist?(config["puppet_bin"])
-    return get_result_from_report(DEFAULT_ERROR_CODE, config, nil,
-                                  "Puppet executable '#{config["puppet_bin"]}' does not exist", true)
+    return make_error_result(DEFAULT_EXITCODE, Errors::NoPuppetBin,
+                             "Puppet executable '#{config["puppet_bin"]}' does not exist")
   end
 
   # Instead of failing we could poll until the lockfile goes away and start a
   # run then as mentioned in https://tickets.puppetlabs.com/browse/CTH-272. I'm
   # going to start by failing and take it from there.
   if running?(config)
-    return get_result_from_report(DEFAULT_ERROR_CODE, config, nil,
-                                  "Puppet agent is already performing a run", true)
+    return make_error_result(DEFAULT_EXITCODE, Errors::AlreadyRunning,
+                             "Puppet agent is already performing a run")
   end
 
   if disabled?(config)
-    return get_result_from_report(DEFAULT_ERROR_CODE, config, nil,
-                                  "Puppet agent is disabled", true)
+    return make_error_result(DEFAULT_EXITCODE, Errors::Disabled,
+                             "Puppet agent is disabled")
   end
 
   return start_run(config, params)

--- a/modules/spec/unit/modules/puppet_spec.rb
+++ b/modules/spec/unit/modules/puppet_spec.rb
@@ -12,6 +12,19 @@ describe "pxp-module-puppet" do
     {"puppet_bin" => "puppet"}
   }
 
+  describe "last_run_result" do
+    it "returns the basic structure with exitcode set" do
+      expect(last_run_result(42)).to be == {"kind" => "unknown",
+                                            "time" => "unknown",
+                                            "transaction_uuid" => "unknown",
+                                            "environment" => "unknown",
+                                            "status" => "unknown",
+                                            "error_type" => "",
+                                            "error" => "",
+                                            "exitcode" => 42}
+    end
+  end
+
   describe "check_config_print" do
     it "returns the result of configprint" do
       cli_str = "puppet agent --configprint value"
@@ -71,6 +84,20 @@ describe "pxp-module-puppet" do
     end
   end
 
+  describe "make_error_result" do
+    it "should set the exitcode, error_type and error_message" do
+      expect(make_error_result(42, Errors::FailedToStart, "test error")).to be == 
+          {"kind" => "unknown",
+           "time" => "unknown",
+           "transaction_uuid" => "unknown",
+           "environment" => "unknown",
+           "status" => "unknown",
+           "error_type" => "agent_failed_to_start",
+           "error" => "test error",
+           "exitcode" => 42}
+    end
+  end
+
   describe "get_result_from_report" do
     it "doesn't process the last_run_report if the file doens't exist" do
       allow(File).to receive(:exist?).and_return(false)
@@ -81,6 +108,7 @@ describe "pxp-module-puppet" do
            "transaction_uuid" => "unknown",
            "environment"      => "unknown",
            "status"           => "unknown",
+           "error_type"       => "no_last_run_report",
            "error"            => "/opt/puppetlabs/puppet/cache/state/last_run_report.yaml doesn't exist",
            "exitcode"         => 0}
     end
@@ -95,6 +123,7 @@ describe "pxp-module-puppet" do
            "transaction_uuid" => "unknown",
            "environment"      => "unknown",
            "status"           => "unknown",
+           "error_type"       => "invalid_last_run_report",
            "error"            => "/opt/puppetlabs/puppet/cache/state/last_run_report.yaml could not be loaded: error",
            "exitcode"         => 0}
     end
@@ -114,12 +143,13 @@ describe "pxp-module-puppet" do
       allow_any_instance_of(Object).to receive(:check_config_print).and_return("/opt/puppetlabs/puppet/cache/state/")
       allow(YAML).to receive(:load_file).and_return(last_run_report)
 
-      expect(get_result_from_report(-1, default_config, start_time, "Puppet agent exited with a non 0 exitcode")).to be ==
+      expect(get_result_from_report(-1, default_config, start_time)).to be ==
           {"kind"             => "unknown",
            "time"             => "unknown",
            "transaction_uuid" => "unknown",
            "environment"      => "unknown",
            "status"           => "unknown",
+           "error_type"       => "agent_exit_non_zero",
            "error"            => "Puppet agent exited with a non 0 exitcode",
            "exitcode"         => -1}
     end
@@ -139,12 +169,13 @@ describe "pxp-module-puppet" do
       allow_any_instance_of(Object).to receive(:check_config_print).and_return("/opt/puppetlabs/puppet/cache/state/")
       allow(YAML).to receive(:load_file).and_return(last_run_report)
 
-      expect(get_result_from_report(-1, default_config, start_time, "Puppet agent exited with a non 0 exitcode")).to be ==
+      expect(get_result_from_report(-1, default_config, start_time)).to be ==
           {"kind"             => "apply",
            "time"             => run_time,
            "transaction_uuid" => "ac59acbe-6a0f-49c9-8ece-f781a689fda9",
            "environment"      => "production",
            "status"           => "changed",
+           "error_type"       => "agent_exit_non_zero",
            "error"            => "Puppet agent exited with a non 0 exitcode",
            "exitcode"         => -1}
     end
@@ -170,6 +201,7 @@ describe "pxp-module-puppet" do
            "transaction_uuid" => "ac59acbe-6a0f-49c9-8ece-f781a689fda9",
            "environment"      => "production",
            "status"           => "changed",
+           "error_type"       => "",
            "error"            => "",
            "exitcode"         => 0}
     end
@@ -183,22 +215,20 @@ describe "pxp-module-puppet" do
     it "populates output when it terminated normally" do
       allow(Puppet::Util::Execution).to receive(:execute).and_return(runoutcome)
       allow(runoutcome).to receive(:exitstatus).and_return(0)
-      allow_any_instance_of(Object).to receive(:get_result_from_report).with(0, default_config, anything)
+      expect_any_instance_of(Object).to receive(:get_result_from_report).with(0, default_config, anything)
       start_run(default_config, default_params)
     end
 
     it "populates output when it terminated with a non 0 code" do
       allow(Puppet::Util::Execution).to receive(:execute).and_return(runoutcome)
       allow(runoutcome).to receive(:exitstatus).and_return(1)
-      allow_any_instance_of(Object).to receive(:get_result_from_report).with(1, default_config, anything,
-                                                                        "Puppet agent exited with a non 0 exitcode")
+      expect_any_instance_of(Object).to receive(:get_result_from_report).with(1, default_config, anything)
       start_run(default_config, default_params)
     end
 
     it "populates output when it couldn't start" do
       allow(Puppet::Util::Execution).to receive(:execute).and_return(nil)
-      allow_any_instance_of(Object).to receive(:get_result_from_report).with(-1, default_config, anything,
-                                                                        "Failed to start Puppet agent")
+      expect_any_instance_of(Object).to receive(:make_error_result).with(-1, Errors::FailedToStart, "Failed to start Puppet agent")
       start_run(default_config, default_params)
     end
   end


### PR DESCRIPTION
Here we add a new field to the response, error_type. This field is
intended to be machine readable so that consumers of the response
message can easier determine how to react to failures.

We are also able to refactor #get_result_from_report by adding
a #make_error_result function. This simplifies it's calling convention
by removing the need for the optional error string and fail_hard
boolean. Calls that do not require the last_run_report to be parsed can
now directly call #make_error_result.