### PR TITLE
(PCP-196) Remove full path for systemctl in logrotate

### DIFF
--- a/ext/systemd/pxp-agent.logrotate
+++ b/ext/systemd/pxp-agent.logrotate
@@ -6,6 +6,6 @@
     notifempty
     sharedscripts
     postrotate
-        /usr/bin/systemctl kill --signal=USR2 --kill-who=main pxp-agent.service
+        systemctl kill --signal=USR2 --kill-who=main pxp-agent.service
     endscript
 }


### PR DESCRIPTION
systemctl is either in /bin or /usr/bin depending on whether or not
you're running on deb-based systems. Those directories should always be
in your path so there's no need to specify the full path for systemctl.