### PR TITLE
(maint) Add acceptance test for enable service

### DIFF
--- a/acceptance/tests/service_stop_start.rb
+++ b/acceptance/tests/service_stop_start.rb
@@ -39,6 +39,18 @@ assert_stopped
 start_service
 assert_running
 
+step 'C94777 - Service enabled and started' do
+  step 'Enable and start service' do
+    on(@agent1, puppet('resource service pxp-agent ensure=running enable=true'))
+  end
+  step 'validate that service is enabled and running' do
+    on(@agent1, puppet('resource service pxp-agent')) do |result|
+      assert_running
+      assert_match(/enable\s+=>\s+'true'/, result.stdout, 'pxp-agent failed to enable')
+    end
+  end
+end
+
 step 'C93069 - Service Stop (from running, with configuration)'
 stop_service
 assert_stopped


### PR DESCRIPTION
This commit adds an acceptance test to ensure that the pxp-agent
service can be enabled and started.

[skip ci]