### PR TITLE
(PCP-164) Quote puppet_bin property

### DIFF
--- a/modules/pxp-module-puppet
+++ b/modules/pxp-module-puppet
@@ -27,15 +27,6 @@ def is_win?
   return !!File::ALT_SEPARATOR
 end
 
-def quote(s)
-  quoted = (s[0] == '"' || s[0] == "'")
-  if !quoted && s.include?(' ')
-    '"'+s+'"'
-  else
-    s
-  end
-end
-
 def last_run_result(exitcode)
   return {"kind"             => "unknown",
           "time"             => "unknown",
@@ -47,8 +38,8 @@ def last_run_result(exitcode)
 end
 
 def check_config_print(cli_arg, config)
-  command = "#{quote(config["puppet_bin"])} agent --configprint #{cli_arg}"
-  process_output = Puppet::Util::Execution.execute(command)
+  command_array = [config["puppet_bin"], "agent", "--configprint", cli_arg]
+  process_output = Puppet::Util::Execution.execute(command_array)
   return process_output.to_s.chomp
 end
 
@@ -71,7 +62,7 @@ def make_environment_hash(params)
 end
 
 def make_command_array(config, params)
-  cmd_array = [quote(config["puppet_bin"]), "agent"]
+  cmd_array = [config["puppet_bin"], "agent"]
   cmd_array +=  params["flags"]
   return cmd_array
 end

--- a/modules/spec/unit/modules/puppet_spec.rb
+++ b/modules/spec/unit/modules/puppet_spec.rb
@@ -26,8 +26,8 @@ describe "pxp-module-puppet" do
 
   describe "check_config_print" do
     it "returns the result of configprint" do
-      cli_str = "puppet agent --configprint value"
-      expect(Puppet::Util::Execution).to receive(:execute).with(cli_str).and_return("value\n")
+      cli_vec = ["puppet", "agent", "--configprint", "value"]
+      expect(Puppet::Util::Execution).to receive(:execute).with(cli_vec).and_return("value\n")
       expect(check_config_print("value", default_config)).to be == "value"
     end
   end


### PR DESCRIPTION
The previous commit added quotes to command created by
 #make_command_array. Passing the quoted result to
Puppet::Util::Execution::execute would cause the result to be quoted
twice.

Here we remove the additional quoting and rely on passing an array to
Puppet::Util::Execution::execute to always take care of executing
correctly on Windows.