### PR TITLE
(maint) Fix wrong regex for association acceptance test

### DIFF
--- a/acceptance/lib/pxp-agent/test_helper.rb
+++ b/acceptance/lib/pxp-agent/test_helper.rb
@@ -7,7 +7,7 @@ PXP_LOG_FILE_CYGPATH = '/cygdrive/c/ProgramData/PuppetLabs/pxp-agent/var/log/pxp
 PXP_LOG_FILE_POSIX = '/var/log/puppetlabs/pxp-agent/pxp-agent.log'
 
 PXP_AGENT_LOG_ENTRY_WEBSOCKET_SUCCESS = 'INFO.*Successfully established a WebSocket connection with the PCP broker.*'
-PXP_AGENT_LOG_ENTRY_ASSOCIATION_SUCCESS = 'INFO.*Received Associate Session response.*success'
+PXP_AGENT_LOG_ENTRY_ASSOCIATION_SUCCESS = 'INFO.*Received associate session response.*success'
 
 # @param host the beaker host you want the path to the log file on
 # @return The path to the log file on the host. For Windows, a cygpath is returned


### PR DESCRIPTION
Fixing the log message that acceptance tests use to check whether the
session association succeeded or not.