### PR TITLE
(PCP-172) Synchronize status metadata writing

### DIFF
--- a/lib/src/modules/status.cc
+++ b/lib/src/modules/status.cc
@@ -2,10 +2,16 @@
 #include <pxp-agent/util/process.hpp>
 #include <pxp-agent/external_module.hpp>    // readNonBlockingOutcome
 
+// #include <cpp-pcp-client/util/thread.hpp>   // this_thread::sleep_for
+// #include <cpp-pcp-client/util/chrono.hpp>
+
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/operations.hpp>
 
+#include <boost/interprocess/sync/named_mutex.hpp>
+
 #include <leatherman/file_util/file.hpp>
+#include <leatherman/util/scope_exit.hpp>
 
 #define LEATHERMAN_LOGGING_NAMESPACE "puppetlabs.pxp_agent.modules.status"
 #include <leatherman/logging/logging.hpp>
@@ -14,15 +20,19 @@
 
 #include <string>
 #include <stdexcept>
+// #include <stdint.h>
 
 namespace PXPAgent {
 namespace Modules {
 
 namespace fs = boost::filesystem;
+namespace ip = boost::interprocess;
 namespace lth_file = leatherman::file_util;
+namespace lth_util = leatherman::util;
 namespace HW = HorseWhisperer;
 
 static const std::string QUERY { "query" };
+// static const uint32_t METADATA_RACE_MS { 50 };
 
 const std::string Status::UNKNOWN { "unknown" };
 const std::string Status::SUCCESS { "success" };
@@ -124,6 +134,8 @@ ActionOutcome Status::callAction(const ActionRequest& request) {
     fs::path spool_path { HW::GetFlag<std::string>("spool-dir") };
     auto results_dir_path = spool_path / t_id;
     results.set<std::string>("transaction_id", t_id);
+
+    // Initialize the job status to 'unknown'
     results.set<std::string>("status", Status::UNKNOWN);
 
     if (!fs::exists(results_dir_path)) {
@@ -134,11 +146,56 @@ ActionOutcome Status::callAction(const ActionRequest& request) {
     LOG_DEBUG("Retrieving results for job %1% from %2%",
               t_id, results_dir_path.string());
 
-    auto metadata_file = (results_dir_path / "metadata").string();
+    bool running_by_pid { false };
+    bool not_running_by_pid { false };
+    auto pid_file = (results_dir_path / "pid").string();
+    std::string pid_txt {};
+    int pid {};
+
+    // Read the PID file before the metadata, to avoid a race in the
+    // non-blocking task thread, due to the elapsed time between the
+    // end of the job and the metadata write
+    if (!fs::exists(pid_file)) {
+        LOG_DEBUG("PID file '%1%' does not exist", pid_file);
+    } else if (!lth_file::read(pid_file, pid_txt)) {
+        LOG_ERROR("Failed to read PID file '%1%'", pid_file);
+    } else if (pid_txt.empty()) {
+        LOG_ERROR("PID file '%1%' is empty", pid_file);
+    } else {
+        try {
+            pid = std::stoi(pid_txt);
+            // NOTE(ale): processExists() does not throw
+            if (Util::processExists(pid)) {
+                // Status will be 'running' if !metadata.completed
+                running_by_pid = true;
+            } else {
+                // We know that the process is not running - wait a
+                // bit before reading the metadata; in case the
+                // non-blocking task wants to write the metadata now,
+                // it will be able to acquire the named mutex lock
+                not_running_by_pid = true;
+                // PCPClient::Util::this_thread::sleep_for(
+                //     PCPClient::Util::chrono::milliseconds(METADATA_RACE_MS));
+            }
+        } catch (const std::invalid_argument& e) {
+            LOG_ERROR("Invalid value '%1%' stored in PID file '%2%'",
+                      pid_txt, pid_file);
+        }
+    }
+
     ActionMetadata metadata {};
+    auto metadata_file = (results_dir_path / "metadata").string();
 
     try {
+        ip::named_mutex mtx { ip::open_or_create, t_id.substr(0, 8).c_str() };
+        mtx.lock();
+        lth_util::scope_exit mtx_cleaner { [&mtx]() { mtx.unlock(); } };
         metadata = ActionMetadata(metadata_file);
+    } catch (const boost::interprocess::interprocess_exception& e) {
+        // TODO(ale): consider reporting back the lock file failure
+        LOG_ERROR("Cannot retrieve metadata from %1% - failed to get the file "
+                  "lock: %2%", metadata_file, e.what());
+        return ActionOutcome { EXIT_SUCCESS, results };
     } catch (const ActionMetadata::Error& e) {
         // The file may not exist, may not be readable, or contain
         // invalid JSON - return "unknown"
@@ -146,51 +203,21 @@ ActionOutcome Status::callAction(const ActionRequest& request) {
         return ActionOutcome { EXIT_SUCCESS, results };
     }
 
-    bool not_running_by_pid { false };
-
+    // At this point, we know that the metadata file is valid
     if (metadata.completed) {
+        // We consider the job as completed, regardless of the PID
         results.set<std::string>(
             "status",
             (metadata.exitcode == EXIT_SUCCESS ? Status::SUCCESS : Status::FAILURE));
-    } else {
-        // The metadata does not report the task as completed, but it
-        // may be due to a previous pxp-agent crash; if the PID file
-        // is available, check if the process is running
-        auto pid_file = (results_dir_path / "pid").string();
-        std::string pid_txt;
-        int pid {};
-
-        if (!fs::exists(pid_file)) {
-            LOG_ERROR("PID file '%1%' does not exist", pid_file);
-        } else if (!lth_file::read(pid_file, pid_txt)) {
-            LOG_ERROR("Failed to read PID file '%1%'", pid_file);
-        } else if (pid_txt.empty()) {
-            LOG_ERROR("PID file '%1%' is empty", pid_file);
-        } else {
-            try {
-                pid = std::stoi(pid_txt);
-                // NOTE(ale): processExists() does not throw
-                if (Util::processExists(pid)) {
-                    results.set<std::string>("status", Status::RUNNING);
-                } else {
-                    // We know that the process is not running, but
-                    // its status is 'unknown'
-                    not_running_by_pid = true;
-                }
-            } catch (const std::invalid_argument& e) {
-                // We didn't manage to get the PID and the metadata
-                // file does not report the action as completed; we
-                // cannot determine the state, so leave it 'unknown'
-                LOG_ERROR("Invalid value '%1%' stored in PID file '%2%'",
-                          pid_txt, pid_file);
-            }
-        }
+    } else if (running_by_pid) {
+        results.set<std::string>("status", Status::RUNNING);
     }
 
     if (metadata.completed || not_running_by_pid) {
-        // The process is either completed (state may be 'failure' or
+        assert(!running_by_pid);
+        // The process is either completed (status may be 'failure' or
         // 'success', depending on the exit code) or not running
-        // (after checking the pid - state is 'unknown'); we can send
+        // (after checking the pid - status is 'unknown'); we can send
         // back the contents of stdout / stderr files
         std::string o;
         std::string e;


### PR DESCRIPTION
With this commit we synchronize reading and writing operations on
transaction status metadata files by non-blocking tasks and status
requests handlers.

The status query action now reads the PID file before accessing the
metadata file. In case the PID is related to an existent process, the
status handler will sleep for 0.1 s, to ensure that the non-blocking
task have the time to acquire the lock that enables writing the metadata.

Both the non-blocking task and status handler use a boost named_mutex to
synchronize the access to the metadata file. Such mutex will be named
after the first 8 letters of the transaction id of the interested
non-blocking task.