### PR TITLE
Use lastrunreport setting instead of guessed value

### DIFF
--- a/modules/pxp-module-puppet
+++ b/modules/pxp-module-puppet
@@ -75,8 +75,7 @@ def make_error_result(exitcode, error_type, error_message)
 end
 
 def get_result_from_report(exitcode, config, start_time)
-  last_run_report = File.join(check_config_print("statedir",config),
-                              "last_run_report.yaml")
+  last_run_report = check_config_print("lastrunreport",config)
 
   if !File.exist?(last_run_report)
     return make_error_result(exitcode, Errors::NoLastRunReport,

--- a/modules/spec/unit/modules/puppet_spec.rb
+++ b/modules/spec/unit/modules/puppet_spec.rb
@@ -104,7 +104,7 @@ describe "pxp-module-puppet" do
   describe "get_result_from_report" do
     it "doesn't process the last_run_report if the file doens't exist" do
       allow(File).to receive(:exist?).and_return(false)
-      allow_any_instance_of(Object).to receive(:check_config_print).and_return("/opt/puppetlabs/puppet/cache/state/")
+      allow_any_instance_of(Object).to receive(:check_config_print).and_return("/opt/puppetlabs/puppet/cache/state/last_run_report.yaml")
       expect(get_result_from_report(0, default_config, Time.now)).to be ==
           {"kind"             => "unknown",
            "time"             => "unknown",
@@ -119,7 +119,7 @@ describe "pxp-module-puppet" do
 
     it "doesn't process the last_run_report if the file cant be loaded" do
       allow(File).to receive(:exist?).and_return(true)
-      allow_any_instance_of(Object).to receive(:check_config_print).and_return("/opt/puppetlabs/puppet/cache/state/")
+      allow_any_instance_of(Object).to receive(:check_config_print).and_return("/opt/puppetlabs/puppet/cache/state/last_run_report.yaml")
       allow(YAML).to receive(:load_file).and_raise("error")
       expect(get_result_from_report(0, default_config, Time.now)).to be ==
           {"kind"             => "unknown",
@@ -145,7 +145,7 @@ describe "pxp-module-puppet" do
       allow(last_run_report).to receive(:status).and_return("changed")
 
       allow(File).to receive(:exist?).and_return(true)
-      allow_any_instance_of(Object).to receive(:check_config_print).and_return("/opt/puppetlabs/puppet/cache/state/")
+      allow_any_instance_of(Object).to receive(:check_config_print).and_return("/opt/puppetlabs/puppet/cache/state/last_run_report.yaml")
       allow(YAML).to receive(:load_file).and_return(last_run_report)
 
       expect(get_result_from_report(-1, default_config, start_time)).to be ==
@@ -172,7 +172,7 @@ describe "pxp-module-puppet" do
       allow(last_run_report).to receive(:status).and_return("changed")
 
       allow(File).to receive(:exist?).and_return(true)
-      allow_any_instance_of(Object).to receive(:check_config_print).and_return("/opt/puppetlabs/puppet/cache/state/")
+      allow_any_instance_of(Object).to receive(:check_config_print).and_return("/opt/puppetlabs/puppet/cache/state/last_run_report.yaml")
       allow(YAML).to receive(:load_file).and_return(last_run_report)
 
       expect(get_result_from_report(-1, default_config, start_time)).to be ==
@@ -199,7 +199,7 @@ describe "pxp-module-puppet" do
       allow(last_run_report).to receive(:status).and_return("changed")
 
       allow(File).to receive(:exist?).and_return(true)
-      allow_any_instance_of(Object).to receive(:check_config_print).and_return("/opt/puppetlabs/puppet/cache/state/")
+      allow_any_instance_of(Object).to receive(:check_config_print).and_return("/opt/puppetlabs/puppet/cache/state/last_run_report.yaml")
       allow(YAML).to receive(:load_file).and_return(last_run_report)
 
       expect(get_result_from_report(0, default_config, start_time)).to be ==


### PR DESCRIPTION
Better use the configured value instead of joining statedir and a fixed string.