### PR TITLE
(PCP-177) Add connection-timeout configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,12 @@ default location is:
 
 Don't become a daemon and execute on foreground on the associated terminal.
 
+** connection-timeout (optional flag) **
+
+Maximum amount of time that may elapse when trying to establish a connection to
+the broker in seconds. Setting the value to 0 will disable the timeout.
+Defaults to 5 seconds.
+
 **pidfile (optional; only on *nix platforms)**
 
 The path of the PID file; the default is */var/run/puppetlabs/pxp-agent.pid*

--- a/lib/inc/pxp-agent/configuration.hpp
+++ b/lib/inc/pxp-agent/configuration.hpp
@@ -131,6 +131,7 @@ class Configuration {
         std::string spool_dir;
         std::string modules_config_dir;
         std::string client_type;
+        long connection_timeout;
     };
 
     /// Reset the HorseWhisperer singleton.

--- a/lib/src/configuration.cc
+++ b/lib/src/configuration.cc
@@ -266,7 +266,8 @@ const Configuration::Agent& Configuration::getAgentConfiguration() const {
         HW::GetFlag<std::string>("ssl-key"),
         HW::GetFlag<std::string>("spool-dir"),
         HW::GetFlag<std::string>("modules-config-dir"),
-        AGENT_CLIENT_TYPE };
+        AGENT_CLIENT_TYPE,
+        HW::GetFlag<int>("connection-timeout") * 1000};
     return agent_configuration_;
 }
 
@@ -408,6 +409,15 @@ void Configuration::defineDefaultValues() {
                     "Don't daemonize, default: false",
                     Types::Bool,
                     false) } });
+
+    defaults_.insert(
+        Option { "connection-timeout",
+                 Base_ptr { new Entry<int>(
+                    "connection-timeout",
+                    "",
+                    "Timeout (in seconds) for establishing a websocket connection. 0 disables, default: 5",
+                    Types::Integer,
+                    5) } });
 
 #ifndef _WIN32
     // NOTE(ale): we don't daemonize on Windows; we rely NSSM to start

--- a/lib/src/pxp_connector.cc
+++ b/lib/src/pxp_connector.cc
@@ -35,7 +35,8 @@ PXPConnector::PXPConnector(const Configuration::Agent& agent_configuration)
                                  agent_configuration.client_type,
                                  agent_configuration.ca,
                                  agent_configuration.crt,
-                                 agent_configuration.key } {
+                                 agent_configuration.key,
+                                 agent_configuration.connection_timeout} {
 }
 
 void PXPConnector::sendPCPError(const std::string& request_id,

--- a/lib/tests/unit/agent_test.cc
+++ b/lib/tests/unit/agent_test.cc
@@ -26,7 +26,8 @@ TEST_CASE("Agent::Agent", "[agent]") {
                                                getKeyPath(),
                                                SPOOL,
                                                "",  // modules config dir
-                                               "test_agent" };
+                                               "test_agent",
+                                               5000 };
 
     SECTION("does not throw if it fails to find the external modules directory") {
         agent_configuration.modules_dir = MODULES + "/fake_dir";

--- a/lib/tests/unit/request_processor_test.cc
+++ b/lib/tests/unit/request_processor_test.cc
@@ -37,7 +37,8 @@ static const Configuration::Agent agent_configuration { MODULES,
                                                         KEY,
                                                         SPOOL,
                                                         "",  // modules config dir
-                                                        "test_agent" };
+                                                        "test_agent",
+                                                        5000 };
 
 TEST_CASE("RequestProcessor::RequestProcessor", "[agent]") {
     auto c_ptr = std::make_shared<PXPConnector>(agent_configuration);


### PR DESCRIPTION
Here we add the "connection-timeout" config parameter. This allows us to
set the timeout that cpp-pcp-client passes on to websocketpp so that
users can tweak on slow networks.

This requires a cpp-pcp-client update to work.