### PR TITLE
(maint) Update appveyor Git moves

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,16 +18,20 @@ install:
   - cd cpp-pcp-client
   - git checkout 1.0.1
   - git submodule update --init --recursive
-  - ps: mv "C:\Program Files (x86)\Git\bin\sh.exe" "C:\Program Files (x86)\Git\bin\shxx.exe"
+  - ps: mv "C:\Program Files\Git\usr\bin\sh.exe" "C:\Program Files\Git\usr\bin\shxx.exe"
+  - ps: mv "C:\Program Files\Git\bin\sh.exe" "C:\Program Files\Git\bin\shxx.exe"
   - ps: cmake -G "MinGW Makefiles" -DBOOST_ROOT="C:\tools\boost_1_58_0-x86_64_mingw-w64_4.8.3_win32_seh" -DBOOST_STATIC=ON -DBOOST_NOWIDE_SKIP_TESTS=ON -Wno-dev -DCMAKE_INSTALL_PREFIX=C:\tools .
-  - ps: mv "C:\Program Files (x86)\Git\bin\shxx.exe" "C:\Program Files (x86)\Git\bin\sh.exe"
+  - ps: mv "C:\Program Files\Git\usr\bin\shxx.exe" "C:\Program Files\Git\usr\bin\sh.exe"
+  - ps: mv "C:\Program Files\Git\bin\shxx.exe" "C:\Program Files\Git\bin\sh.exe"
   - ps: mingw32-make install
   - cd ..
 
 build_script:
-  - ps: mv "C:\Program Files (x86)\Git\bin\sh.exe" "C:\Program Files (x86)\Git\bin\shxx.exe"
+  - ps: mv "C:\Program Files\Git\usr\bin\sh.exe" "C:\Program Files\Git\usr\bin\shxx.exe"
+  - ps: mv "C:\Program Files\Git\bin\sh.exe" "C:\Program Files\Git\bin\shxx.exe"
   - ps: cmake -G "MinGW Makefiles" -DBOOST_ROOT="C:\tools\boost_1_58_0-x86_64_mingw-w64_4.8.3_win32_seh" -DBOOST_STATIC=ON -DBOOST_NOWIDE_SKIP_TESTS=ON -Wno-dev -DCMAKE_PREFIX_PATH=C:\tools -DCMAKE_INSTALL_PREFIX=C:\tools .
-  - ps: mv "C:\Program Files (x86)\Git\bin\shxx.exe" "C:\Program Files (x86)\Git\bin\sh.exe"
+  - ps: mv "C:\Program Files\Git\usr\bin\shxx.exe" "C:\Program Files\Git\usr\bin\sh.exe"
+  - ps: mv "C:\Program Files\Git\bin\shxx.exe" "C:\Program Files\Git\bin\sh.exe"
   - ps: mingw32-make install
 
 test_script:


### PR DESCRIPTION
It seems that appveyor's git install with the problematic Git\bin\sh.exe
have moved, so we need to update.