### PR TITLE
(PCP-129) New PID-base status module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
   # Use a predefined install location; cppcheck requires the cfg location is defined at compile-time.
   - mkdir -p $USERDIR
   # grab a pre-built cmake 3.2.3
-  - wget http://www.cmake.org/files/v3.2/cmake-3.2.3-Linux-x86_64.tar.gz
+  - wget --no-check-certificate https://www.cmake.org/files/v3.2/cmake-3.2.3-Linux-x86_64.tar.gz
   - tar xzvf cmake-3.2.3-Linux-x86_64.tar.gz --strip 1 -C $USERDIR
 
 script:

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ configuration file (see below), pxp-agent will use this value to execute the
 module instead.
 
 Note that the [transaction status module][7] is implemented natively; there is
-no external file for it.
+no external file for it. Also, `status query` [requests][6] must be *blocking*.
 
 ### Modules configuration
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -30,6 +30,7 @@ if (UNIX)
     set(LIBRARY_STANDARD_SOURCES
         src/util/posix/daemonize.cc
         src/util/posix/pid_file.cc
+        src/util/posix/process.cc
         src/configuration/posix/configuration.cc
     )
 endif()
@@ -37,6 +38,7 @@ endif()
 if (WIN32)
     set(LIBRARY_STANDARD_SOURCES
         src/util/windows/daemonize.cc
+        src/util/windows/process.cc
         src/configuration/windows/configuration.cc
     )
 endif()

--- a/lib/inc/pxp-agent/external_module.hpp
+++ b/lib/inc/pxp-agent/external_module.hpp
@@ -33,6 +33,9 @@ class ExternalModule : public Module {
     explicit ExternalModule(const std::string& path,
                             const lth_jc::JsonContainer& config);
 
+    /// The type of the module.
+    Module::Type type() { return Module::Type::External; }
+
     /// In case a configuration schema has been registered for this
     /// module, validate configuration data.
     /// Throw a validation_error in case the configuration schema was

--- a/lib/inc/pxp-agent/module.hpp
+++ b/lib/inc/pxp-agent/module.hpp
@@ -18,6 +18,8 @@ namespace lth_jc = leatherman::json_container;
 
 class Module {
   public:
+    enum class Type { Internal, External };
+
     struct Error : public std::runtime_error {
         explicit Error(std::string const& msg) : std::runtime_error(msg) {}
     };
@@ -40,6 +42,9 @@ class Module {
 
     /// Whether or not the module has the specified action.
     bool hasAction(const std::string& action_name);
+
+    /// The type of the module.
+    virtual Type type() { return Type::Internal; }
 
     /// Call the specified action.
     /// Return an ActionOutcome instance containing the action outcome.

--- a/lib/inc/pxp-agent/util/posix/pid_file.hpp
+++ b/lib/inc/pxp-agent/util/posix/pid_file.hpp
@@ -75,10 +75,6 @@ class PIDFile {
     // Sets the flag that will trigger a cleanup() call by the dtor.
     void cleanupWhenDone();
 
-    // Checks the PID by sending NULL SIGNAL WITH kill().
-    // NB: does not consider recycled PIDs nor zombie processes.
-    static bool isProcessExecuting(pid_t pid);
-
     // Lock the file related to the specified file descriptor with the
     // specified lock type (F_RDLCK or F_WRLCK).
     // NB: the created lock will be specific to this process and the

--- a/lib/inc/pxp-agent/util/process.hpp
+++ b/lib/inc/pxp-agent/util/process.hpp
@@ -5,6 +5,7 @@ namespace PXPAgent {
 namespace Util {
 
 bool processExists(int pid);
+int getPid();
 
 }  // namespace Util
 }  // namespace PXPAgent

--- a/lib/inc/pxp-agent/util/process.hpp
+++ b/lib/inc/pxp-agent/util/process.hpp
@@ -1,0 +1,12 @@
+#ifndef SRC_UTIL_PROCESS_HPP_
+#define SRC_UTIL_PROCESS_HPP_
+
+namespace PXPAgent {
+namespace Util {
+
+bool processExists(int pid);
+
+}  // namespace Util
+}  // namespace PXPAgent
+
+#endif  // SRC_UTIL_PROCESS_HPP_

--- a/lib/src/external_module.cc
+++ b/lib/src/external_module.cc
@@ -201,7 +201,6 @@ void ExternalModule::registerAction(const lth_jc::JsonContainer& action) {
     }
 }
 
-
 ActionOutcome ExternalModule::callAction(const ActionRequest& request) {
     auto& action_name = request.action();
 

--- a/lib/src/modules/status.cc
+++ b/lib/src/modules/status.cc
@@ -103,8 +103,9 @@ ActionOutcome Status::callAction(const ActionRequest& request) {
     }
 
     if (completed_by_metadata) {
-        std::string status {
-            (exitcode == EXIT_SUCCESS ? Status::SUCCESS : Status::FAILURE) };
+        results.set<std::string>(
+            "status",
+            (exitcode == EXIT_SUCCESS ? Status::SUCCESS : Status::FAILURE));
     } else {
         // The metadata does not report the task as completed, but it
         // may be due to a previous pxp-agent crash; if the PID file

--- a/lib/src/modules/status.cc
+++ b/lib/src/modules/status.cc
@@ -1,4 +1,5 @@
 #include <pxp-agent/modules/status.hpp>
+#include <pxp-agent/util/process.hpp>
 
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/operations.hpp>
@@ -37,37 +38,133 @@ Status::Status() {
     output_validator_.registerSchema(output_schema);
 }
 
+//
+//                         STATUS TABLE
+//
+// |+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++|
+// |                    |          |             |                   |
+// | metadata.completed | PID file | PID process |     response      |
+// | and exitcode       | exists?  | exists?     |                   |
+// | available?         |          |             |                   |
+// |                    |          |             |                   |
+// |+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++|
+// |         yes        |     -    |      -      | success / failure |
+// |                    |          |             | + stdout & stderr |
+// |+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++|
+// |         no         |    no    |      -      |      unknown      |
+// |+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++|
+// |         no         |    yes   |     yes     |      running      |
+// |+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++|
+// |         no         |    yes   |     no      |      unknown      |
+// |                    |          |             | + stdout & stderr |
+// |+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++|
+//
+
 ActionOutcome Status::callAction(const ActionRequest& request) {
     lth_jc::JsonContainer results {};
     auto t_id = request.params().get<std::string>("transaction_id");
-    fs::path results_path { HW::GetFlag<std::string>("spool-dir") };
-    auto results_dir = (results_path / t_id).string();
+    fs::path spool_path { HW::GetFlag<std::string>("spool-dir") };
+    auto results_dir_path = spool_path / t_id;
+    results.set<std::string>("status", Status::UNKNOWN);
 
-    if (!fs::exists(results_dir)) {
-        LOG_ERROR("Found no results for job %1%", t_id);
-        results.set<std::string>("status", Status::UNKNOWN);
+    if (!fs::exists(results_dir_path)) {
+        LOG_DEBUG("Found no results for job %1%", t_id);
+        return ActionOutcome { EXIT_SUCCESS, results };
+    }
+
+    LOG_DEBUG("Retrieving results for job %1% from %2%",
+              t_id, results_dir_path.string());
+
+    std::string metadata_txt;
+    lth_jc::JsonContainer action_metadata {};
+    int exitcode {};
+    auto metadata_file = (results_dir_path / "metadata").string();
+    bool completed_by_metadata { false };
+    bool not_running_by_pid { false };
+    bool valid_metadata { false };
+
+    if (!fs::exists(metadata_file)) {
+        LOG_ERROR("Metadata file '%1%' does not exist", metadata_file);
+    } else if (!lth_file::read(metadata_file, metadata_txt)) {
+        LOG_ERROR("Failed to read '%1%'", metadata_file);
     } else {
-        LOG_DEBUG("Retrieving results for job %1% from %2%", t_id, results_dir);
-        lth_jc::JsonContainer status_data { lth_file::read(results_dir + "/status") };
-
-        auto status_txt = status_data.get<std::string>("status");
-        auto exitcode = status_data.get<int>("exitcode");;
-
-        if (status_txt == "running") {
-            results.set<std::string>("status", Status::RUNNING);
-        } else if (status_txt == "completed") {
-            std::string status {
-                (exitcode == EXIT_SUCCESS ? Status::SUCCESS : Status::FAILURE) };
-            auto err = lth_file::read(results_dir + "/stderr");
-            auto out = lth_file::read(results_dir + "/stdout");
-
-            results.set<std::string>("status", status);
-            results.set<int>("exitcode", exitcode);
-            results.set<std::string>("stdout", out);
-            results.set<std::string>("stderr", err);
-        } else {
-            results.set<std::string>("status", Status::UNKNOWN);
+        try {
+            action_metadata = lth_jc::JsonContainer(metadata_txt);
+            completed_by_metadata = action_metadata.get<bool>("completed");
+            exitcode = action_metadata.get<int>("exitcode");
+            valid_metadata = true;
+        } catch (const lth_jc::data_error& e) {
+            LOG_ERROR("Metadata file '%1%' has invalid format", metadata_file);
         }
+    }
+
+    if (!valid_metadata) {
+        return ActionOutcome { EXIT_SUCCESS, results };
+    }
+
+    if (completed_by_metadata) {
+        std::string status {
+            (exitcode == EXIT_SUCCESS ? Status::SUCCESS : Status::FAILURE) };
+    } else {
+        // The metadata does not report the task as completed, but it
+        // may be due to a previous pxp-agent crash; if the PID file
+        // is available, check if the process is running
+        auto pid_file = (results_dir_path / "pid").string();
+        std::string pid_txt;
+        int pid {};
+
+        if (!fs::exists(pid_file)) {
+            LOG_ERROR("PID file '%1%' does not exist", pid_file);
+        } else if (!lth_file::read(pid_file, pid_txt)) {
+            LOG_ERROR("Failed to read PID file '%1%'", pid_file);
+        } else if (pid_txt.empty()) {
+            LOG_ERROR("PID file '%1%' is empty", pid_file);
+        } else {
+            try {
+                pid = std::stoi(pid_txt);
+
+                // NOTE(ale): processExists() does not throw
+                if (Util::processExists(pid)) {
+                    results.set<std::string>("status", Status::RUNNING);
+                } else {
+                    // We know that the process is not running, but
+                    // its status is 'unknown'
+                    not_running_by_pid = true;
+                }
+            } catch (const std::invalid_argument& e) {
+                // We didn't manage to get the PID and the metadata
+                // file does not report the action as completed; we
+                // cannot determine the state, so leave it 'unknown'
+                LOG_ERROR("Invalid value '%1%' stored in PID file '%2%'",
+                          pid_txt, pid_file);
+            }
+        }
+    }
+
+    if (completed_by_metadata || not_running_by_pid) {
+        // The process is either completed (state may be 'failure' or
+        // 'success', depending on the exit code) or not running
+        // (after checking the pid - state is 'unknown'); we can send
+        // back the contents of stdout / stderr files
+        std::string out;
+        auto out_file = (results_dir_path / "stdout").string();
+        if (!fs::exists(out_file)) {
+            LOG_DEBUG("Stdout file '%1%' does not exist", out_file);
+        } else if (!lth_file::read(out_file, out)) {
+            LOG_ERROR("Failed to read %1%", out_file);
+        }
+
+        std::string err;
+        auto err_file = (results_dir_path / "stderr").string();
+        if (!fs::exists(err_file)) {
+            LOG_DEBUG("Stderr file '%1%' does not exist", err_file);
+        } else if (!lth_file::read(err_file, err)) {
+            LOG_ERROR("Failed to read %1%", err_file);
+        }
+
+        results.set<int>("exitcode", exitcode);
+        results.set<std::string>("stdout", out);
+        results.set<std::string>("stderr", err);
     }
 
     return ActionOutcome { EXIT_SUCCESS, results };

--- a/lib/src/modules/status.cc
+++ b/lib/src/modules/status.cc
@@ -11,6 +11,8 @@
 
 #include <horsewhisperer/horsewhisperer.h>
 
+#include <string>
+
 namespace PXPAgent {
 namespace Modules {
 

--- a/lib/src/request_processor.cc
+++ b/lib/src/request_processor.cc
@@ -240,7 +240,7 @@ void RequestProcessor::validateRequestContent(const ActionRequest& request) {
     try {
         if (!modules_.at(request.module())->hasAction(request.action())) {
             throw RequestProcessor::Error { "unknown action '" + request.action()
-                                            + "' for module " + request.module() };
+                                            + "' for module '" + request.module() + "'" };
         }
     } catch (std::out_of_range& e) {
         throw RequestProcessor::Error { "unknown module: " + request.module() };

--- a/lib/src/request_processor.cc
+++ b/lib/src/request_processor.cc
@@ -242,7 +242,8 @@ void RequestProcessor::validateRequestContent(const ActionRequest& request) {
     }
 
     // If it's an internal module, the request must be blocking
-    if (modules_.at(request.module())->type() == Module::Type::Internal) {
+    if (modules_.at(request.module())->type() == Module::Type::Internal
+        && request.type() == RequestType::NonBlocking) {
         throw RequestProcessor::Error { "the module '" + request.module() + "' "
                                         "supports only blocking PXP requests" };
     }

--- a/lib/src/request_processor.cc
+++ b/lib/src/request_processor.cc
@@ -46,38 +46,38 @@ class ResultsStorage {
     ResultsStorage(const ActionRequest& request, const std::string& results_dir)
             : module { request.module() },
               action { request.action() },
-              out_path { results_dir + "/stdout" },
-              err_path { results_dir + "/stderr" },
-              status_path { results_dir + "/status" },
-              action_status {} {
+              out_file { results_dir + "/stdout" },
+              err_file { results_dir + "/stderr" },
+              metadata_file { results_dir + "/metadata" },
+              action_metadata {} {
         initialize(request, results_dir);
     }
 
     void write(const ActionOutcome& outcome, const std::string& exec_error,
                const std::string& duration) {
         assert(outcome.type == ActionOutcome::Type::External);
-        action_status.set<std::string>("status", "completed");
-        action_status.set<std::string>("duration", duration);
-        action_status.set<int>("exitcode", outcome.exitcode);
-        lth_file::atomic_write_to_file(action_status.toString() + "\n", status_path);
+        action_metadata.set<bool>("completed", true);
+        action_metadata.set<std::string>("duration", duration);
+        action_metadata.set<int>("exitcode", outcome.exitcode);
+        lth_file::atomic_write_to_file(action_metadata.toString() + "\n", metadata_file);
 
         if (exec_error.empty()) {
-            lth_file::atomic_write_to_file(outcome.std_out + "\n", out_path);
+            lth_file::atomic_write_to_file(outcome.std_out + "\n", out_file);
             if (!outcome.std_err.empty()) {
-                lth_file::atomic_write_to_file(outcome.std_err + "\n", err_path);
+                lth_file::atomic_write_to_file(outcome.std_err + "\n", err_file);
             }
         } else {
-            lth_file::atomic_write_to_file(exec_error, err_path);
+            lth_file::atomic_write_to_file(exec_error, err_file);
         }
     }
 
   private:
     std::string module;
     std::string action;
-    std::string out_path;
-    std::string err_path;
-    std::string status_path;
-    lth_jc::JsonContainer action_status;
+    std::string out_file;
+    std::string err_file;
+    std::string metadata_file;
+    lth_jc::JsonContainer action_metadata;
 
     void initialize(const ActionRequest& request, const std::string& results_dir) {
         if (!fs::exists(results_dir)) {
@@ -92,21 +92,21 @@ class ResultsStorage {
             }
         }
 
-        action_status.set<std::string>("module", module);
-        action_status.set<std::string>("action", action);
-        action_status.set<std::string>("status", "running");
-        action_status.set<std::string>("duration", "0 s");
-        action_status.set<int>("exitcode", EXIT_SUCCESS);
+        action_metadata.set<std::string>("module", module);
+        action_metadata.set<std::string>("action", action);
+        action_metadata.set<bool>("completed", false);
+        action_metadata.set<std::string>("duration", "0 s");
+        action_metadata.set<int>("exitcode", EXIT_SUCCESS);
 
         if (!request.paramsTxt().empty()) {
-            action_status.set<std::string>("input", request.paramsTxt());
+            action_metadata.set<std::string>("input", request.paramsTxt());
         } else {
-            action_status.set<std::string>("input", "none");
+            action_metadata.set<std::string>("input", "none");
         }
 
-        lth_file::atomic_write_to_file("", out_path);
-        lth_file::atomic_write_to_file("", err_path);
-        lth_file::atomic_write_to_file(action_status.toString() + "\n", status_path);
+        lth_file::atomic_write_to_file("", out_file);
+        lth_file::atomic_write_to_file("", err_file);
+        lth_file::atomic_write_to_file(action_metadata.toString() + "\n", metadata_file);
     }
 };
 

--- a/lib/src/util/posix/process.cc
+++ b/lib/src/util/posix/process.cc
@@ -2,6 +2,7 @@
 
 #include <signal.h>
 #include <errno.h>
+#include <unistd.h>         // getpid()
 
 namespace PXPAgent {
 namespace Util {
@@ -23,6 +24,10 @@ bool processExists(int pid) {
     }
 
     return true;
+}
+
+int getPid() {
+    return getpid();
 }
 
 }  // namespace Util

--- a/lib/src/util/posix/process.cc
+++ b/lib/src/util/posix/process.cc
@@ -1,0 +1,29 @@
+#include <pxp-agent/util/process.hpp>
+
+#include <signal.h>
+#include <errno.h>
+
+namespace PXPAgent {
+namespace Util {
+
+// Checks the PID by sending NULL SIGNAL WITH kill().
+// NB: does not consider recycled PIDs nor zombie processes.
+bool processExists(int pid) {
+    if (kill(pid, 0)) {
+        switch (errno) {
+            case ESRCH:
+                return false;
+            case EPERM:
+                // Process exists, but we can't signal to it
+                return true;
+            default:
+                // Unexpected
+                return false;
+        }
+    }
+
+    return true;
+}
+
+}  // namespace Util
+}  // namespace PXPAgent

--- a/lib/src/util/windows/process.cc
+++ b/lib/src/util/windows/process.cc
@@ -1,0 +1,27 @@
+#include <pxp-agent/util/process.hpp>
+
+#include <leatherman/windows/windows.hpp>
+#include <leatherman/windows/system_error.hpp>
+
+#define LEATHERMAN_LOGGING_NAMESPACE "puppetlabs.pxp_agent.util.windows.process"
+#include <leatherman/logging/logging.hpp>
+
+namespace PXPAgent {
+namespace Util {
+
+namespace lth_win = leatherman::windows;
+
+bool processExists(int pid) {
+    auto p_handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
+    if (p_handle) {
+        CloseHandle(p_handle);
+        return true;
+    } else {
+        LOG_TRACE("OpenProcess failure while trying to determine the state "
+                  "of PID %1%: %2%", pid, lth_win::system_error());
+    }
+    return false;
+}
+
+}  // namespace Util
+}  // namespace PXPAgent

--- a/lib/src/util/windows/process.cc
+++ b/lib/src/util/windows/process.cc
@@ -23,5 +23,9 @@ bool processExists(int pid) {
     return false;
 }
 
+int getPid() {
+    return GetCurrentProcessId();
+}
+
 }  // namespace Util
 }  // namespace PXPAgent

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -16,11 +16,12 @@ set(COMMON_TEST_SOURCES
     unit/certs.cc
     unit/configuration_test.cc
     unit/external_module_test.cc
-    unit/request_processor_test.cc
     unit/module_test.cc
+    unit/request_processor_test.cc
     unit/thread_container_test.cc
     unit/modules/ping_test.cc
     unit/modules/status_test.cc
+    unit/util/process_test.cc
 )
 
 if (UNIX)

--- a/lib/tests/resources/delayed_result_failure/metadata
+++ b/lib/tests/resources/delayed_result_failure/metadata
@@ -1,6 +1,6 @@
 {"module":"foo",
  "action":"bar",
  "input":"{10}",
- "status":"completed",
+ "completed":true,
  "exitcode":4,
  "duration":"3.141592s"}

--- a/lib/tests/resources/delayed_result_success/metadata
+++ b/lib/tests/resources/delayed_result_success/metadata
@@ -1,6 +1,6 @@
 {"module":"spam",
  "action":"eggs",
  "input":"{42}",
- "status":"completed",
+ "completed":true,
  "exitcode":0,
  "duration":"2.158332s"}

--- a/lib/tests/unit/configuration_test.cc
+++ b/lib/tests/unit/configuration_test.cc
@@ -57,7 +57,6 @@ static void configureTest() {
         [](std::vector<std::string>) {
             return EXIT_SUCCESS;
         });
-    // Configuration::Instance().initialize(ARGC, const_cast<char**>(ARGV), false);
 }
 
 static void resetTest() {

--- a/lib/tests/unit/content_format.hpp
+++ b/lib/tests/unit/content_format.hpp
@@ -20,6 +20,15 @@ static boost::format DATA_FORMAT {
     "}"
 };
 
+static boost::format NON_BLOCKING_DATA_FORMAT {
+    "{  \"transaction_id\" : %1%,"
+    "   \"module\" : %2%,"
+    "   \"action\" : %3%,"
+    "   \"params\" : %4%,"
+    "   \"notify_outcome\" : %5%"
+    "}"
+};
+
 static const std::string ENVELOPE_TXT {
     (ENVELOPE_FORMAT % "\"123456\""
                      % "\"test_message\""

--- a/lib/tests/unit/external_module_test.cc
+++ b/lib/tests/unit/external_module_test.cc
@@ -63,6 +63,16 @@ TEST_CASE("ExternalModule::ExternalModule", "[modules]") {
     }
 }
 
+TEST_CASE("ExternalModule::type", "[modules]") {
+    ExternalModule mod { PXP_AGENT_ROOT_PATH
+                         "/lib/tests/resources/modules/reverse_valid"
+                         EXTENSION };
+
+    SECTION("correctly reports its type") {
+        REQUIRE(mod.type() == Module::Type::External);
+    }
+}
+
 TEST_CASE("ExternalModule::hasAction", "[modules]") {
     ExternalModule mod { PXP_AGENT_ROOT_PATH
                          "/lib/tests/resources/modules/reverse_valid"

--- a/lib/tests/unit/external_module_test.cc
+++ b/lib/tests/unit/external_module_test.cc
@@ -3,11 +3,13 @@
 
 #include <pxp-agent/external_module.hpp>
 #include <pxp-agent/configuration.hpp>
+#include <pxp-agent/util/process.hpp>
 
 #include <cpp-pcp-client/protocol/chunks.hpp>       // ParsedChunks
 
 #include <leatherman/json_container/json_container.hpp>
 #include <leatherman/util/scope_exit.hpp>
+#include <leatherman/file_util/file.hpp>
 
 #include <boost/filesystem/operations.hpp>
 
@@ -31,6 +33,7 @@ namespace fs = boost::filesystem;
 namespace HW = HorseWhisperer;
 namespace lth_jc = leatherman::json_container;
 namespace lth_util = leatherman::util;
+namespace lth_file = leatherman::file_util;
 
 static const std::string SPOOL_DIR { std::string { PXP_AGENT_ROOT_PATH }
                                      + "/lib/tests/resources/test_spool" };
@@ -200,6 +203,13 @@ TEST_CASE("ExternalModule::callAction - non blocking", "[modules]") {
 
         REQUIRE_NOTHROW(e_m.executeAction(request));
         REQUIRE(fs::exists(pid_path));
+
+        try {
+            auto pid_txt = lth_file::read(pid_path.string());
+            auto pid = std::stoi(pid_txt);
+        } catch (std::exception) {
+            FAIL("fail to get pid");
+        }
     }
 }
 

--- a/lib/tests/unit/module_test.cc
+++ b/lib/tests/unit/module_test.cc
@@ -32,6 +32,14 @@ static const PCPClient::ParsedChunks PARSED_CHUNKS {
                 NO_DEBUG,
                 0 };
 
+TEST_CASE("Module::type", "[modules]") {
+    Modules::Echo echo_module {};
+
+    SECTION("correctly reports its type") {
+        REQUIRE(echo_module.type() == Module::Type::Internal);
+    }
+}
+
 TEST_CASE("Module::hasAction", "[modules]") {
     Modules::Echo echo_module {};
 

--- a/lib/tests/unit/modules/status_test.cc
+++ b/lib/tests/unit/modules/status_test.cc
@@ -73,7 +73,6 @@ static void configureTest() {
 }
 
 static void resetTest() {
-    // Configuration::Instance().reset();
     fs::remove_all(SPOOL_DIR);
 }
 

--- a/lib/tests/unit/util/posix/pid_file_test.cc
+++ b/lib/tests/unit/util/posix/pid_file_test.cc
@@ -436,11 +436,5 @@ TEST_CASE("PIDFile::canLockFile", "[util]") {
     fs::remove_all(SPOOL_DIR);
 }
 
-TEST_CASE("PIDFile::isProcessExecuting", "[util]") {
-    SECTION("this process is executing") {
-        REQUIRE(PIDFile::isProcessExecuting(getpid()));
-    }
-}
-
 }  // namespace Util
 }  // namespace PXPAgent

--- a/lib/tests/unit/util/process_test.cc
+++ b/lib/tests/unit/util/process_test.cc
@@ -1,0 +1,26 @@
+#include <pxp-agent/util/process.hpp>
+
+#include <catch.hpp>
+
+#ifdef _WIN32
+    #include <leatherman/windows/windows.hpp>
+    #undef ERROR
+#else
+    #include <unistd.h>
+#endif
+
+namespace PXPAgent {
+namespace Util {
+
+TEST_CASE("processExists", "[util]") {
+    SECTION("this process is executing") {
+#ifdef _WIN32
+        REQUIRE(processExists(GetCurrentProcessId()));
+#else
+        REQUIRE(processExists(getpid()));
+#endif
+    }
+}
+
+}  // namespace Util
+}  // namespace PXPAgent

--- a/lib/tests/unit/util/process_test.cc
+++ b/lib/tests/unit/util/process_test.cc
@@ -22,5 +22,11 @@ TEST_CASE("processExists", "[util]") {
     }
 }
 
+TEST_CASE("getPid", "[util]") {
+    SECTION("can call it") {
+        REQUIRE_NOTHROW(getPid());
+    }
+}
+
 }  // namespace Util
 }  // namespace PXPAgent


### PR DESCRIPTION
- internal modules (ping, echo, and status) must now be invoked only by blocking request
- add processExist() function for Windows
- write PID of non-blocking action jobs (separate process) on file
- rewrite status query action 