### PR TITLE
(maint) acceptance - replace rsync with scp_to

### DIFF
--- a/acceptance/setup/aio/010_Install.rb
+++ b/acceptance/setup/aio/010_Install.rb
@@ -20,12 +20,10 @@ end
 
 PACKAGES = {
   :redhat => [
-    'puppet',
-    'rsync'
+    'puppet'
   ],
   :debian => [
-    'puppet',
-    'rsync'
+    'puppet'
   ],
 }
 

--- a/acceptance/setup/common/020_Configure_Pxp_Agents.rb
+++ b/acceptance/setup/common/020_Configure_Pxp_Agents.rb
@@ -1,6 +1,6 @@
 step 'Copy test certs to agents'
 agents.each do |agent|
-  rsync_to(agent, '../test-resources', '~/test-resources')
+  scp_to(agent, '../test-resources', 'test-resources')
 end
 
 step 'Create config file'


### PR DESCRIPTION
Previously, acceptance tests were failing in CI due to the lack
of a defined SSH key needed to execute rsync on the test runner.

This commit replaces the call to rsync with the beaker helper
method `scp_to`. Since, beaker manages the SSH keys as part of
the startup process, further mention of the SSH key is not
required.