### PR TITLE
(maint) Remove ssh-agent call

### DIFF
--- a/acceptance/Rakefile
+++ b/acceptance/Rakefile
@@ -8,19 +8,6 @@ namespace :ci do
     end
 
     task :aio do
-      # Start ssh-agent, parse the env variables from its output and add them to ENV
-      # The usual `eval $(ssh-agent)` does not work because
-      # the exported values will not persist after the statement completes
-      # TODO (JS) - QA-2108 - This no longer works for local execution and must be skipped.
-      if not ENV['LOCAL_EXECUTION']
-        `ssh-agent -t 24h -s`
-          .split.map{|e| e.tr(';', '')}
-          .map{|e| e.split('=') }
-          .select{|e| e.length == 2 && e[0] =~ /[A-Z]+$/ }
-          .each {|e| ENV[e[0]] = e[1] }
-        `ssh-add "${HOME}/.ssh/id_rsa"`
-      end
-
       if not ENV['TEST_TARGET']
         fail "TEST_TARGET environment variable must be set to the name of a host config e.g. redhat-7-x86_64"
       end

--- a/acceptance/config/aio/options.rb
+++ b/acceptance/config/aio/options.rb
@@ -1,4 +1,5 @@
 {
+  :log_level     => 'debug',
   :type          => 'packages',
   :forge_host    => 'forge-aio01-petest.puppetlabs.com',
   :load_path     => './lib/',


### PR DESCRIPTION
Previously, acceptance was only failing in CI, but not when run locally,
and the failure was that the ca_crt.pem was never rsync'ed to the agent
node:

    WebSocket configuration error (ssl-ca-cert file '/root/test-resources/ssl/ca/ca_crt.pem' not found

I believe the root cause is due to using ssh-agent on the coordinator
node. This step was only necessary so we could git clone the private
pcp-broker repo. Now that the repo is public, the step is not necessary,
and it eliminates having to interact with ssh-agent on the shared CI
coordinator.

This commit also increases the beaker log level so we can see what
commands beaker is executing.