### PR TITLE
(maint) Fix acceptance test not using keyword argument correctly

### DIFF
--- a/acceptance/lib/pxp-agent/config_helper.rb
+++ b/acceptance/lib/pxp-agent/config_helper.rb
@@ -120,7 +120,7 @@ end
 # @param client_number which client 01-05 you want the key file for
 # @param [boolean] use_alt_path Use alternative test ssl file if true, otherwise use standard test ssl file
 # @return the path to the client ssl key file on this host
-def ssl_key_file(host, client_number, use_alt_path: false)
+def ssl_key_file(host, client_number, use_alt_path=false)
   alt_str = use_alt_path ? '.alt' : ''
   alt_suffix = use_alt_path ? ALT_SUFFIX_POSIX : ''
   client_number = left_pad_with_zero(client_number)
@@ -138,7 +138,7 @@ end
 # @param host the beaker host (to determine the correct path for the OS)
 # @param [boolean] use_alt_path Use alternative test ssl file if true, otherwise use standard test ssl file
 # @return the path to the ssl ca file on this host
-def ssl_ca_file(host, use_alt_path: false)
+def ssl_ca_file(host, use_alt_path=false)
   alt_str = use_alt_path ? '.alt' : ''
   alt_suffix = use_alt_path ? ALT_SUFFIX_POSIX : ''
   case host['platform']
@@ -156,7 +156,7 @@ end
 # @param client_number which client 01-05 you want the key file for
 # @param [boolean] use_alt_path Use alternative test ssl file if true, otherwise use standard test ssl file
 # @return the path to the ssl cert for this client on this host
-def ssl_cert_file(host, client_number, use_alt_path: false)
+def ssl_cert_file(host, client_number, use_alt_path=false)
   alt_str = use_alt_path ? '.alt' : ''
   alt_suffix = use_alt_path ? ALT_SUFFIX_POSIX : ''
   client_number = left_pad_with_zero(client_number)

--- a/acceptance/lib/pxp-agent/config_helper.rb
+++ b/acceptance/lib/pxp-agent/config_helper.rb
@@ -120,7 +120,7 @@ end
 # @param client_number which client 01-05 you want the key file for
 # @param [boolean] use_alt_path Use alternative test ssl file if true, otherwise use standard test ssl file
 # @return the path to the client ssl key file on this host
-def ssl_key_file(host, client_number, use_alt_path=false)
+def ssl_key_file(host, client_number, use_alt_path: false)
   alt_str = use_alt_path ? '.alt' : ''
   alt_suffix = use_alt_path ? ALT_SUFFIX_POSIX : ''
   client_number = left_pad_with_zero(client_number)
@@ -138,7 +138,7 @@ end
 # @param host the beaker host (to determine the correct path for the OS)
 # @param [boolean] use_alt_path Use alternative test ssl file if true, otherwise use standard test ssl file
 # @return the path to the ssl ca file on this host
-def ssl_ca_file(host, use_alt_path=false)
+def ssl_ca_file(host, use_alt_path: false)
   alt_str = use_alt_path ? '.alt' : ''
   alt_suffix = use_alt_path ? ALT_SUFFIX_POSIX : ''
   case host['platform']
@@ -156,7 +156,7 @@ end
 # @param client_number which client 01-05 you want the key file for
 # @param [boolean] use_alt_path Use alternative test ssl file if true, otherwise use standard test ssl file
 # @return the path to the ssl cert for this client on this host
-def ssl_cert_file(host, client_number, use_alt_path=false)
+def ssl_cert_file(host, client_number, use_alt_path: false)
   alt_str = use_alt_path ? '.alt' : ''
   alt_suffix = use_alt_path ? ALT_SUFFIX_POSIX : ''
   client_number = left_pad_with_zero(client_number)

--- a/acceptance/tests/invalid_ssl_config.rb
+++ b/acceptance/tests/invalid_ssl_config.rb
@@ -21,7 +21,7 @@ step "Setup - Change pxp-agent config to use a cert that doesn't match private k
 invalid_config_mismatching_keys = {:broker_ws_uri => broker_ws_uri(master),
                                    :ssl_key => ssl_key_file(agent1, 1),
                                    :ssl_ca_cert => ssl_ca_file(agent1),
-                                   :ssl_cert => ssl_cert_file(agent1, 1, use_alt_path=true)}
+                                   :ssl_cert => ssl_cert_file(agent1, 1, use_alt_path: true)}
 create_remote_file(agent1, pxp_agent_config_file(agent1), pxp_config_json(master, agent1, invalid_config_mismatching_keys).to_s)
 
 step 'C94730 - Attempt to run pxp-agent with mismatching SSL cert and private key'
@@ -50,9 +50,9 @@ on(agent, "rm -rf #{logfile(agent1)}")
 
 step "Change pxp-agent config so the cert and key match but they are of a different ca than the broker"
 invalid_config_wrong_ca = {:broker_ws_uri => broker_ws_uri(master),
-                           :ssl_key => ssl_key_file(agent1, 1, use_alt_path=true),
+                           :ssl_key => ssl_key_file(agent1, 1, use_alt_path: true),
                            :ssl_ca_cert => ssl_ca_file(agent1),
-                           :ssl_cert => ssl_cert_file(agent1, 1, use_alt_path=true)}
+                           :ssl_cert => ssl_cert_file(agent1, 1, use_alt_path: true)}
 create_remote_file(agent1, pxp_agent_config_file(agent1), pxp_config_json(master, agent1, invalid_config_wrong_ca).to_s)
 
 step 'C94729 - Attempt to run pxp-agent with SSL keypair from a different ca'

--- a/acceptance/tests/invalid_ssl_config.rb
+++ b/acceptance/tests/invalid_ssl_config.rb
@@ -21,7 +21,7 @@ step "Setup - Change pxp-agent config to use a cert that doesn't match private k
 invalid_config_mismatching_keys = {:broker_ws_uri => broker_ws_uri(master),
                                    :ssl_key => ssl_key_file(agent1, 1),
                                    :ssl_ca_cert => ssl_ca_file(agent1),
-                                   :ssl_cert => ssl_cert_file(agent1, 1, use_alt_path: true)}
+                                   :ssl_cert => ssl_cert_file(agent1, 1, true)}
 create_remote_file(agent1, pxp_agent_config_file(agent1), pxp_config_json(master, agent1, invalid_config_mismatching_keys).to_s)
 
 step 'C94730 - Attempt to run pxp-agent with mismatching SSL cert and private key'
@@ -50,9 +50,9 @@ on(agent, "rm -rf #{logfile(agent1)}")
 
 step "Change pxp-agent config so the cert and key match but they are of a different ca than the broker"
 invalid_config_wrong_ca = {:broker_ws_uri => broker_ws_uri(master),
-                           :ssl_key => ssl_key_file(agent1, 1, use_alt_path: true),
+                           :ssl_key => ssl_key_file(agent1, 1, true),
                            :ssl_ca_cert => ssl_ca_file(agent1),
-                           :ssl_cert => ssl_cert_file(agent1, 1, use_alt_path: true)}
+                           :ssl_cert => ssl_cert_file(agent1, 1, true)}
 create_remote_file(agent1, pxp_agent_config_file(agent1), pxp_config_json(master, agent1, invalid_config_wrong_ca).to_s)
 
 step 'C94729 - Attempt to run pxp-agent with SSL keypair from a different ca'


### PR DESCRIPTION
The use_alt_file option for SSL config methods was being called like a named argument, but it was actually creating a local variable with the argument name rather than passing by keyword.
This commit changes the helper methods and the test to use an actual keyword argument.