### PR TITLE
(maint) Use cpp-pcp-client master branch in CI

### DIFF
--- a/.travis_target.sh
+++ b/.travis_target.sh
@@ -24,7 +24,6 @@ fi
 
 git clone https://github.com/puppetlabs/cpp-pcp-client
 cd cpp-pcp-client
-git checkout 1.0.1
 git submodule update --init --recursive
 cmake -DCMAKE_INSTALL_PREFIX=$USERDIR .
 make install -j2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,6 @@ install:
 
   - git clone https://github.com/puppetlabs/cpp-pcp-client
   - cd cpp-pcp-client
-  - git checkout 1.0.1
   - git submodule update --init --recursive
   - ps: mv "C:\Program Files\Git\usr\bin\sh.exe" "C:\Program Files\Git\usr\bin\shxx.exe"
   - ps: mv "C:\Program Files\Git\bin\sh.exe" "C:\Program Files\Git\bin\shxx.exe"


### PR DESCRIPTION
Updating Travis and AppVeyor scripts to use master instead of
cpp-pcp-client 1.0.1