### PR TITLE
(PCP-178) Acceptance tests should repeat test steps on each agent host

### DIFF
--- a/acceptance/tests/invalid_ssl_config.rb
+++ b/acceptance/tests/invalid_ssl_config.rb
@@ -3,66 +3,71 @@ require 'pxp-agent/test_helper.rb'
 
 test_name 'Attempt to start pxp-agent with invalid SSL config'
 
-agent1 = agents[0]
-
-cert_dir = configure_std_certs_on_host(agent1)
-
-# On teardown, restore valid config file
+# On teardown, restore valid config file on each agent
 teardown do
-  on agent1, puppet('resource service pxp-agent ensure=stopped')
-  create_remote_file(agent1, pxp_agent_config_file(agent1), pxp_config_json_using_test_certs(master, agent1, 1, cert_dir).to_s)
-  on agent1, puppet('resource service pxp-agent ensure=running')
-end
-
-step 'Setup - Stop pxp-agent service' do
-  on agent1, puppet('resource service pxp-agent ensure=stopped')
-end
-
-step "Setup - Wipe pxp-agent log" do
-  on(agent1, "rm -rf #{logfile(agent1)}")
-end
-
-step "Setup - Change pxp-agent config to use a cert that doesn't match private key" do
-  invalid_config_mismatching_keys = {:broker_ws_uri => broker_ws_uri(master),
-                                     :ssl_key => ssl_key_file(agent1, 1, cert_dir),
-                                     :ssl_ca_cert => ssl_ca_file(agent1, cert_dir),
-                                     :ssl_cert => ssl_cert_file(agent1, 1, cert_dir, true)}
-  create_remote_file(agent1, pxp_agent_config_file(agent1), pxp_config_json(master, agent1, invalid_config_mismatching_keys).to_s)
-end
-
-step 'C94730 - Attempt to run pxp-agent with mismatching SSL cert and private key' do
-  on agent1, puppet('resource service pxp-agent ensure=running')
-  expect_file_on_host_to_contain(agent1, logfile(agent1), 'failed to load private key')
-  assert(on(agent1, "grep 'pxp-agent will start unconfigured' #{logfile(agent1)}"),
-       "pxp-agent should log that is will start unconfigured")
-  on agent1, puppet('resource service pxp-agent') do |result|
-    assert_match(/running/, result.stdout, "pxp-agent service should be running (unconfigured)")
+  agents.each_with_index do |agent, i|
+    on agent, puppet('resource service pxp-agent ensure=stopped')
+    cert_dir = configure_std_certs_on_host(agent)
+    create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_test_certs(master, agent, i+1, cert_dir).to_s)
+    on agent, puppet('resource service pxp-agent ensure=running')
   end
 end
 
-step "Stop pxp-agent service and wipe log" do
-  on agent1, puppet('resource service pxp-agent ensure=stopped')
-  on(agent, "rm -rf #{logfile(agent1)}")
-end
+agents.each_with_index do |agent, i|
 
-step "Change pxp-agent config so the cert and key match but they are of a different ca than the broker" do
-  invalid_config_wrong_ca = {:broker_ws_uri => broker_ws_uri(master),
-                             :ssl_key => ssl_key_file(agent1, 1, cert_dir, true),
-                             :ssl_ca_cert => ssl_ca_file(agent1, cert_dir),
-                             :ssl_cert => ssl_cert_file(agent1, 1, cert_dir, true)}
-  create_remote_file(agent1, pxp_agent_config_file(agent1), pxp_config_json(master, agent1, invalid_config_wrong_ca).to_s)
-end
+  cert_dir = configure_std_certs_on_host(agent)
+  cert_number = i + 1
 
-step 'C94729 - Attempt to run pxp-agent with SSL keypair from a different ca' do
-  on agent1, puppet('resource service pxp-agent ensure=running')
-  expect_file_on_host_to_contain(agent1, logfile(agent1), 'TLS handshake failed')
-  expect_file_on_host_to_contain(agent1, logfile(agent1), 'retrying in')
-  on agent1, puppet('resource service pxp-agent') do |result|
-    assert_match(/running/, result.stdout, "pxp-agent service should be running (failing handshake)")
+  step 'Setup - Stop pxp-agent service' do
+    on agent, puppet('resource service pxp-agent ensure=stopped')
   end
-  on agent1, puppet('resource service pxp-agent ensure=stopped')
-  on agent1, puppet('resource service pxp-agent') do |result|
-    assert_match(/stopped/, result.stdout,
-                 "pxp-agent service should stop cleanly when it is running in a loop retrying invalid certs")
+
+  step "Setup - Wipe pxp-agent log" do
+    on(agent, "rm -rf #{logfile(agent)}")
+  end
+
+  step "Setup - Change pxp-agent config to use a cert that doesn't match private key" do
+    invalid_config_mismatching_keys = {:broker_ws_uri => broker_ws_uri(master),
+                                       :ssl_key => ssl_key_file(agent, cert_number, cert_dir),
+                                       :ssl_ca_cert => ssl_ca_file(agent, cert_dir),
+                                       :ssl_cert => ssl_cert_file(agent, cert_number, cert_dir, true)}
+    create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json(master, agent, invalid_config_mismatching_keys).to_s)
+  end
+
+  step 'C94730 - Attempt to run pxp-agent with mismatching SSL cert and private key' do
+    on agent, puppet('resource service pxp-agent ensure=running')
+    expect_file_on_host_to_contain(agent, logfile(agent), 'failed to load private key')
+    assert(on(agent, "grep 'pxp-agent will start unconfigured' #{logfile(agent)}"),
+         "pxp-agent should log that is will start unconfigured")
+    on agent, puppet('resource service pxp-agent') do |result|
+      assert_match(/running/, result.stdout, "pxp-agent service should be running (unconfigured)")
+    end
+  end
+
+  step "Stop pxp-agent service and wipe log" do
+    on agent, puppet('resource service pxp-agent ensure=stopped')
+    on(agent, "rm -rf #{logfile(agent)}")
+  end
+
+  step "Change pxp-agent config so the cert and key match but they are of a different ca than the broker" do
+    invalid_config_wrong_ca = {:broker_ws_uri => broker_ws_uri(master),
+                               :ssl_key => ssl_key_file(agent, cert_number, cert_dir, true),
+                               :ssl_ca_cert => ssl_ca_file(agent, cert_dir),
+                               :ssl_cert => ssl_cert_file(agent, cert_number, cert_dir, true)}
+    create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json(master, agent, invalid_config_wrong_ca).to_s)
+  end
+
+  step 'C94729 - Attempt to run pxp-agent with SSL keypair from a different ca' do
+    on agent, puppet('resource service pxp-agent ensure=running')
+    expect_file_on_host_to_contain(agent, logfile(agent), 'TLS handshake failed')
+    expect_file_on_host_to_contain(agent, logfile(agent), 'retrying in')
+    on agent, puppet('resource service pxp-agent') do |result|
+      assert_match(/running/, result.stdout, "pxp-agent service should be running (failing handshake)")
+    end
+    on agent, puppet('resource service pxp-agent ensure=stopped')
+    on agent, puppet('resource service pxp-agent') do |result|
+      assert_match(/stopped/, result.stdout,
+                   "pxp-agent service should stop cleanly when it is running in a loop retrying invalid certs")
+    end
   end
 end

--- a/acceptance/tests/pxp_agent_associate.rb
+++ b/acceptance/tests/pxp_agent_associate.rb
@@ -2,27 +2,28 @@ require 'pxp-agent/test_helper.rb'
 
 test_name 'C93807 - Associate pxp-agent with a PCP broker'
 
-agent1 = agents[0]
+agents.each_with_index do |agent, i|
 
-cert_dir = configure_std_certs_on_host(agent1)
-create_remote_file(agent1, pxp_agent_config_file(agent1), pxp_config_json_using_test_certs(master, agent1, 1, cert_dir).to_s)
+  cert_dir = configure_std_certs_on_host(agent)
+  create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_test_certs(master, agent, i + 1, cert_dir).to_s)
 
-step 'Stop pxp-agent if it is currently running' do
-  on agent1, puppet('resource service pxp-agent ensure=stopped')
-end
+  step 'Stop pxp-agent if it is currently running' do
+    on agent, puppet('resource service pxp-agent ensure=stopped')
+  end
 
-step 'Clear existing logs so we don\'t match an existing association entry' do
-  on(agent1, "rm -rf #{logfile(agent1)}")
-end
+  step 'Clear existing logs so we don\'t match an existing association entry' do
+    on(agent, "rm -rf #{logfile(agent)}")
+  end
 
-step 'Start pxp-agent service' do
-  on agent1, puppet('resource service pxp-agent ensure=running')
-end
+  step 'Start pxp-agent service' do
+    on agent, puppet('resource service pxp-agent ensure=running')
+  end
 
-step 'Check that within 60 seconds, log file contains entry for WebSocket connection being established' do
-  expect_file_on_host_to_contain(agent1, logfile(agent1), 'INFO.*Successfully established a WebSocket connection with the PCP broker.*', 60)
-end
+  step 'Check that within 60 seconds, log file contains entry for WebSocket connection being established' do
+    expect_file_on_host_to_contain(agent, logfile(agent), 'INFO.*Successfully established a WebSocket connection with the PCP broker.*', 60)
+  end
 
-step 'Check that log file contains entry that association has succeeded' do
-  expect_file_on_host_to_contain(agent1, logfile(agent1), 'INFO.*Received associate session response.*success')
+  step 'Check that log file contains entry that association has succeeded' do
+    expect_file_on_host_to_contain(agent, logfile(agent), 'INFO.*Received associate session response.*success')
+  end
 end

--- a/acceptance/tests/pxp_agent_version.rb
+++ b/acceptance/tests/pxp_agent_version.rb
@@ -2,10 +2,10 @@ require 'pxp-agent/config_helper.rb'
 
 test_name 'C93805 - pxp-agent - Versioning test'
 
-agent1 = agents[0]
-
-step 'cd into pxp-agent bin folder and check the version' do
-  on(agent1, "cd #{pxp_agent_dir(agent1)} && ./pxp-agent --version") do |result|
-    assert(/[0-9\.]*/ =~ result.stdout, "Version number should be numbers and periods but was \"#{result.stdout.to_s}\"")
+agents.each do |agent|
+  step 'cd into pxp-agent bin folder and check the version' do
+    on(agent, "cd #{pxp_agent_dir(agent)} && ./pxp-agent --version") do |result|
+      assert(/[0-9\.]*/ =~ result.stdout, "Version number should be numbers and periods but was \"#{result.stdout.to_s}\"")
+    end
   end
 end

--- a/acceptance/tests/service_stop_start.rb
+++ b/acceptance/tests/service_stop_start.rb
@@ -1,75 +1,81 @@
 require 'pxp-agent/config_helper.rb'
 
 test_name 'Service Start stop/start, with configuration)'
-@agent1 = agents[0]
+
 @pxp_temp_file = '~/pxp-agent.conf'
 
-# On teardown, restore configuration file
+# On teardown, restore configuration file on each agent
 teardown do
-  if @agent1.file_exist?(@pxp_temp_file)
-    on(@agent1, "mv #{@pxp_temp_file} #{pxp_agent_config_file(@agent1)}")
+  agents.each do |agent|
+    if agent.file_exist?(@pxp_temp_file)
+      on(agent, "mv #{@pxp_temp_file} #{pxp_agent_config_file(agent)}")
+    end
   end
 end
 
-cert_dir = configure_std_certs_on_host(@agent1)
-create_remote_file(@agent1, pxp_agent_config_file(@agent1), pxp_config_json_using_test_certs(master, @agent1, 1, cert_dir).to_s)
-
 def stop_service
-  on(@agent1, puppet('resource service pxp-agent ensure=stopped'))
+  on(@agent, puppet('resource service pxp-agent ensure=stopped'))
 end
 
 def start_service
-  on(@agent1, puppet('resource service pxp-agent ensure=running'))
+  on(@agent, puppet('resource service pxp-agent ensure=running'))
 end
 
 def assert_stopped
-  on(@agent1, puppet('resource service pxp-agent ')) do |result|
+  on(@agent, puppet('resource service pxp-agent ')) do |result|
     assert_match(/ensure => .stopped.,/, result.stdout,
                  "pxp-agent not in expected stopped state")
   end
 end
 
 def assert_running
-  on(@agent1, puppet('resource service pxp-agent ')) do |result|
+  on(@agent, puppet('resource service pxp-agent ')) do |result|
     assert_match(/ensure => .running.,/, result.stdout,
                  "pxp-agent not in expected running state")
   end
 end
 
-step 'C93070 - Service Start (from stopped, with configuration)' do
-  stop_service
-  assert_stopped
-  start_service
-  assert_running
-end
+agents.each_with_index do |agent, i|
+  @agent = agent
 
-step 'C93069 - Service Stop (from running, with configuration)' do
-  stop_service
-  assert_stopped
-end
+  cert_dir = configure_std_certs_on_host(@agent)
+  create_remote_file(@agent, pxp_agent_config_file(@agent), pxp_config_json_using_test_certs(master, @agent, i + 1, cert_dir).to_s)
 
-# Solaris service administration will prevent the service from starting
-# if it is un-configured because it has been defined as required.
-# See: https://github.com/puppetlabs/pxp-agent/blob/stable/ext/solaris/smf/pxp-agent.xml#L10-L12
-#
-# Therefore, the un-configured test steps need to be skipped on Solaris
-unless (@agent1['platform'] =~ /solaris/) then
-  step 'Remove configuration' do
+  step 'C93070 - Service Start (from stopped, with configuration)' do
     stop_service
-    on(@agent1, "mv #{pxp_agent_config_file(@agent1)} #{@pxp_temp_file}")
-  end
-
-  step 'C94686 - Service Start (from stopped, un-configured)' do
+    assert_stopped
     start_service
     assert_running
   end
 
-  step 'C94687 - Service Stop (from running, un-configured)' do
+  step 'C93069 - Service Stop (from running, with configuration)' do
     stop_service
     assert_stopped
   end
 
-  step 'Restore configuration' do
-    on(@agent1, "mv #{@pxp_temp_file} #{pxp_agent_config_file(@agent1)}")
+  # Solaris service administration will prevent the service from starting
+  # if it is un-configured because it has been defined as required.
+  # See: https://github.com/puppetlabs/pxp-agent/blob/stable/ext/solaris/smf/pxp-agent.xml#L10-L12
+  #
+  # Therefore, the un-configured test steps need to be skipped on Solaris
+  unless (@agent['platform'] =~ /solaris/) then
+    step 'Remove configuration' do
+      stop_service
+      on(@agent, "mv #{pxp_agent_config_file(@agent)} #{@pxp_temp_file}")
+    end
+
+    step 'C94686 - Service Start (from stopped, un-configured)' do
+      start_service
+      assert_running
+    end
+
+    step 'C94687 - Service Stop (from running, un-configured)' do
+      stop_service
+      assert_stopped
+    end
+
+    step 'Restore configuration' do
+      on(@agent, "mv #{@pxp_temp_file} #{pxp_agent_config_file(@agent)}")
+    end
   end
 end


### PR DESCRIPTION
The tests were assuming (and our CI only uses) one agent host.
This commit has each test case iterate through the available agents and repeat the test steps on each.