### PR TITLE
(PA-46) Don't '--foreground' on startup on Solaris

### DIFF
--- a/ext/solaris/smf/pxp-agent.xml
+++ b/ext/solaris/smf/pxp-agent.xml
@@ -23,7 +23,7 @@
       <service_fmri value="svc:/system/filesystem/local"/>
     </dependency>
 
-    <exec_method type="method" name="start" exec="/opt/puppetlabs/puppet/bin/pxp-agent --foreground" timeout_seconds="60"/>
+    <exec_method type="method" name="start" exec="/opt/puppetlabs/puppet/bin/pxp-agent" timeout_seconds="60"/>
 
     <exec_method type="method" name="stop" exec=":kill" timeout_seconds="60"/>
 


### PR DESCRIPTION
Currently, once a Solaris pxp-agent successfully connects
to a PCP broker, the startup does not return. After 60 seconds,
SMF kills the service and places it into maintenance mode.

This commit removes `--foreground` from puppet-agent's SMF
SMF manifest, which allows the start method to return.