### PR TITLE
(PCP-164) Quote puppet_bin property

### DIFF
--- a/modules/pxp-module-puppet
+++ b/modules/pxp-module-puppet
@@ -27,6 +27,15 @@ def is_win?
   return !!File::ALT_SEPARATOR
 end
 
+def quote(s)
+  quoted = (s[0] == '"' || s[0] == "'")
+  if !quoted && s.include?(' ')
+    '"'+s+'"'
+  else
+    s
+  end
+end
+
 def last_run_result(exitcode)
   return {"kind"             => "unknown",
           "time"             => "unknown",
@@ -38,7 +47,7 @@ def last_run_result(exitcode)
 end
 
 def check_config_print(cli_arg, config)
-  command = "#{config["puppet_bin"]} agent --configprint #{cli_arg}"
+  command = "#{quote(config["puppet_bin"])} agent --configprint #{cli_arg}"
   process_output = Puppet::Util::Execution.execute(command)
   return process_output.to_s.chomp
 end
@@ -62,7 +71,7 @@ def make_environment_hash(params)
 end
 
 def make_command_array(config, params)
-  cmd_array = [config["puppet_bin"], "agent"]
+  cmd_array = [quote(config["puppet_bin"]), "agent"]
   cmd_array +=  params["flags"]
   return cmd_array
 end


### PR DESCRIPTION
If puppet_bin is configured, and contains a space, executing it will
fail attempting to find an executable with the path preceding the space.
Quote unquoted paths with spaces to fix this.