### PR TITLE
(PCP-127) Make error and error_type optional in response

### DIFF
--- a/modules/pxp-module-puppet
+++ b/modules/pxp-module-puppet
@@ -33,8 +33,6 @@ def last_run_result(exitcode)
           "transaction_uuid" => "unknown",
           "environment"      => "unknown",
           "status"           => "unknown",
-          "error_type"       => "",
-          "error"            => "",
           "exitcode"         => exitcode,
           "version"          => 1}
 end
@@ -189,7 +187,7 @@ def metadata()
             }
           },
           :required => [:kind, :time, :transaction_uuid, :environment, :status,
-                        :error_type, :error, :exitcode, :version]
+                        :exitcode, :version]
         }
       }
     ],
@@ -243,7 +241,7 @@ if __FILE__ == $0
     run_result = run(params_and_config)
     puts run_result.to_json
 
-    if !run_result["error"].empty?
+    if !run_result["error"].nil?
       exit 1
     end
   end

--- a/modules/spec/unit/modules/puppet_spec.rb
+++ b/modules/spec/unit/modules/puppet_spec.rb
@@ -19,8 +19,6 @@ describe "pxp-module-puppet" do
                                             "transaction_uuid" => "unknown",
                                             "environment"      => "unknown",
                                             "status"           => "unknown",
-                                            "error_type"       => "",
-                                            "error"            => "",
                                             "exitcode"         => 42,
                                             "version"          => 1}
     end
@@ -210,8 +208,6 @@ describe "pxp-module-puppet" do
            "transaction_uuid" => "ac59acbe-6a0f-49c9-8ece-f781a689fda9",
            "environment"      => "production",
            "status"           => "changed",
-           "error_type"       => "",
-           "error"            => "",
            "exitcode"         => 0,
            "version"          => 1}
     end
@@ -311,7 +307,7 @@ describe "pxp-module-puppet" do
                 }
               },
               :required => [:kind, :time, :transaction_uuid, :environment, :status,
-                            :error_type, :error, :exitcode, :version]
+                            :exitcode, :version]
             }
           }
         ],


### PR DESCRIPTION
Here we make the `"error"` and `"error_type"` fields optional so that
the structure makes it more obvious as to when an error occurred.