### PR TITLE
(maint) Acceptance tests should give test failures and not exceptions when checking log file

### DIFF
--- a/acceptance/lib/pxp-agent/test_helper.rb
+++ b/acceptance/lib/pxp-agent/test_helper.rb
@@ -1,0 +1,20 @@
+# This file contains general test helper methods
+
+# @param host the host to check the file on
+# @param file path to file to check
+# @param expected the string or pattern expected in the file
+# @param seconds number of seconds to retry (one retry per second). Default 30.
+def expect_file_on_host_to_contain(host, file, expected, seconds=30)
+  # If the expected file entry does not appear in the file within 30 seconds, then do an explicit assertion
+  # that the file should contain the expected text, so we get a test fail (not an unhandled error), and the
+  # log contents will appear in the test failure output
+  begin
+    retry_on(host, "grep '#{expected}' #{file}", {:max_retries => 30,
+                                                     :retry_interval => 1})
+  rescue
+    on(host, "cat #{file}") do |result|
+      assert_match(expected, result.stdout,
+                  "Expected text '#{expected}' did not appear in file #{file}")
+    end
+  end
+end

--- a/acceptance/setup/common/010_Setup_Broker.rb
+++ b/acceptance/setup/common/010_Setup_Broker.rb
@@ -1,25 +1,33 @@
 pcp_broker_port = 8142
 pcp_broker_minutes_to_start = 2
 
-step 'Clone pcp-broker to master'
-on master, puppet('resource package git ensure=present')
-on master, 'git clone https://github.com/puppetlabs/pcp-broker.git'
+step 'Clone pcp-broker to master' do
+  on master, puppet('resource package git ensure=present')
+  on master, 'git clone https://github.com/puppetlabs/pcp-broker.git'
+end
 
-step 'Install Java'
-on master, puppet('resource package java ensure=present')
-step 'Download lein bootstrap'
-on master, 'cd /usr/bin && '\
-           'curl -O https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein'
-step 'Run lein once so it sets itself up'
-on master, 'chmod a+x /usr/bin/lein && export LEIN_ROOT=ok && /usr/bin/lein'
+step 'Install Java' do
+  on master, puppet('resource package java ensure=present')
+end
 
-step 'Run lein deps to download dependencies'
-# 'lein tk' will download dependencies automatically, but downloading them will take
-# some time and will eat into the polling period we allow for the broker to start
-on master, 'cd ~/pcp-broker; export LEIN_ROOT=ok; lein deps'
+step 'Download lein bootstrap script' do
+  on master, 'cd /usr/bin && '\
+             'curl -O https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein'
+end
 
-step "Run pcp-broker in trapperkeeper in background and wait for port #{pcp_broker_port.to_s}"
-on master, 'cd ~/pcp-broker; export LEIN_ROOT=ok; lein tk </dev/null >/var/log/pcp-broker.log 2>&1 &'
-assert(port_open_within?(master, pcp_broker_port, 60 * pcp_broker_minutes_to_start),
-       "pcp-broker port #{pcp_broker_port.to_s} not open within " \
-       "#{pcp_broker_minutes_to_start.to_s} minutes of starting the broker")
+step 'Run lein once so it sets itself up' do
+  on master, 'chmod a+x /usr/bin/lein && export LEIN_ROOT=ok && /usr/bin/lein'
+end
+
+step 'Run lein deps to download dependencies' do
+  # 'lein tk' will download dependencies automatically, but downloading them will take
+  # some time and will eat into the polling period we allow for the broker to start
+  on master, 'cd ~/pcp-broker; export LEIN_ROOT=ok; lein deps'
+end
+
+step "Run pcp-broker in trapperkeeper in background and wait for port #{pcp_broker_port.to_s}" do
+  on master, 'cd ~/pcp-broker; export LEIN_ROOT=ok; lein tk </dev/null >/var/log/pcp-broker.log 2>&1 &'
+  assert(port_open_within?(master, pcp_broker_port, 60 * pcp_broker_minutes_to_start),
+         "pcp-broker port #{pcp_broker_port.to_s} not open within " \
+         "#{pcp_broker_minutes_to_start.to_s} minutes of starting the broker")
+end

--- a/acceptance/tests/invalid_ssl_config.rb
+++ b/acceptance/tests/invalid_ssl_config.rb
@@ -14,48 +14,55 @@ teardown do
   on agent1, puppet('resource service pxp-agent ensure=running')
 end
 
-step 'Setup - Stop pxp-agent service'
-on agent1, puppet('resource service pxp-agent ensure=stopped')
+step 'Setup - Stop pxp-agent service' do
+  on agent1, puppet('resource service pxp-agent ensure=stopped')
+end
 
-step "Setup - Wipe pxp-agent log"
-on(agent1, "rm -rf #{logfile(agent1)}")
+step "Setup - Wipe pxp-agent log" do
+  on(agent1, "rm -rf #{logfile(agent1)}")
+end
 
-step "Setup - Change pxp-agent config to use a cert that doesn't match private key"
-invalid_config_mismatching_keys = {:broker_ws_uri => broker_ws_uri(master),
-                                   :ssl_key => ssl_key_file(agent1, 1, cert_dir),
-                                   :ssl_ca_cert => ssl_ca_file(agent1, cert_dir),
-                                   :ssl_cert => ssl_cert_file(agent1, 1, cert_dir, true)}
-create_remote_file(agent1, pxp_agent_config_file(agent1), pxp_config_json(master, agent1, invalid_config_mismatching_keys).to_s)
+step "Setup - Change pxp-agent config to use a cert that doesn't match private key" do
+  invalid_config_mismatching_keys = {:broker_ws_uri => broker_ws_uri(master),
+                                     :ssl_key => ssl_key_file(agent1, 1, cert_dir),
+                                     :ssl_ca_cert => ssl_ca_file(agent1, cert_dir),
+                                     :ssl_cert => ssl_cert_file(agent1, 1, cert_dir, true)}
+  create_remote_file(agent1, pxp_agent_config_file(agent1), pxp_config_json(master, agent1, invalid_config_mismatching_keys).to_s)
+end
 
-step 'C94730 - Attempt to run pxp-agent with mismatching SSL cert and private key'
-on agent1, puppet('resource service pxp-agent ensure=running')
-expect_file_on_host_to_contain(agent1, logfile(agent1), 'failed to load private key')
-assert(on(agent1, "grep 'pxp-agent will start unconfigured' #{logfile(agent1)}"),
+step 'C94730 - Attempt to run pxp-agent with mismatching SSL cert and private key' do
+  on agent1, puppet('resource service pxp-agent ensure=running')
+  expect_file_on_host_to_contain(agent1, logfile(agent1), 'failed to load private key')
+  assert(on(agent1, "grep 'pxp-agent will start unconfigured' #{logfile(agent1)}"),
        "pxp-agent should log that is will start unconfigured")
-on agent1, puppet('resource service pxp-agent') do |result|
-  assert_match(/running/, result.stdout, "pxp-agent service should be running (unconfigured)")
+  on agent1, puppet('resource service pxp-agent') do |result|
+    assert_match(/running/, result.stdout, "pxp-agent service should be running (unconfigured)")
+  end
 end
 
-step "Stop service and wipe log"
-on agent1, puppet('resource service pxp-agent ensure=stopped')
-on(agent, "rm -rf #{logfile(agent1)}")
-
-step "Change pxp-agent config so the cert and key match but they are of a different ca than the broker"
-invalid_config_wrong_ca = {:broker_ws_uri => broker_ws_uri(master),
-                           :ssl_key => ssl_key_file(agent1, 1, cert_dir, true),
-                           :ssl_ca_cert => ssl_ca_file(agent1, cert_dir),
-                           :ssl_cert => ssl_cert_file(agent1, 1, cert_dir, true)}
-create_remote_file(agent1, pxp_agent_config_file(agent1), pxp_config_json(master, agent1, invalid_config_wrong_ca).to_s)
-
-step 'C94729 - Attempt to run pxp-agent with SSL keypair from a different ca'
-on agent1, puppet('resource service pxp-agent ensure=running')
-expect_file_on_host_to_contain(agent1, logfile(agent1), 'TLS handshake failed')
-expect_file_on_host_to_contain(agent1, logfile(agent1), 'retrying in')
-on agent1, puppet('resource service pxp-agent') do |result|
-  assert_match(/running/, result.stdout, "pxp-agent service should be running (failing handshake)")
+step "Stop pxp-agent service and wipe log" do
+  on agent1, puppet('resource service pxp-agent ensure=stopped')
+  on(agent, "rm -rf #{logfile(agent1)}")
 end
-on agent1, puppet('resource service pxp-agent ensure=stopped')
-on agent1, puppet('resource service pxp-agent') do |result|
-  assert_match(/stopped/, result.stdout,
-               "pxp-agent service should stop cleanly when it is running in a loop retrying invalid certs")
+
+step "Change pxp-agent config so the cert and key match but they are of a different ca than the broker" do
+  invalid_config_wrong_ca = {:broker_ws_uri => broker_ws_uri(master),
+                             :ssl_key => ssl_key_file(agent1, 1, cert_dir, true),
+                             :ssl_ca_cert => ssl_ca_file(agent1, cert_dir),
+                             :ssl_cert => ssl_cert_file(agent1, 1, cert_dir, true)}
+  create_remote_file(agent1, pxp_agent_config_file(agent1), pxp_config_json(master, agent1, invalid_config_wrong_ca).to_s)
+end
+
+step 'C94729 - Attempt to run pxp-agent with SSL keypair from a different ca' do
+  on agent1, puppet('resource service pxp-agent ensure=running')
+  expect_file_on_host_to_contain(agent1, logfile(agent1), 'TLS handshake failed')
+  expect_file_on_host_to_contain(agent1, logfile(agent1), 'retrying in')
+  on agent1, puppet('resource service pxp-agent') do |result|
+    assert_match(/running/, result.stdout, "pxp-agent service should be running (failing handshake)")
+  end
+  on agent1, puppet('resource service pxp-agent ensure=stopped')
+  on agent1, puppet('resource service pxp-agent') do |result|
+    assert_match(/stopped/, result.stdout,
+                 "pxp-agent service should stop cleanly when it is running in a loop retrying invalid certs")
+  end
 end

--- a/acceptance/tests/pxp_agent_associate.rb
+++ b/acceptance/tests/pxp_agent_associate.rb
@@ -1,3 +1,5 @@
+require 'pxp-agent/test_helper.rb'
+
 test_name 'C93807 - Associate pxp-agent with a PCP broker'
 
 agent1 = agents[0]
@@ -14,19 +16,9 @@ on(agent1, "rm -rf #{logfile(agent1)}")
 step 'Start pxp-agent service'
 on agent1, puppet('resource service pxp-agent ensure=running')
 
-step 'Allow 10 seconds after service start-up for association to complete'
-sleep(10)
-
-websocket_success = /INFO.*Successfully established a WebSocket connection with the PCP broker.*/
-association_success = /INFO.*Received associate session response.*success/
-on(agent1, "cat #{logfile(agent1)}") do |result|
-  log_contents = result.stdout
-  step 'Check pxp-agent.log for websocket connection'
-  assert_match(websocket_success, log_contents,
-               "Did not match expected websocket connection message '#{websocket_success.to_s}' " \
-               "in actual pxp-agent.log contents '#{log_contents}'")
-  step 'Check pxp-agent.log for successful association response'
-  assert_match(association_success, log_contents,
-               "Did not match expected association success message '#{association_success.to_s}' " \
-               "in actual pxp-agent.log contents '#{log_contents}'")
+step 'Check that within 60 seconds, log file contains entry for WebSocket connection being established' do
+  expect_file_on_host_to_contain(agent1, logfile(agent1), 'INFO.*Successfully established a WebSocket connection with the PCP broker.*', 60)
+end
+step 'Check that log file contains entry that association has succeeded' do
+  expect_file_on_host_to_contain(agent1, logfile(agent1), 'INFO.*Received associate session response.*success')
 end

--- a/acceptance/tests/pxp_agent_associate.rb
+++ b/acceptance/tests/pxp_agent_associate.rb
@@ -7,18 +7,22 @@ agent1 = agents[0]
 cert_dir = configure_std_certs_on_host(agent1)
 create_remote_file(agent1, pxp_agent_config_file(agent1), pxp_config_json_using_test_certs(master, agent1, 1, cert_dir).to_s)
 
-step 'Stop pxp-agent if it is currently running'
-on agent1, puppet('resource service pxp-agent ensure=stopped')
+step 'Stop pxp-agent if it is currently running' do
+  on agent1, puppet('resource service pxp-agent ensure=stopped')
+end
 
-step 'Clear existing logs so we don\'t match an existing association entry'
-on(agent1, "rm -rf #{logfile(agent1)}")
+step 'Clear existing logs so we don\'t match an existing association entry' do
+  on(agent1, "rm -rf #{logfile(agent1)}")
+end
 
-step 'Start pxp-agent service'
-on agent1, puppet('resource service pxp-agent ensure=running')
+step 'Start pxp-agent service' do
+  on agent1, puppet('resource service pxp-agent ensure=running')
+end
 
 step 'Check that within 60 seconds, log file contains entry for WebSocket connection being established' do
   expect_file_on_host_to_contain(agent1, logfile(agent1), 'INFO.*Successfully established a WebSocket connection with the PCP broker.*', 60)
 end
+
 step 'Check that log file contains entry that association has succeeded' do
   expect_file_on_host_to_contain(agent1, logfile(agent1), 'INFO.*Received associate session response.*success')
 end

--- a/acceptance/tests/pxp_agent_version.rb
+++ b/acceptance/tests/pxp_agent_version.rb
@@ -4,7 +4,8 @@ test_name 'C93805 - pxp-agent - Versioning test'
 
 agent1 = agents[0]
 
-step 'cd into pxp-agent bin folder and check the version'
-on(agent1, "cd #{pxp_agent_dir(agent1)} && ./pxp-agent --version") do |result|
-  assert(/[0-9\.]*/ =~ result.stdout, "Version number should be numbers and periods but was \"#{result.stdout.to_s}\"")
+step 'cd into pxp-agent bin folder and check the version' do
+  on(agent1, "cd #{pxp_agent_dir(agent1)} && ./pxp-agent --version") do |result|
+    assert(/[0-9\.]*/ =~ result.stdout, "Version number should be numbers and periods but was \"#{result.stdout.to_s}\"")
+  end
 end

--- a/acceptance/tests/service_stop_start.rb
+++ b/acceptance/tests/service_stop_start.rb
@@ -36,15 +36,17 @@ def assert_running
   end
 end
 
-step 'C93070 - Service Start (from stopped, with configuration)'
-stop_service
-assert_stopped
-start_service
-assert_running
+step 'C93070 - Service Start (from stopped, with configuration)' do
+  stop_service
+  assert_stopped
+  start_service
+  assert_running
+end
 
-step 'C93069 - Service Stop (from running, with configuration)'
-stop_service
-assert_stopped
+step 'C93069 - Service Stop (from running, with configuration)' do
+  stop_service
+  assert_stopped
+end
 
 # Solaris service administration will prevent the service from starting
 # if it is un-configured because it has been defined as required.
@@ -52,18 +54,22 @@ assert_stopped
 #
 # Therefore, the un-configured test steps need to be skipped on Solaris
 unless (@agent1['platform'] =~ /solaris/) then
-  step 'Remove configuration'
-  stop_service
-  on(@agent1, "mv #{pxp_agent_config_file(@agent1)} #{@pxp_temp_file}")
+  step 'Remove configuration' do
+    stop_service
+    on(@agent1, "mv #{pxp_agent_config_file(@agent1)} #{@pxp_temp_file}")
+  end
 
-  step 'C94686 - Service Start (from stopped, un-configured)'
-  start_service
-  assert_running
+  step 'C94686 - Service Start (from stopped, un-configured)' do
+    start_service
+    assert_running
+  end
 
-  step 'C94687 - Service Stop (from running, un-configured)'
-  stop_service
-  assert_stopped
+  step 'C94687 - Service Stop (from running, un-configured)' do
+    stop_service
+    assert_stopped
+  end
 
-  step 'Restore configuration'
-  on(@agent1, "mv #{@pxp_temp_file} #{pxp_agent_config_file(@agent1)}")
+  step 'Restore configuration' do
+    on(@agent1, "mv #{@pxp_temp_file} #{pxp_agent_config_file(@agent1)}")
+  end
 end


### PR DESCRIPTION
Additionally contains a commit to ensure all our beaker test code uses 'do' code blocks for each beaker test step.