### PR TITLE
(PCP-136) Fix Solaris dependencies that were implicit

### DIFF
--- a/exe/CMakeLists.txt
+++ b/exe/CMakeLists.txt
@@ -22,6 +22,8 @@ set (PXP-AGENT_BIN_LIBS
 
 if (WIN32)
     set(PLATFORM_LIBS Ws2_32)
+elseif ("${CMAKE_SYSTEM_NAME}" MATCHES "SunOS")
+    set(PLATFORM_LIBS socket nsl)
 endif()
 
 add_executable(pxp-agent ${PXP-AGENT_SOURCES})

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -41,6 +41,8 @@ set (PXP-AGENT_TEST_LIBS
 
 if (WIN32)
     set(PLATFORM_LIBS Ws2_32)
+elseif ("${CMAKE_SYSTEM_NAME}" MATCHES "SunOS")
+    set(PLATFORM_LIBS socket nsl)
 endif()
 
 add_executable(${test_BIN} ${COMMON_TEST_SOURCES} ${STANDARD_TEST_SOURCES})


### PR DESCRIPTION
When we were building shared libraries, system libraries were
being included implicitly. Call them out explicitly now for unit
tests and the pxp-agent binary.