### PR TITLE
(PCP-138) Link Ws2_32 on Windows

### DIFF
--- a/exe/CMakeLists.txt
+++ b/exe/CMakeLists.txt
@@ -20,7 +20,11 @@ set (PXP-AGENT_BIN_LIBS
     ${LEATHERMAN_LIBRARIES}
 )
 
+if (WIN32)
+    set(PLATFORM_LIBS Ws2_32)
+endif()
+
 add_executable(pxp-agent ${PXP-AGENT_SOURCES})
-target_link_libraries(pxp-agent ${PXP-AGENT_BIN_LIBS})
+target_link_libraries(pxp-agent ${PXP-AGENT_BIN_LIBS} ${PLATFORM_LIBS})
 
 install(TARGETS pxp-agent DESTINATION bin)

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -39,8 +39,12 @@ set (PXP-AGENT_TEST_LIBS
     ${LEATHERMAN_LIBRARIES}
 )
 
+if (WIN32)
+    set(PLATFORM_LIBS Ws2_32)
+endif()
+
 add_executable(${test_BIN} ${COMMON_TEST_SOURCES} ${STANDARD_TEST_SOURCES})
-target_link_libraries(${test_BIN} ${PXP-AGENT_TEST_LIBS})
+target_link_libraries(${test_BIN} ${PXP-AGENT_TEST_LIBS} ${PLATFORM_LIBS})
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -lpthread -pthread")


### PR DESCRIPTION
With cpp-pcp-client built as a static library, its dependency on WS2_32
now needs to be handled in the consumers in pxp-agent. Add the library for
unit tests and pxp-agent binary.