### PR TITLE
(maint) Fix warnings from GCC 5.2 on Windows

### DIFF
--- a/lib/tests/unit/external_module_test.cc
+++ b/lib/tests/unit/external_module_test.cc
@@ -76,7 +76,7 @@ TEST_CASE("ExternalModule::ExternalModule", "[modules]") {
         ExternalModule mod { PXP_AGENT_ROOT_PATH
                              "/lib/tests/resources/modules/failures_test"
                              EXTENSION };
-        REQUIRE(mod.actions.size() == 2);
+        REQUIRE(mod.actions.size() == 2u);
     }
 
     SECTION("throw a Module::LoadingError in case the module has an invalid "

--- a/lib/tests/unit/modules/ping_test.cc
+++ b/lib/tests/unit/modules/ping_test.cc
@@ -127,7 +127,7 @@ TEST_CASE("Modules::Ping::ping", "[modules]") {
         auto hops = result.get<std::vector<lth_jc::JsonContainer>>(
                         "request_hops");
 
-        REQUIRE(hops.size() == 4);
+        REQUIRE(hops.size() == 4u);
         REQUIRE(hops[3].get<std::string>("time") == "007");
     }
 }


### PR DESCRIPTION
On Windows, GCC 5.2 complains about signed/unsigned comparisons (possibly
to keep in-line with MSVC). Update tests to fix this warning.