### PR TITLE
(PCP-136) Try to fix Catch failure with different macro

### DIFF
--- a/lib/tests/unit/util/posix/pid_file_test.cc
+++ b/lib/tests/unit/util/posix/pid_file_test.cc
@@ -56,7 +56,8 @@ TEST_CASE("PIDFile ctor", "[util]") {
 
     SECTION("it fails if the directory does not exist") {
         fs::remove_all(PID_DIR);
-        REQUIRE_THROWS(PIDFile { PID_DIR + "/foo/bar/pxp-agent.pid" });
+        REQUIRE_THROWS_AS(PIDFile { PID_DIR + "/foo/bar/pxp-agent.pid" },
+                          PIDFile::Error);
     }
 
     SECTION("cannot instantiate if the directory is a regular file") {


### PR DESCRIPTION
The PIDFile ctor test, section "it fails if the dir does not exist" was
causing an error on different platforms; apparently Catch was not
filtering the asserted error when the REQUIRE_THROWS macro was used.
Here we replace such macro with REQUIRE_THROWS_AS to investigate the
behaviour of the unit tests.