### PR TITLE
(PCP-155) Distinguish between cert not found and not readable

### DIFF
--- a/lib/src/configuration.cc
+++ b/lib/src/configuration.cc
@@ -561,13 +561,14 @@ void Configuration::checkUnconfiguredMode() {
     auto cert = HW::GetFlag<std::string>("ssl-cert");
     auto key = HW::GetFlag<std::string>("ssl-key");
 
-
     if (ca.empty()) {
         throw Configuration::UnconfiguredError { "ssl-ca-cert value must be defined" };
     } else {
         ca = lth_file::tilde_expand(ca);
-        if (!lth_file::file_readable(ca)) {
+        if (!fs::exists(ca)){
             throw Configuration::UnconfiguredError { "ssl-ca-cert file not found" };
+        } else if (!lth_file::file_readable(ca)) {
+            throw Configuration::UnconfiguredError { "ssl-ca-cert file not readable" };
         }
     }
 
@@ -575,8 +576,10 @@ void Configuration::checkUnconfiguredMode() {
         throw Configuration::UnconfiguredError { "ssl-cert value must be defined" };
     } else {
         cert = lth_file::tilde_expand(cert);
-        if (!lth_file::file_readable(ca)) {
+        if (!fs::exists(cert)) {
             throw Configuration::UnconfiguredError { "ssl-cert file not found" };
+        } else if (!lth_file::file_readable(cert)) {
+            throw Configuration::UnconfiguredError { "ssl-cert file not readable" };
         }
     }
 
@@ -584,8 +587,10 @@ void Configuration::checkUnconfiguredMode() {
         throw Configuration::UnconfiguredError { "ssl-key value must be defined" };
     } else {
         key = lth_file::tilde_expand(key);
-        if (!lth_file::file_readable(key)) {
+        if (!fs::exists(key)) {
             throw Configuration::UnconfiguredError { "ssl-key file not found" };
+        } else if (!lth_file::file_readable(key)) {
+            throw Configuration::UnconfiguredError { "ssl-key file not readable" };
         }
     }
 

--- a/lib/tests/unit/configuration_test.cc
+++ b/lib/tests/unit/configuration_test.cc
@@ -228,6 +228,13 @@ TEST_CASE("Configuration::validate", "[configuration]") {
                           Configuration::UnconfiguredError);
     }
 
+    SECTION("it throws an UnconfiguredError when ssl-ca-cert file is not "
+            "readable (is a directory)") {
+        HW::SetFlag<std::string>("ssl-ca-cert", "/fake");
+        REQUIRE_THROWS_AS(Configuration::Instance().validate(),
+                          Configuration::UnconfiguredError);
+    }
+
     SECTION("it throws an UnconfiguredError when ssl-cert is undefined") {
         HW::SetFlag<std::string>("ssl-cert", "");
         REQUIRE_THROWS_AS(Configuration::Instance().validate(),
@@ -236,6 +243,13 @@ TEST_CASE("Configuration::validate", "[configuration]") {
 
     SECTION("it throws an UnconfiguredError when ssl-cert file cannot be found") {
         HW::SetFlag<std::string>("ssl-cert", "/fake/file");
+        REQUIRE_THROWS_AS(Configuration::Instance().validate(),
+                          Configuration::UnconfiguredError);
+    }
+
+    SECTION("it throws an UnconfiguredError when ssl-cert file is not "
+            "readable (is a directory)") {
+        HW::SetFlag<std::string>("ssl-cert", "/fake");
         REQUIRE_THROWS_AS(Configuration::Instance().validate(),
                           Configuration::UnconfiguredError);
     }
@@ -252,7 +266,14 @@ TEST_CASE("Configuration::validate", "[configuration]") {
                           Configuration::UnconfiguredError);
     }
 
-    SECTION("it fails when spool-dir is empty") {
+    SECTION("it throws an UnconfiguredError when ssl-key file is not "
+            "readable (is a directory)") {
+        HW::SetFlag<std::string>("ssl-key", "/fake");
+        REQUIRE_THROWS_AS(Configuration::Instance().validate(),
+                          Configuration::UnconfiguredError);
+    }
+
+    SECTION("it fails when --spool-dir is empty") {
         HW::SetFlag<std::string>("spool-dir", "");
         REQUIRE_THROWS_AS(Configuration::Instance().validate(),
                           Configuration::Error);


### PR DESCRIPTION
When validating the configuration, we now discriminate between SSL that
don't exist and that are not readable. Adding unit tests for that.