### PR TITLE
(PCP-172) Synchronize non-blocking tasks and status handlers

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -15,15 +15,16 @@ set(LIBRARY_COMMON_SOURCES
     src/action_request.cc
     src/agent.cc
     src/configuration.cc
-    src/pxp_connector.cc
     src/external_module.cc
     src/module.cc
+    src/pxp_connector.cc
+    src/pxp_schemas.cc
+    src/request_processor.cc
+    src/results_mutex.cc
+    src/thread_container.cc
     src/modules/echo.cc
     src/modules/ping.cc
     src/modules/status.cc
-    src/request_processor.cc
-    src/pxp_schemas.cc
-    src/thread_container.cc
 )
 
 if (UNIX)

--- a/lib/inc/pxp-agent/results_mutex.hpp
+++ b/lib/inc/pxp-agent/results_mutex.hpp
@@ -33,6 +33,11 @@ class ResultsMutex {
     using Lock = PCPClient::Util::unique_lock<PCPClient::Util::mutex>;
     using LockGuard = PCPClient::Util::lock_guard<PCPClient::Util::mutex>;
 
+    // TODO(ale): update this as soon as we have tagged cpp-pcp-client
+    static constexpr boost::defer_lock_t defer_lock() {
+        return boost::defer_lock_t();
+    };
+
     // Singleton users should lock this class mutex before accessing
     // the cache.
     // Note that the singleton caches shared_ptrs to mutexes; because

--- a/lib/inc/pxp-agent/results_mutex.hpp
+++ b/lib/inc/pxp-agent/results_mutex.hpp
@@ -1,0 +1,69 @@
+#ifndef SRC_AGENT_RESULTS_MUTEX_HPP_
+#define SRC_AGENT_RESULTS_MUTEX_HPP_
+
+#include <cpp-pcp-client/util/thread.hpp>
+
+#include <map>
+#include <string>
+#include <memory>
+#include <stdexcept>
+
+namespace PXPAgent {
+
+// NOTE(ale): this class does not provide general synchronizaion
+// functions; it provides a cache for named mutexes where it is
+// assumed that a single actor (the RequestProcessor instance, in
+// practice) is allowed to add and remove mutexes, whereas all actors
+// (including instances of the Transaction Status request handler) can
+// lock the cached mutexes
+
+class ResultsMutex {
+  public:
+    struct Error : public std::runtime_error {
+        explicit Error(std::string const& msg) : std::runtime_error(msg) {}
+    };
+
+    static ResultsMutex& Instance() {
+        static ResultsMutex instance {};
+        return instance;
+    }
+
+    using Mutex = PCPClient::Util::mutex;
+    using Mutex_Ptr = std::shared_ptr<PCPClient::Util::mutex>;
+    using Lock = PCPClient::Util::unique_lock<PCPClient::Util::mutex>;
+    using LockGuard = PCPClient::Util::lock_guard<PCPClient::Util::mutex>;
+
+    // Singleton users should lock this class mutex before accessing
+    // the cache.
+    // Note that the singleton caches shared_ptrs to mutexes; because
+    // of that, it is safe to use the mutex pointer returned by get()
+    // after releasing the access_mtx lock, even if a concurrent
+    // thread is removing such mutex from the cache.
+    Mutex access_mtx;
+
+    // Useful for testing
+    void reset();
+
+    // Whether the specified transaction mutex exists
+    bool exists(std::string const& transaction_id);
+
+    // Throw Error if transaction_id does not exist
+    Mutex_Ptr get(std::string const& transaction_id);
+
+    // Throw Error if transaction_id exists
+    void add(std::string const& transaction_id);
+
+    // Throw Error if transaction_id does not exist
+    void remove(std::string const& transaction_id);
+
+  private:
+    // Cache
+    std::map<std::string, Mutex_Ptr> mutexes_;
+
+    // Private ctor
+    ResultsMutex();
+};
+
+}  // namespace PXPAgent
+
+#endif  // SRC_AGENT_RESULTS_MUTEX_HPP_

--- a/lib/src/modules/status.cc
+++ b/lib/src/modules/status.cc
@@ -1,6 +1,10 @@
 #include <pxp-agent/modules/status.hpp>
 #include <pxp-agent/util/process.hpp>
 #include <pxp-agent/external_module.hpp>    // readNonBlockingOutcome
+#include <pxp-agent/results_mutex.hpp>
+
+#include <cpp-pcp-client/util/thread.hpp>   // this_thread::sleep_for
+#include <cpp-pcp-client/util/chrono.hpp>
 
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/operations.hpp>
@@ -14,6 +18,7 @@
 
 #include <string>
 #include <stdexcept>
+#include <stdint.h>
 
 namespace PXPAgent {
 namespace Modules {
@@ -21,8 +26,10 @@ namespace Modules {
 namespace fs = boost::filesystem;
 namespace lth_file = leatherman::file_util;
 namespace HW = HorseWhisperer;
+namespace pcp_util = PCPClient::Util;
 
 static const std::string QUERY { "query" };
+static const uint32_t METADATA_RACE_MS { 100 };
 
 const std::string Status::UNKNOWN { "unknown" };
 const std::string Status::SUCCESS { "success" };
@@ -124,6 +131,8 @@ ActionOutcome Status::callAction(const ActionRequest& request) {
     fs::path spool_path { HW::GetFlag<std::string>("spool-dir") };
     auto results_dir_path = spool_path / t_id;
     results.set<std::string>("transaction_id", t_id);
+
+    // Initialize the job status to 'unknown'
     results.set<std::string>("status", Status::UNKNOWN);
 
     if (!fs::exists(results_dir_path)) {
@@ -134,63 +143,102 @@ ActionOutcome Status::callAction(const ActionRequest& request) {
     LOG_DEBUG("Retrieving results for job %1% from %2%",
               t_id, results_dir_path.string());
 
-    auto metadata_file = (results_dir_path / "metadata").string();
+    bool running_by_pid { false };
+    bool not_running_by_pid { false };
+    auto pid_file = (results_dir_path / "pid").string();
+    std::string pid_txt {};
+    int pid {};
+
+    // Read the PID file before the metadata, to avoid a race in the
+    // non-blocking task thread, due to the elapsed time between the
+    // end of the job and the metadata write
+    if (!fs::exists(pid_file)) {
+        LOG_DEBUG("PID file '%1%' does not exist", pid_file);
+    } else if (!lth_file::read(pid_file, pid_txt)) {
+        LOG_ERROR("Failed to read PID file '%1%'", pid_file);
+    } else if (pid_txt.empty()) {
+        LOG_ERROR("PID file '%1%' is empty", pid_file);
+    } else {
+        try {
+            pid = std::stoi(pid_txt);
+            // NOTE(ale): processExists() does not throw
+            if (Util::processExists(pid)) {
+                // NOTE(ale): will set status to 'running' iff
+                // metadata is valid and metadata.completed == false
+                running_by_pid = true;
+            } else {
+                not_running_by_pid = true;
+                bool cached { false };
+                {
+                    ResultsMutex::LockGuard a_l {
+                        ResultsMutex::Instance().access_mtx };  // RAII
+                    cached = ResultsMutex::Instance().exists(t_id);
+                }
+                if (cached) {
+                    // The process doe not exist anymore, but its
+                    // mutex is still cached - wait a bit before
+                    // reading the metadata to allow the non-blocking
+                    // to lock its mutex and update the metadata
+                    pcp_util::this_thread::sleep_for(
+                        pcp_util::chrono::milliseconds(METADATA_RACE_MS));
+                }
+            }
+        } catch (const std::invalid_argument& e) {
+            LOG_ERROR("Invalid value '%1%' stored in PID file '%2%'",
+                      pid_txt, pid_file);
+        }
+    }
+
     ActionMetadata metadata {};
+    auto metadata_file = (results_dir_path / "metadata").string();
 
     try {
-        metadata = ActionMetadata(metadata_file);
+        // Acquire the result mutex lock, if the transaction is cached
+        ResultsMutex::Mutex_Ptr mtx_ptr;
+        {
+            ResultsMutex::LockGuard a_l {
+                ResultsMutex::Instance().access_mtx };  // RAII
+            if (ResultsMutex::Instance().exists(t_id)) {
+                mtx_ptr = ResultsMutex::Instance().get(t_id);
+            }
+        }
+        if (mtx_ptr != nullptr) {
+            LOG_TRACE("Non-blocking transaction %1% mutex is cached; "
+                      "locking it", t_id);
+            ResultsMutex::LockGuard r_l { *mtx_ptr };  // RAII
+            metadata = ActionMetadata(metadata_file);
+        } else {
+            LOG_TRACE("Non-blocking transaction %1% mutex is not cached", t_id);
+            metadata = ActionMetadata(metadata_file);
+        }
     } catch (const ActionMetadata::Error& e) {
+        // TODO(ale): consider reporting back the read failure
         // The file may not exist, may not be readable, or contain
         // invalid JSON - return "unknown"
         LOG_ERROR("Cannot retrieve metadata from %1%: %2%", metadata_file, e.what());
         return ActionOutcome { EXIT_SUCCESS, results };
+    } catch (const std::exception& e) {
+        // Unexpected as we locked access_mtx before getting the mutex
+        LOG_ERROR("Unexpected failure while retrieving metadata from %1%: %2%",
+                  metadata_file, e.what());
+        return ActionOutcome { EXIT_SUCCESS, results };
     }
 
-    bool not_running_by_pid { false };
-
+    // At this point, we know that the metadata file is valid
     if (metadata.completed) {
+        // We consider the job completed, regardless of the PID
         results.set<std::string>(
             "status",
             (metadata.exitcode == EXIT_SUCCESS ? Status::SUCCESS : Status::FAILURE));
-    } else {
-        // The metadata does not report the task as completed, but it
-        // may be due to a previous pxp-agent crash; if the PID file
-        // is available, check if the process is running
-        auto pid_file = (results_dir_path / "pid").string();
-        std::string pid_txt;
-        int pid {};
-
-        if (!fs::exists(pid_file)) {
-            LOG_ERROR("PID file '%1%' does not exist", pid_file);
-        } else if (!lth_file::read(pid_file, pid_txt)) {
-            LOG_ERROR("Failed to read PID file '%1%'", pid_file);
-        } else if (pid_txt.empty()) {
-            LOG_ERROR("PID file '%1%' is empty", pid_file);
-        } else {
-            try {
-                pid = std::stoi(pid_txt);
-                // NOTE(ale): processExists() does not throw
-                if (Util::processExists(pid)) {
-                    results.set<std::string>("status", Status::RUNNING);
-                } else {
-                    // We know that the process is not running, but
-                    // its status is 'unknown'
-                    not_running_by_pid = true;
-                }
-            } catch (const std::invalid_argument& e) {
-                // We didn't manage to get the PID and the metadata
-                // file does not report the action as completed; we
-                // cannot determine the state, so leave it 'unknown'
-                LOG_ERROR("Invalid value '%1%' stored in PID file '%2%'",
-                          pid_txt, pid_file);
-            }
-        }
+    } else if (running_by_pid) {
+        results.set<std::string>("status", Status::RUNNING);
     }
 
     if (metadata.completed || not_running_by_pid) {
-        // The process is either completed (state may be 'failure' or
+        assert(!running_by_pid);
+        // The process is either completed (status may be 'failure' or
         // 'success', depending on the exit code) or not running
-        // (after checking the pid - state is 'unknown'); we can send
+        // (after checking the pid - status is 'unknown'); we can send
         // back the contents of stdout / stderr files
         std::string o;
         std::string e;

--- a/lib/src/request_processor.cc
+++ b/lib/src/request_processor.cc
@@ -203,7 +203,7 @@ void RequestProcessor::processRequest(const RequestType& request_type,
             return;
         }
 
-        LOG_DEBUG("%1% request, transaction %2%, has been successfully validated",
+        LOG_DEBUG("The %1% request, transaction %2%, has been successfully validated",
                   requestTypeNames[request_type], request.transactionId());
 
         try {
@@ -212,7 +212,7 @@ void RequestProcessor::processRequest(const RequestType& request_type,
             } else {
                 processNonBlockingRequest(request);
             }
-            LOG_DEBUG("%1% request %2% by %3%, transaction %4%, has been "
+            LOG_DEBUG("The %1% request %2% by %3%, transaction %4%, has been "
                       "successfully processed", requestTypeNames[request_type],
                      request.id(), request.sender(), request.transactionId());
         } catch (std::exception& e) {

--- a/lib/src/request_processor.cc
+++ b/lib/src/request_processor.cc
@@ -134,7 +134,8 @@ void nonBlockingActionTask(std::shared_ptr<Module> module_ptr,
     try {
         ResultsMutex::LockGuard a_l { ResultsMutex::Instance().access_mtx };
         mtx_ptr = ResultsMutex::Instance().get(transaction_id);
-        lck_ptr.reset(new ResultsMutex::Lock(*mtx_ptr, pcp_util::defer_lock));
+        // TODO(ale): update defer_lock to cpp-pcp-client const
+        lck_ptr.reset(new ResultsMutex::Lock(*mtx_ptr, ResultsMutex::defer_lock()));
     } catch (const ResultsMutex::Error& e) {
         // This is unexpected
         LOG_ERROR("Failed to obtain the mutex pointer for transaction %1%: %2%",

--- a/lib/src/results_mutex.cc
+++ b/lib/src/results_mutex.cc
@@ -1,0 +1,53 @@
+#include <pxp-agent/results_mutex.hpp>
+
+#include <cpp-pcp-client/util/chrono.hpp>
+
+#define LEATHERMAN_LOGGING_NAMESPACE "puppetlabs.pxp_agent.results_mutex"
+#include <leatherman/logging/logging.hpp>
+
+namespace PXPAgent {
+
+// Private ctor
+
+ResultsMutex::ResultsMutex()
+        : access_mtx {},
+          mutexes_ {} {
+}
+
+// Public interface
+
+void ResultsMutex::reset() {
+    LockGuard a_lck { access_mtx };
+    mutexes_.clear();
+}
+
+bool ResultsMutex::exists(std::string const& transaction_id) {
+    return (mutexes_.find(transaction_id) != mutexes_.end());
+}
+
+ResultsMutex::Mutex_Ptr ResultsMutex::get(std::string const& transaction_id) {
+    if (!exists(transaction_id)) {
+        throw Error { "does not exists" };
+    }
+    return mutexes_[transaction_id];
+}
+
+void ResultsMutex::add(std::string const& transaction_id) {
+    LOG_TRACE("Adding transaction id %1%", transaction_id);
+    if (exists(transaction_id)) {
+        throw Error { "already exists" };
+    }
+    auto mtx = std::make_shared<Mutex>();
+    mutexes_.emplace(transaction_id, mtx);
+}
+
+void ResultsMutex::remove(std::string const& transaction_id) {
+    LOG_TRACE("Removing transaction id %1%", transaction_id);
+    if (!exists(transaction_id)) {
+        throw Error { "does not exist" };
+    }
+    mutexes_.erase(transaction_id);
+}
+
+
+}  // namespace PXPAgent

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ set(COMMON_TEST_SOURCES
     unit/external_module_test.cc
     unit/module_test.cc
     unit/request_processor_test.cc
+    unit/results_mutex_test.cc
     unit/thread_container_test.cc
     unit/modules/ping_test.cc
     unit/modules/status_test.cc

--- a/lib/tests/unit/results_mutex_test.cc
+++ b/lib/tests/unit/results_mutex_test.cc
@@ -27,8 +27,9 @@ TEST_CASE("ResultsMutex::get", "[async]") {
     SECTION("can lock with the returned mutex pointer") {
         ResultsMutex::Instance().add("spam");
         ResultsMutex::Mutex_Ptr mtx_ptr;
+        // TODO(ale): update defer_lock to cpp-pcp-client const
         ResultsMutex::Lock lck { ResultsMutex::Instance().access_mtx,
-                                 PCPClient::Util::defer_lock };
+                                 ResultsMutex::defer_lock() };
         REQUIRE_FALSE(lck.owns_lock());
         lck.lock();
         REQUIRE(lck.owns_lock());

--- a/lib/tests/unit/results_mutex_test.cc
+++ b/lib/tests/unit/results_mutex_test.cc
@@ -1,0 +1,83 @@
+#include <pxp-agent/results_mutex.hpp>
+
+#include <cpp-pcp-client/util/thread.hpp>
+
+#include <catch.hpp>
+
+namespace PXPAgent {
+
+TEST_CASE("ResultsMutex::exists", "[async]") {
+    ResultsMutex::Instance().reset();
+
+    SECTION("returns false correctly") {
+        ResultsMutex::LockGuard lck { ResultsMutex::Instance().access_mtx };
+        REQUIRE_FALSE(ResultsMutex::Instance().exists("spam"));
+    }
+
+    SECTION("returns true correctly") {
+        ResultsMutex::Instance().add("beans");
+        ResultsMutex::LockGuard lck { ResultsMutex::Instance().access_mtx };
+        REQUIRE(ResultsMutex::Instance().exists("beans"));
+    }
+}
+
+TEST_CASE("ResultsMutex::get", "[async]") {
+    ResultsMutex::Instance().reset();
+
+    SECTION("can lock with the returned mutex pointer") {
+        ResultsMutex::Instance().add("spam");
+        ResultsMutex::Mutex_Ptr mtx_ptr;
+        ResultsMutex::Lock lck { ResultsMutex::Instance().access_mtx,
+                                 PCPClient::Util::defer_lock };
+        REQUIRE_FALSE(lck.owns_lock());
+        lck.lock();
+        REQUIRE(lck.owns_lock());
+        mtx_ptr = ResultsMutex::Instance().get("spam");
+        lck.unlock();
+        REQUIRE_FALSE(lck.owns_lock());
+        REQUIRE_NOTHROW(ResultsMutex::LockGuard(*mtx_ptr));
+    }
+
+    SECTION("throws an error if the named mutex doesn't exist") {
+        ResultsMutex::LockGuard lck { ResultsMutex::Instance().access_mtx };
+        REQUIRE_FALSE(ResultsMutex::Instance().exists("eggs"));
+        REQUIRE_THROWS_AS(ResultsMutex::Instance().get("eggs"),
+                          ResultsMutex::Error);
+    }
+}
+
+TEST_CASE("ResultsMutex::add", "[async]") {
+    ResultsMutex::Instance().reset();
+
+    SECTION("can add") {
+        REQUIRE_NOTHROW(ResultsMutex::Instance().add("foo"));
+        REQUIRE(ResultsMutex::Instance().exists("foo"));
+    }
+
+    SECTION("throws an error when adding duplicates") {
+        ResultsMutex::Instance().add("bar");
+        REQUIRE_THROWS_AS(ResultsMutex::Instance().add("bar"),
+                          ResultsMutex::Error);
+    }
+}
+
+TEST_CASE("ResultsMutex::remove", "[async]") {
+    ResultsMutex::Instance().reset();
+
+    SECTION("can remove") {
+        ResultsMutex::Instance().add("spam");
+        REQUIRE(ResultsMutex::Instance().exists("spam"));
+        REQUIRE_NOTHROW(ResultsMutex::Instance().remove("spam"));
+        REQUIRE_FALSE(ResultsMutex::Instance().exists("spam"));
+
+        REQUIRE_NOTHROW(ResultsMutex::Instance().add("foo"));
+    }
+
+    SECTION("throws an error if the named mutex doesn't exist") {
+        REQUIRE_FALSE(ResultsMutex::Instance().exists("eggs"));
+        REQUIRE_THROWS_AS(ResultsMutex::Instance().remove("eggs"),
+                          ResultsMutex::Error);
+    }
+}
+
+}  // namespace PXPAgent


### PR DESCRIPTION
With this commit we synchronize reading and writing operations on
transaction status metadata files by non-blocking tasks and status
requests handlers.

The status query action now reads the PID file before accessing the
metadata file. In case the PID is related to a non-existent process, and
its mutex is still in the cache, the status handler will sleep for 0.1 s,
to ensure that the non-blocking task has the time to lock the mutex
and update the metadata file.

The synchronization relies on the ResultsMutex singleton that caches
mutexes named against transaction IDs.