### PR TITLE
(PCP-143) Association acceptance test asserts the correct log entry.

### DIFF
--- a/acceptance/tests/pxp_agent_associate.rb
+++ b/acceptance/tests/pxp_agent_associate.rb
@@ -19,10 +19,16 @@ on agent1, puppet('resource service pxp-agent ensure=running')
 step 'Allow 10 seconds after service start-up for association to complete'
 sleep(10)
 
-success = /INFO.*Successfully established a WebSocket connection with the PCP broker/
+websocket_success = /INFO.*Successfully established a WebSocket connection with the PCP broker/
+association_success = /INFO.*Received associate session response.*success/
 on(agent1, "cat #{log_file}") do |result|
   log_contents = result.stdout
-  assert_match(success, log_contents,
-               "Did not match expected association message '#{success.to_s}' " \
+  step 'Check pxp-agent.log for websocket connection'
+  assert_match(websocket_success, log_contents,
+               "Did not match expected websocket connection message '#{websocket_success.to_s}' " \
+               "in actual pxp-agent.log contents '#{log_contents}'")
+  step 'Check pxp-agent.log for successful association response'
+  assert_match(association_success, log_contents,
+               "Did not match expected association success message '#{association_success.to_s}' " \
                "in actual pxp-agent.log contents '#{log_contents}'")
 end


### PR DESCRIPTION
The test previously only checked for websocket success. It now checks for association succeeding.
The assertion on websocket success has been left in so that in the event of a failure we have more information on when it failed.