### PR TITLE
(maint) Use PCPClient::Util::defer_lock

### DIFF
--- a/lib/inc/pxp-agent/results_mutex.hpp
+++ b/lib/inc/pxp-agent/results_mutex.hpp
@@ -33,11 +33,6 @@ class ResultsMutex {
     using Lock = PCPClient::Util::unique_lock<PCPClient::Util::mutex>;
     using LockGuard = PCPClient::Util::lock_guard<PCPClient::Util::mutex>;
 
-    // TODO(ale): update this as soon as we have tagged cpp-pcp-client
-    static constexpr boost::defer_lock_t defer_lock() {
-        return boost::defer_lock_t();
-    };
-
     // Singleton users should lock this class mutex before accessing
     // the cache.
     // Note that the singleton caches shared_ptrs to mutexes; because

--- a/lib/src/request_processor.cc
+++ b/lib/src/request_processor.cc
@@ -134,8 +134,7 @@ void nonBlockingActionTask(std::shared_ptr<Module> module_ptr,
     try {
         ResultsMutex::LockGuard a_l { ResultsMutex::Instance().access_mtx };
         mtx_ptr = ResultsMutex::Instance().get(transaction_id);
-        // TODO(ale): update defer_lock to cpp-pcp-client const
-        lck_ptr.reset(new ResultsMutex::Lock(*mtx_ptr, ResultsMutex::defer_lock()));
+        lck_ptr.reset(new ResultsMutex::Lock(*mtx_ptr, pcp_util::defer_lock));
     } catch (const ResultsMutex::Error& e) {
         // This is unexpected
         LOG_ERROR("Failed to obtain the mutex pointer for transaction %1%: %2%",

--- a/lib/tests/unit/results_mutex_test.cc
+++ b/lib/tests/unit/results_mutex_test.cc
@@ -27,9 +27,8 @@ TEST_CASE("ResultsMutex::get", "[async]") {
     SECTION("can lock with the returned mutex pointer") {
         ResultsMutex::Instance().add("spam");
         ResultsMutex::Mutex_Ptr mtx_ptr;
-        // TODO(ale): update defer_lock to cpp-pcp-client const
         ResultsMutex::Lock lck { ResultsMutex::Instance().access_mtx,
-                                 ResultsMutex::defer_lock() };
+                                 PCPClient::Util::defer_lock };
         REQUIRE_FALSE(lck.owns_lock());
         lck.lock();
         REQUIRE(lck.owns_lock());


### PR DESCRIPTION
Use constant definition from the thread abstraction in cpp-pcp-client
instead of having another one in pxp-agent.