### PR TITLE
(PCP-176) Support 32bit Puppet on 64bit Windows

### DIFF
--- a/acceptance/lib/pxp-agent/config_helper.rb
+++ b/acceptance/lib/pxp-agent/config_helper.rb
@@ -7,10 +7,6 @@ PXP_CONFIG_DIR_POSIX = '/etc/puppetlabs/pxp-agent/'
 PXP_LOG_FILE_CYGPATH = '/cygdrive/c/ProgramData/PuppetLabs/pxp-agent/var/log/pxp-agent.log'
 PXP_LOG_FILE_POSIX = '/var/log/puppetlabs/pxp-agent/pxp-agent.log'
 
-PXP_EXE_DIR_CYGPATH = "/cygdrive/c/Program\\ Files/Puppet\\ Labs/Puppet/pxp-agent/bin"
-PXP_EXE_DIR_CYGPATH_x86 = "/cygdrive/c/Program\\ Files\\ \\(x86\\)/Puppet\\ Labs/Puppet/pxp-agent/bin"
-PXP_EXE_DIR_POSIX = "/opt/puppetlabs/puppet/bin"
-
 PCP_BROKER_PORT = 8142
 
 # SSL directories and files for our standard set of test certs
@@ -45,11 +41,11 @@ def pxp_agent_dir(host)
   if (windows?(host))
     # If 32bit Puppet on 64bit Windows then Puppet will be in Program Files (x86)
     if((host.is_x86_64?) && (host[:ruby_arch] == "x86"))
-      return PXP_EXE_DIR_CYGPATH_x86
+      return "/cygdrive/c/Program\\ Files\\ \\(x86\\)/Puppet\\ Labs/Puppet/pxp-agent/bin"
     end
-    return PXP_EXE_DIR_CYGPATH
+    return "/cygdrive/c/Program\\ Files/Puppet\\ Labs/Puppet/pxp-agent/bin"
   end
-  PXP_EXE_DIR_POSIX
+  "/opt/puppetlabs/puppet/bin"
 end
 
 # @param broker hostname or beaker host object of the machine running pcp-broker

--- a/acceptance/lib/pxp-agent/config_helper.rb
+++ b/acceptance/lib/pxp-agent/config_helper.rb
@@ -7,6 +7,10 @@ PXP_CONFIG_DIR_POSIX = '/etc/puppetlabs/pxp-agent/'
 PXP_LOG_FILE_CYGPATH = '/cygdrive/c/ProgramData/PuppetLabs/pxp-agent/var/log/pxp-agent.log'
 PXP_LOG_FILE_POSIX = '/var/log/puppetlabs/pxp-agent/pxp-agent.log'
 
+PXP_EXE_DIR_CYGPATH = "/cygdrive/c/Program\\ Files/Puppet\\ Labs/Puppet/pxp-agent/bin"
+PXP_EXE_DIR_CYGPATH_x86 = "/cygdrive/c/Program\\ Files\\ \\(x86\\)/Puppet\\ Labs/Puppet/pxp-agent/bin"
+PXP_EXE_DIR_POSIX = "/opt/puppetlabs/puppet/bin"
+
 PCP_BROKER_PORT = 8142
 
 # SSL directories and files for our standard set of test certs
@@ -33,6 +37,19 @@ end
 
 def windows?(host)
   host.platform.upcase.start_with?('WINDOWS')
+end
+
+# @param host the beaker host object you want the path on
+# @return the path to the directory that pxp-agent is located in. A cygpath is returned in the case of Windows.
+def pxp_agent_dir(host)
+  if (windows?(host))
+    # If 32bit Puppet on 64bit Windows then Puppet will be in Program Files (x86)
+    if((host.is_x86_64?) && (host[:ruby_arch] == "x86"))
+      return PXP_EXE_DIR_CYGPATH_x86
+    end
+    return PXP_EXE_DIR_CYGPATH
+  end
+  PXP_EXE_DIR_POSIX
 end
 
 # @param broker hostname or beaker host object of the machine running pcp-broker

--- a/acceptance/setup/aio/010_Install.rb
+++ b/acceptance/setup/aio/010_Install.rb
@@ -34,11 +34,11 @@ agents.each do |agent|
     install_puppet_agent_dev_repo_on(agent, :version => sha)
     logger.info 'Prevent Puppet Service from Running'
     on(agent, puppet('resource service puppet ensure=stopped enable=false'))
-    logger.info 'Vendored Ruby needs to be on PATH for pxp-agent to load libraries'
-    # export needs sed'd to first line as bashrc exits for non-interaction shells near top of file
+    logger.info 'Add vendored Ruby to PATH so that pxp-agent can be run as an executable at command line'
     (agent.is_x86_64? && (agent[:ruby_arch] == "x86")) ?
       export_path = "\$PATH\":\/cygdrive\/c\/Program\ Files\ \(x86\)\/Puppet\ Labs\/Puppet\/sys\/ruby\/bin\"" :
       export_path = "\$PATH\":\/cygdrive\/c\/Program\ Files\/Puppet\ Labs\/Puppet\/sys\/ruby\/bin\""
+    # bashrc exits almost immediately for non-interaction shells, so our export needs sed'd to first line
     on(agent, "sed -i '1iexport\ PATH=#{export_path}' ~/.bashrc")
   end
 end

--- a/acceptance/setup/aio/010_Install.rb
+++ b/acceptance/setup/aio/010_Install.rb
@@ -32,8 +32,6 @@ agents.each do |agent|
   if agent.platform.start_with?('windows')
     logger.info "Installing Puppet agent msi #{sha} on #{agent}"
     install_puppet_agent_dev_repo_on(agent, :version => sha)
-    logger.info 'Prevent Puppet Service from Running'
-    on(agent, puppet('resource service puppet ensure=stopped enable=false'))
     logger.info 'Add vendored Ruby to PATH so that pxp-agent can be run as an executable at command line'
     (agent.is_x86_64? && (agent[:ruby_arch] == "x86")) ?
       export_path = "\$PATH\":\/cygdrive\/c\/Program\ Files\ \(x86\)\/Puppet\ Labs\/Puppet\/sys\/ruby\/bin\"" :

--- a/acceptance/setup/aio/010_Install.rb
+++ b/acceptance/setup/aio/010_Install.rb
@@ -36,6 +36,9 @@ agents.each do |agent|
     on(agent, puppet('resource service puppet ensure=stopped enable=false'))
     logger.info 'Vendored Ruby needs to be on PATH for pxp-agent to load libraries'
     # export needs sed'd to first line as bashrc exits for non-interaction shells near top of file
-    on(agent, "sed -i '1iexport\ PATH=\$PATH\":\/cygdrive\/c\/Program\ Files\/Puppet\ Labs\/Puppet\/sys\/ruby\/bin\"' ~/.bashrc")
+    (agent.is_x86_64? && (agent[:ruby_arch] == "x86")) ?
+      export_path = "\$PATH\":\/cygdrive\/c\/Program\ Files\ \(x86\)\/Puppet\ Labs\/Puppet\/sys\/ruby\/bin\"" :
+      export_path = "\$PATH\":\/cygdrive\/c\/Program\ Files\/Puppet\ Labs\/Puppet\/sys\/ruby\/bin\""
+    on(agent, "sed -i '1iexport\ PATH=#{export_path}' ~/.bashrc")
   end
 end

--- a/acceptance/tests/pxp_agent_version.rb
+++ b/acceptance/tests/pxp_agent_version.rb
@@ -1,12 +1,10 @@
+require 'pxp-agent/config_helper.rb'
+
 test_name 'C93805 - pxp-agent - Versioning test'
 
 agent1 = agents[0]
 
 step 'cd into pxp-agent bin folder and check the version'
-pxp_agent_folder = ''
-agent1.platform.start_with?('windows') ?
-  pxp_agent_folder = "/cygdrive/c/Program\\ Files/Puppet\\ Labs/Puppet/pxp-agent/bin" :
-  pxp_agent_folder = "/opt/puppetlabs/puppet/bin"
-on(agent1, "cd #{pxp_agent_folder} && ./pxp-agent --version") do |result|
+on(agent1, "cd #{pxp_agent_dir(agent1)} && ./pxp-agent --version") do |result|
   assert(/[0-9\.]*/ =~ result.stdout, "Version number should be numbers and periods but was \"#{result.stdout.to_s}\"")
 end


### PR DESCRIPTION
Puppet and pxp-agent will be in the Program Files x86 folder if Puppet is 32bit on 64bit Windows.
To support this, I've added a helper method to get the path to pxp-agent.
Removed the static strings in the pxp_agent_version test and replaced with a call to the helper.