### PR TITLE
(PCP-169) Acceptance tests should not use sed

### DIFF
--- a/acceptance/lib/pxp-agent/config_helper.rb
+++ b/acceptance/lib/pxp-agent/config_helper.rb
@@ -1,0 +1,151 @@
+# This file contains common strings and functions for pxp-agent acceptance tests to use
+
+PXP_CONFIG_DIR_CYGPATH = '/cygdrive/c/ProgramData/PuppetLabs/pxp-agent/etc/'
+PXP_CONFIG_DIR_POSIX = '/etc/puppetlabs/pxp-agent/'
+
+PCP_BROKER_PORT = 8142
+
+SSL_BASE_DIR_WINDOWS = "C:\\\\cygwin64\\\\home\\\\Administrator\\\\test-resources\\\\ssl\\\\"
+SSL_BASE_DIR_POSIX = "/root/test-resources/ssl/"
+ALT_SSL_BASE_DIR_WINDOWS = "C:\\\\cygwin64\\\\home\\\\Administrator\\\\test-resources\\\\ssl\\\\alternative\\\\"
+ALT_SSL_BASE_DIR_POSIX = "/root/test-resources/ssl/alternative/"
+SSL_KEY_FILE_DIR_WINDOWS = "private_keys\\\\"
+SSL_KEY_FILE_DIR_POSIX = "private_keys/"
+SSL_CA_FILE_DIR_WINDOWS = "ca\\\\"
+SSL_CA_FILE_DIR_POSIX = "ca/"
+SSL_CERT_FILE_DIR_WINDOWS = "certs\\\\"
+SSL_CERT_FILE_DIR_POSIX = "certs/"
+
+def left_pad_with_zero(number)
+  if (number.to_s.length == 1)
+    "0#{number}"
+  else
+    number
+  end
+end
+
+def windows?(host)
+  host.platform.upcase.start_with?('WINDOWS')
+end
+
+# @param broker_host the host name or beaker host object for the pcp-broker host
+# @return the broker-ws-uri config string
+def broker_ws_uri(broker_host)
+  "wss://#{master}:#{PCP_BROKER_PORT}/pcp/"
+end
+
+# @param host the beaker host (to determine the correct path for the OS)
+# @return path to the pxp-agent.conf file for that host (a cygpath in the case of Windows)
+def pxp_agent_config_file(host)
+  windows?(host)?
+    "#{PXP_CONFIG_DIR_CYGPATH}pxp-agent.conf" :
+    "#{PXP_CONFIG_DIR_POSIX}pxp-agent.conf"
+end
+
+def ssl_key_file_windows(client_number)
+  client_number = left_pad_with_zero(client_number)
+  "#{SSL_BASE_DIR_WINDOWS}#{SSL_KEY_FILE_DIR_WINDOWS}client#{client_number}.example.com.pem"
+end
+
+def ssl_key_file_posix(client_number)
+  client_number = left_pad_with_zero(client_number)
+  "#{SSL_BASE_DIR_POSIX}#{SSL_KEY_FILE_DIR_POSIX}client#{client_number}.example.com.pem"
+end
+
+# @param host a beaker host (to determine the correct path for the OS)
+# @param client_number which client 01-05 you want the key file for
+# @return the path to the client ssl key file on this host
+def ssl_key_file(host, client_number)
+  windows?(host)?
+    ssl_key_file_windows(client_number) :
+    ssl_key_file_posix(client_number)
+end
+
+def alt_ssl_key_file_windows(client_number)
+  client_number = left_pad_with_zero(client_number)
+  "#{ALT_SSL_BASE_DIR_WINDOWS}#{SSL_KEY_FILE_DIR_WINDOWS}client#{client_number}.alt.example.com.pem"
+end
+
+def alt_ssl_key_file_posix(client_number)
+  client_number = left_pad_with_zero(client_number)
+  "#{ALT_SSL_BASE_DIR_POSIX}#{SSL_KEY_FILE_DIR_POSIX}client#{client_number}.alt.example.com.pem"
+end
+
+# @param host the beaker host (to determine the correct path for the OS)
+# @param client_number which client 01-05 you want the key file for
+# @return the path to the alternative client ssl key file on this host
+def alt_ssl_key_file(host, client_number)
+  windows?(host)?
+    alt_ssl_key_file_windows(client_number) :
+    alt_ssl_key_file_posix(client_number)
+end
+
+def ssl_ca_file_windows
+  "#{SSL_BASE_DIR_WINDOWS}#{SSL_CA_FILE_DIR_WINDOWS}ca_crt.pem"
+end
+
+def ssl_ca_file_posix
+  "#{SSL_BASE_DIR_POSIX}#{SSL_CA_FILE_DIR_POSIX}ca_crt.pem"
+end
+
+# @param host the beaker host (to determine the correct path for the OS)
+# @return the path to the ssl ca file on this host
+def ssl_ca_file(host)
+  windows?(host)?
+    ssl_ca_file_windows :
+    ssl_ca_file_posix
+end
+
+def alt_ssl_ca_file_windows
+  "#{ALT_SSL_BASE_DIR_WINDOWS}#{SSL_CA_FILE_DIR_WINDOWS}ca_crt.pem"
+end
+
+def alt_ssl_ca_file_posix
+  "#{ALT_SSL_BASE_DIR_POSIX}#{SSL_CA_FILE_DIR_POSIX}ca_crt.pem"
+end
+
+# @param host the beaker host (to determine the correct path for the OS)
+# @return the path to the alternative ssl ca file on this host
+def alt_ssl_ca_file(host)
+  windows?(host)?
+    alt_ssl_ca_file_windows :
+    alt_ssl_ca_file_posix
+end
+
+def ssl_cert_file_windows(client_number)
+  client_number = left_pad_with_zero(client_number)
+  "#{SSL_BASE_DIR_WINDOWS}#{SSL_CERT_FILE_DIR_WINDOWS}client#{client_number}.example.com.pem"
+end
+
+def ssl_cert_file_posix(client_number)
+  client_number = left_pad_with_zero(client_number)
+  "#{SSL_BASE_DIR_POSIX}#{SSL_CERT_FILE_DIR_POSIX}client#{client_number}.example.com.pem"
+end
+
+# @param host the beaker host (to determine the correct path for the OS)
+# @param client_number which client 01-05 you want the key file for
+# @return the path to the ssl cert for this client on this host
+def ssl_cert_file(host, client_number)
+  windows?(host)?
+    ssl_cert_file_windows(client_number) :
+    ssl_cert_file_posix(client_number)
+end
+
+def alt_ssl_cert_file_windows(client_number)
+  client_number = left_pad_with_zero(client_number)
+  "#{ALT_SSL_BASE_DIR_WINDOWS}#{SSL_CERT_FILE_DIR_WINDOWS}client#{client_number}.alt.example.com.pem"
+end
+
+def alt_ssl_cert_file_posix(client_number)
+  client_number = left_pad_with_zero(client_number)
+  "#{ALT_SSL_BASE_DIR_POSIX}#{SSL_CERT_FILE_DIR_POSIX}client#{client_number}.alt.example.com.pem"
+end
+
+# @param host the beaker host (to determine the correct path for the OS)
+# @param client_number which client 01-05 you want the key file for
+# @return the path to the alternative ssl cert for this client on this host
+def alt_ssl_cert_file(host, client_number)
+  windows?(host)?
+    alt_ssl_cert_file_windows(client_number) :
+    alt_ssl_cert_file_posix(client_number)
+end

--- a/acceptance/lib/pxp-agent/config_helper.rb
+++ b/acceptance/lib/pxp-agent/config_helper.rb
@@ -1,3 +1,4 @@
+require 'json'
 # This file contains common strings and functions for pxp-agent acceptance tests to use
 
 PXP_CONFIG_DIR_CYGPATH = '/cygdrive/c/ProgramData/PuppetLabs/pxp-agent/etc/'
@@ -26,6 +27,86 @@ end
 
 def windows?(host)
   host.platform.upcase.start_with?('WINDOWS')
+end
+
+# @param broker the host that runs pcp-broker
+# @param agent the agent machine that this config is for
+# @param client_number which client cert 01-05 to use
+# @return pxp-agent config as a JSON object
+def pxp_config_json(broker, agent, client_number)
+  pxp_config_hash(broker, agent, client_number).to_json
+end
+
+# @param broker the host that runs pcp-broker
+# @param agent the agent machine that this config is for
+# @param client_number which client cert 01-05 to use
+# @return pxp-agent config as a hash
+def pxp_config_hash(broker, agent, client_number)
+  { "broker-ws-uri" => "#{broker_ws_uri(broker)}",
+    "ssl-key" => "#{ssl_key_file(agent, client_number)}",
+    "ssl-ca-cert" => "#{ssl_ca_file(agent)}",
+    "ssl-cert" => "#{ssl_cert_file(agent, client_number)}"
+  }
+end
+
+# @param broker the host that runs pcp-broker
+# @param agent the agent machine that this config is for
+# @param client_number which alternative client cert 01-05 to use
+# @return pxp-agent config, using the alternative set of ssl certs, as a JSON object
+def pxp_alternative_ssl_config_json(broker, agent, client_number)
+  pxp_alternative_ssl_config_hash(broker, agent, client_number).to_json
+end
+
+# @param broker the host that runs pcp-broker
+# @param agent the agent machine that this config is for
+# @param client_number which alternative client cert 01-05 to use
+# @return pxp-agent config, using the alternative set of ssl certs, as a hash
+def pxp_alternative_ssl_config_hash(broker, agent, client_number)
+  { "broker-ws-uri" => "#{broker_ws_uri(broker)}",
+    "ssl-key" => "#{alt_ssl_key_file(agent, client_number)}",
+    "ssl-ca-cert" => "#{alt_ssl_ca_file(agent)}",
+    "ssl-cert" => "#{alt_ssl_cert_file(agent, client_number)}"
+  }
+end
+
+# @param broker the host that runs pcp-broker
+# @param agent the agent machine that this config is for
+# @param client_number which client cert 01-05 to use
+# @return pxp-agent config, with intentionally mismatching ssl cert and key, as a JSON object
+def pxp_invalid_config_mismatching_keys_json(broker, agent, client_number)
+  pxp_invalid_config_mismatching_keys_hash(broker, agent, client_number).to_json
+end
+
+# @param broker the host that runs pcp-broker
+# @param agent the agent machine that this config is for
+# @param client_number which client cert 01-05 to use
+# @return pxp-agent config, with intentionally mismatching ssl cert and key, as a hash
+def pxp_invalid_config_mismatching_keys_hash(broker, agent, client_number)
+  { "broker-ws-uri" => "#{broker_ws_uri(broker)}",
+    "ssl-key" => "#{ssl_key_file(agent, client_number)}",
+    "ssl-ca-cert" => "#{ssl_ca_file(agent)}",
+    "ssl-cert" => "#{alt_ssl_cert_file(agent, client_number)}"
+  }
+end
+
+# @param broker the host that runs pcp-broker
+# @param agent the agent machine that this config is for
+# @param client_number which client cert 01-05 to use
+# @return pxp-agent config, with ssl ca cert intentionally not matching its ssl cert and key, as a JSON object
+def pxp_invalid_config_wrong_ca_json(broker, agent, client_number)
+  pxp_invalid_config_wrong_ca_hash(broker, agent, client_number).to_json
+end
+
+# @param broker the host that runs pcp-broker
+# @param agent the agent machine that this config is for
+# @param client_number which client cert 01-05 to use
+# @return pxp-agent config, with ssl ca cert intentionally not matching its ssl cert and key, as a hash
+def pxp_invalid_config_wrong_ca_hash(broker, agent, client_number)
+  { "broker-ws-uri" => "#{broker_ws_uri(broker)}",
+    "ssl-key" => "#{alt_ssl_key_file(agent, client_number)}",
+    "ssl-ca-cert" => "#{ssl_ca_file(agent)}",
+    "ssl-cert" => "#{alt_ssl_cert_file(agent, client_number)}"
+  }
 end
 
 # @param broker_host the host name or beaker host object for the pcp-broker host

--- a/acceptance/lib/pxp-agent/config_helper.rb
+++ b/acceptance/lib/pxp-agent/config_helper.rb
@@ -4,6 +4,9 @@ require 'json'
 PXP_CONFIG_DIR_CYGPATH = '/cygdrive/c/ProgramData/PuppetLabs/pxp-agent/etc/'
 PXP_CONFIG_DIR_POSIX = '/etc/puppetlabs/pxp-agent/'
 
+PXP_LOG_FILE_CYGPATH = '/cygdrive/c/ProgramData/PuppetLabs/pxp-agent/var/log/pxp-agent.log'
+PXP_LOG_FILE_POSIX = '/var/log/puppetlabs/pxp-agent/pxp-agent.log'
+
 PCP_BROKER_PORT = 8142
 
 SSL_BASE_DIR_WINDOWS = "C:\\\\cygwin64\\\\home\\\\Administrator\\\\test-resources\\\\ssl\\\\"
@@ -113,6 +116,14 @@ end
 # @return the broker-ws-uri config string
 def broker_ws_uri(broker_host)
   "wss://#{master}:#{PCP_BROKER_PORT}/pcp/"
+end
+
+# @param host the beaker host you want the path to the log file on
+# @return The path to the log file on the host. For Windows, a cygpath is returned
+def logfile(host)
+  windows?(host)?
+    PXP_LOG_FILE_CYGPATH :
+    PXP_LOG_FILE_POSIX
 end
 
 # @param host the beaker host (to determine the correct path for the OS)

--- a/acceptance/setup/common/020_Configure_Pxp_Agents.rb
+++ b/acceptance/setup/common/020_Configure_Pxp_Agents.rb
@@ -8,5 +8,5 @@ end
 
 step 'Create config file'
 agents.each_with_index do |agent, i|
-  create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json(master, agent, i+1).to_s)
+  create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_test_certs(master, agent, i+1).to_s)
 end

--- a/acceptance/setup/common/020_Configure_Pxp_Agents.rb
+++ b/acceptance/setup/common/020_Configure_Pxp_Agents.rb
@@ -1,29 +1,19 @@
+require 'pxp-agent/config_helper.rb'
+
 step 'Copy test certs to agents'
 agents.each do |agent|
   scp_to(agent, '../test-resources', 'test-resources')
 end
 
 step 'Create config file'
-agents.each do |agent|
-  if (agent.platform.upcase.start_with?('WINDOWS'))
-    config = <<OUTPUT
+agents.each_with_index do |agent, i|
+  config = <<OUTPUT
 {
-  "broker-ws-uri" : "wss://#{master}:8142/pcp/",
-  "ssl-key" : "C:\\\\cygwin64\\\\home\\\\Administrator\\\\test-resources\\\\ssl\\\\private_keys\\\\client01.example.com.pem",
-  "ssl-ca-cert" : "C:\\\\cygwin64\\\\home\\\\Administrator\\\\test-resources\\\\ssl\\\\ca\\\\ca_crt.pem",
-  "ssl-cert" : "C:\\\\cygwin64\\\\home\\\\Administrator\\\\test-resources\\\\ssl\\\\certs\\\\client01.example.com.pem"
+  "broker-ws-uri" : "#{broker_ws_uri(master)}",
+  "ssl-key" : "#{ssl_key_file(agent, i+1)}",
+  "ssl-ca-cert" : "#{ssl_ca_file(agent)}",
+  "ssl-cert" : "#{ssl_cert_file(agent, i+1)}"
 }
 OUTPUT
-    create_remote_file(agent, '/cygdrive/c/ProgramData/PuppetLabs/pxp-agent/etc/pxp-agent.conf', config)
-  else
-    config = <<OUTPUT
-{
-  "broker-ws-uri" : "wss://#{master}:8142/pcp/",
-  "ssl-key" : "/root/test-resources/ssl/private_keys/client01.example.com.pem",
-  "ssl-ca-cert" : "/root/test-resources/ssl/ca/ca_crt.pem",
-  "ssl-cert" : "/root/test-resources/ssl/certs/client01.example.com.pem"
-}
-OUTPUT
-    create_remote_file(agent, '/etc/puppetlabs/pxp-agent/pxp-agent.conf', config)
-  end
+  create_remote_file(agent, pxp_agent_config_file(agent), config)
 end

--- a/acceptance/setup/common/020_Configure_Pxp_Agents.rb
+++ b/acceptance/setup/common/020_Configure_Pxp_Agents.rb
@@ -1,4 +1,5 @@
 require 'pxp-agent/config_helper.rb'
+require 'json'
 
 step 'Copy test certs to agents'
 agents.each do |agent|
@@ -7,13 +8,5 @@ end
 
 step 'Create config file'
 agents.each_with_index do |agent, i|
-  config = <<OUTPUT
-{
-  "broker-ws-uri" : "#{broker_ws_uri(master)}",
-  "ssl-key" : "#{ssl_key_file(agent, i+1)}",
-  "ssl-ca-cert" : "#{ssl_ca_file(agent)}",
-  "ssl-cert" : "#{ssl_cert_file(agent, i+1)}"
-}
-OUTPUT
-  create_remote_file(agent, pxp_agent_config_file(agent), config)
+  create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json(master, agent, i+1).to_s)
 end

--- a/acceptance/tests/pxp_agent_associate.rb
+++ b/acceptance/tests/pxp_agent_associate.rb
@@ -2,16 +2,11 @@ test_name 'C93807 - Associate pxp-agent with a PCP broker'
 
 agent1 = agents[0]
 
-log_file = ''
-agent1.platform.start_with?('windows') ?
-  log_file = '/cygdrive/c/ProgramData/PuppetLabs/pxp-agent/var/log/pxp-agent.log' :
-  log_file = '/var/log/puppetlabs/pxp-agent/pxp-agent.log'
-
 step 'Stop pxp-agent if it is currently running'
 on agent1, puppet('resource service pxp-agent ensure=stopped')
 
 step 'Clear existing logs so we don\'t match an existing association entry'
-on(agent1, "rm -rf #{log_file}")
+on(agent1, "rm -rf #{logfile(agent1)}")
 
 step 'Start pxp-agent service'
 on agent1, puppet('resource service pxp-agent ensure=running')
@@ -21,7 +16,7 @@ sleep(10)
 
 websocket_success = /INFO.*Successfully established a WebSocket connection with the PCP broker/
 association_success = /INFO.*Received associate session response.*success/
-on(agent1, "cat #{log_file}") do |result|
+on(agent1, "cat #{logfile(agent1)}") do |result|
   log_contents = result.stdout
   step 'Check pxp-agent.log for websocket connection'
   assert_match(websocket_success, log_contents,

--- a/acceptance/tests/service_stop_start.rb
+++ b/acceptance/tests/service_stop_start.rb
@@ -1,15 +1,13 @@
+require 'pxp-agent/config_helper.rb'
+
 test_name 'Service Start stop/start, with configuration)'
 @agent1 = agents[0]
-@pxp_conf_file = '/etc/puppetlabs/pxp-agent/pxp-agent.conf'
-if @agent1.platform.start_with?('windows')
-  @pxp_conf_file = '/cygdrive/c/ProgramData/PuppetLabs/pxp-agent/etc/pxp-agent.conf'
-end
 @pxp_temp_file = '~/pxp-agent.conf'
 
 # On teardown, restore configuration file
 teardown do
   if @agent1.file_exist?(@pxp_temp_file)
-    on(@agent1, "mv #{@pxp_temp_file} #{@pxp_conf_file}")
+    on(@agent1, "mv #{@pxp_temp_file} #{pxp_agent_config_file(@agent1)}")
   end
 end
 
@@ -47,7 +45,7 @@ assert_stopped
 
 step 'Remove configuration'
 stop_service
-on(@agent1, "mv #{@pxp_conf_file} #{@pxp_temp_file}")
+on(@agent1, "mv #{pxp_agent_config_file(@agent1)} #{@pxp_temp_file}")
 
 step 'C94686 - Service Start (from stopped, un-configured)'
 start_service
@@ -58,4 +56,4 @@ stop_service
 assert_stopped
 
 step 'Restore configuration'
-on(@agent1, "mv #{@pxp_temp_file} #{@pxp_conf_file}")
+on(@agent1, "mv #{@pxp_temp_file} #{pxp_agent_config_file(@agent1)}")


### PR DESCRIPTION
Tests fail on some supported platforms due to the use of 'sed -i'.
This PR adds a helper lib file to provide constants and helper methods for pxp-agent. This includes helper methods to generate pxp-agent config JSON.
The sed statements that altered pxp-agent.conf have been replaced with beaker helper methods that replace the config file's content with generated JSON.