### PR TITLE
(PCP-175) Fix acceptance tests on Ubuntu platforms

### DIFF
--- a/acceptance/config/aio/options.rb
+++ b/acceptance/config/aio/options.rb
@@ -1,7 +1,6 @@
 {
   :log_level     => 'info',
-  :type          => 'packages',
-  :forge_host    => 'forge-aio01-petest.puppetlabs.com',
+  :type          => 'aio',
   :load_path     => './lib/',
   :repo_proxy    => true,
   :add_el_extras => true,

--- a/acceptance/setup/aio/010_Install.rb
+++ b/acceptance/setup/aio/010_Install.rb
@@ -20,7 +20,7 @@ PACKAGES = {
     'puppet'
   ],
   :debian => [
-    'puppet'
+    'puppet-agent'
   ],
 }
 


### PR DESCRIPTION
The wrong package name was being installed; leading to an install of Puppet without PXP.
A correction to the beaker options is also required, while :type was not correctly set; puppet would not be available on the path when beaker tried to execute it via ssh.