### PR TITLE
(maint) Remove unused env variables from Rakefile

### DIFF
--- a/acceptance/Rakefile
+++ b/acceptance/Rakefile
@@ -2,18 +2,12 @@ def host_genconfigged
   'hosts.cfg'
 end
 
-def hosts
-  ENV['HOSTS'] || ENV['CONFIG']
-end
-
 namespace :ci do
 
   namespace :test do
 
     def generate_host_config
-      if hosts
-        return
-      end
+      puts "Generating host config using genconfig"
       if not ENV['LAYOUT']
         puts "WARNING: LAYOUT environment variable not set. Defaulting to centos7-64mdc-windows2012r2-64a"
       end


### PR DESCRIPTION
Tests fail on Jenkins because genconfig is unexpectedly skipped.
genconfig is skipped depending on HOSTS or CONFIG being set in the environment.
Currently we use neither value for anything, and always use genconfig; so just remove this.(maint) Remove unused env variables from Rakefile