### PR TITLE
(maint) Use cpp-pcp-client 1.0.1 in travis and appveyor builds

### DIFF
--- a/.travis_target.sh
+++ b/.travis_target.sh
@@ -24,6 +24,7 @@ fi
 
 git clone https://github.com/puppetlabs/cpp-pcp-client
 cd cpp-pcp-client
+git checkout 1.0.1
 git submodule update --init --recursive
 cmake -DCMAKE_INSTALL_PREFIX=$USERDIR .
 make install -j2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,7 @@ install:
 
   - git clone https://github.com/puppetlabs/cpp-pcp-client
   - cd cpp-pcp-client
+  - git checkout 1.0.1
   - git submodule update --init --recursive
   - ps: mv "C:\Program Files (x86)\Git\bin\sh.exe" "C:\Program Files (x86)\Git\bin\shxx.exe"
   - ps: cmake -G "MinGW Makefiles" -DBOOST_ROOT="C:\tools\boost_1_58_0-x86_64_mingw-w64_4.8.3_win32_seh" -DBOOST_STATIC=ON -DBOOST_NOWIDE_SKIP_TESTS=ON -Wno-dev -DCMAKE_INSTALL_PREFIX=C:\tools .


### PR DESCRIPTION
Here we change from integrating master of cpp-pcp-client to integrating a
released version.

Though this means we may not catch issues integrating master:master, that
should be addressed with a more deliberate build target.