### PR TITLE
(maint) Prepare for releasing 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 1.0.2
+
+This is a maintenance release
+
+* [PCP-238](https://tickets.puppetlabs.com/browse/PCP-238) Fixed a bug that prevented pxp-agent from
+loading modules' configuration files named with ".conf" suffix
+* [PCP-234](https://tickets.puppetlabs.com/browse/PCP-234) Fixed a bug that prevented pxp-agent from expanding file paths passed via --module-dir and --modules-config-dir options
+* [PCP-223](https://tickets.puppetlabs.com/browse/PCP-223) Acceptance tests improvements (use helper lib files and run test steps on all agent hosts; remove static config files)
+* [PCP-233](https://tickets.puppetlabs.com/browse/PCP-233) Add Arista support to acceptance tests
+* [PCP-234](https://tickets.puppetlabs.com/browse/PCP-245) Add new set of SSL certificates for testing
+* [QENG-3181](https://tickets.puppetlabs.com/browse/QENG-3181) Use beaker-hostgenerator instead of sqa-utils
+* [#280](https://github.com/puppetlabs/pxp-agent/pull/280) Improve acceptance test based on log message parsing
+* [#278](https://github.com/puppetlabs/pxp-agent/pull/278) Fixed brittle acceptance test regex
+* [PCP-196](https://tickets.puppetlabs.com/browse/PCP-196) Fixed logrotate functionality for debian systems
+
 ## 1.0.1
 
 This is a maintenance release


### PR DESCRIPTION
* Vendoring cpp-pcp-client 1.0.1 for consistency with puppet-agent 1.3.3 packaging.
* Update CHANGELOG.md.