### PR TITLE
(PCP-95) Safely pass command line options to Puppet::Util::Execution

### DIFF
--- a/modules/pxp-module-puppet
+++ b/modules/pxp-module-puppet
@@ -53,11 +53,20 @@ def disabled?(run_result)
   !!(run_result =~ /disabled(.*?)Use 'puppet agent --enable' to re-enable/m)
 end
 
-def make_command_string(config, params)
-  env = params["env"].join(" ")
-  flags = params["flags"].join(" ")
+def make_environment_hash(params)
+  env_hash = {}
+  params["env"].each do |entry|
+    key, value = entry.split('=')
+    env_hash[key] = value
+  end
 
-  return "#{env} #{config["puppet_bin"]} agent #{flags}".lstrip.rstrip
+  return env_hash
+end
+
+def make_command_array(config, params)
+  cmd_array = [config["puppet_bin"], "agent"]
+  cmd_array +=  params["flags"]
+  return cmd_array
 end
 
 def make_error_result(exitcode, error_type, error_message)
@@ -105,10 +114,12 @@ end
 
 def start_run(config, params)
   exitcode = DEFAULT_EXITCODE
-  cmd = make_command_string(config, params)
+  cmd = make_command_array(config, params)
+  env = make_environment_hash(params)
   start_time = Time.now
 
-  run_result = Puppet::Util::Execution.execute(cmd, {:failonfail => false})
+  run_result = Puppet::Util::Execution.execute(cmd, {:failonfail => false,
+                                                     :custom_environment => env})
 
   if !run_result
     return make_error_result(exitcode, Errors::FailedToStart,

--- a/modules/spec/unit/modules/puppet_spec.rb
+++ b/modules/spec/unit/modules/puppet_spec.rb
@@ -64,34 +64,27 @@ describe "pxp-module-puppet" do
     end
   end
 
-  describe "make_command_string"do
-    it "should correctly prepend the env variables" do
+  describe "make_environment_hash" do
+    it "should correctly add the env entries" do
       params = default_params
       params["env"] = ["FOO=bar", "BAR=foo"]
-      expect(make_command_string(default_config, params)).to be ==
-        "FOO=bar BAR=foo puppet agent"
+      expect(make_environment_hash(params)).to be ==
+        {"FOO" => "bar", "BAR" => "foo"}
+    end
+  end
+
+  describe "make_command_array" do
+    it "should correctly append the executable and action" do
+      params = default_params
+      expect(make_command_array(default_config, params)).to be ==
+        ["puppet", "agent"]
     end
 
     it "should correctly append any flags" do
       params = default_params
-      params["flags"] = ["--noop", "--foo=bar"]
-      expect(make_command_string(default_config, params)).to be ==
-        "puppet agent --noop --foo=bar"
-    end
-
-    it "should correctly join both flags and env variables" do
-      params = default_params
-      params["env"] = ["FOO=bar", "BAR=foo"]
-      params["flags"] = ["--noop", "--foo=bar"]
-
-      expect(make_command_string(default_config, params)).to be ==
-        "FOO=bar BAR=foo puppet agent --noop --foo=bar"
-    end
-
-    it "uses the correct 'dev/null' on Windows" do
-      allow_any_instance_of(Object).to receive(:is_win?).and_return("true")
-      expect(make_command_string(default_config, default_params)).to be ==
-        "puppet agent"
+      params["flags"] = ["--noop", "--verbose"]
+      expect(make_command_array(default_config, params)).to be ==
+        ["puppet", "agent", "--noop", "--verbose"]
     end
   end
 


### PR DESCRIPTION
Passing environment entries as a hash via :custom_environment to the
Puppet::Util::Execution.execute function.

Updating spec tests.