### PR TITLE
(PCP-198) Acceptance pre-suite improvements

### DIFF
--- a/acceptance/Rakefile
+++ b/acceptance/Rakefile
@@ -72,7 +72,7 @@ module HarnessOptions
   end
 end
 
-def beaker_test(mode = :packages, options = {})
+def beaker_test(mode = :aio, options = {})
   final_options = HarnessOptions.options(mode, options)
 
   if mode == :git
@@ -222,7 +222,7 @@ def print_preserved(preserved)
 end
 
 def beaker_run_type
-  type = ENV['TYPE'] || :packages
+  type = ENV['TYPE'] || :aio
   type = type.to_sym
 end
 
@@ -273,14 +273,6 @@ If there is a Beaker options hash in a ./local_options.rb, it will be included. 
 EOS
 
     desc <<-EOS
-Run the acceptance tests through Beaker and install packages on the configuration targets.
-#{USAGE}
-EOS
-    task :packages => 'ci:check_env' do
-      beaker_test
-    end
-
-    desc <<-EOS
 Run the acceptance tests through Beaker and install packages as part of the AIO puppet-agent installation.
 #{USAGE}
 EOS
@@ -304,7 +296,7 @@ EOS
 
   desc <<-EOS
 Run an acceptance test for a given node configuration and preserve the hosts.
-Defaults to a packages run, but you can set it to 'git' with TYPE='git'.
+Defaults to an AIO run, but you can set it to 'git' with TYPE='git'.
 #{USAGE}
   EOS
   task :test_and_preserve_hosts => 'ci:check_env'  do

--- a/acceptance/config/aio/options.rb
+++ b/acceptance/config/aio/options.rb
@@ -1,9 +1,14 @@
 {
   :type => 'aio',
+  :is_puppetserver => true,
+  :puppetservice => 'puppetserver',
+  :'puppetserver-confdir' => '/etc/puppetlabs/puppetserver/conf.d',
   :pre_suite => [
     'setup/common/000-delete-puppet-when-none.rb',
     'setup/aio/pre-suite/010_Install.rb',
     'setup/aio/021_InstallAristaModule.rb',
     'setup/common/010_Setup_Broker.rb',
+    'setup/common/035_StartPuppetServer.rb',
+    'setup/common/040_ValidateSignCert.rb',
   ],
 }

--- a/acceptance/lib/puppet/acceptance/common_utils.rb
+++ b/acceptance/lib/puppet/acceptance/common_utils.rb
@@ -6,5 +6,30 @@ module Puppet
       end
       module_function :ruby_command
     end
-  end
-end
+
+    module CAUtils
+      def initialize_ssl
+        agents.each do |agent|
+          next if agent == master
+
+          ssldir = on(agent, puppet('agent --configprint ssldir')).stdout.chomp
+          on(agent, "rm -rf '#{ssldir}'")
+
+          step "Agents: Run agent --test first time to gen CSR"
+          on agent, puppet("agent --test --server #{master}"), :acceptable_exit_codes => [1]
+        end
+
+        step "Master: sign all certs"
+        on master, puppet("cert --sign --all"), :acceptable_exit_codes => [0,24]
+
+        agents.each do |agent|
+          next if agent == master
+
+          step "Agents: Run agent --test second time to obtain signed cert"
+          on agent, puppet("agent --test --server #{master}"), :acceptable_exit_codes => [0,2]
+        end
+      end # initialize_ssl
+
+    end # Module CAUtils
+  end # Module Acceptance
+end # Module Puppet

--- a/acceptance/setup/common/035_StartPuppetServer.rb
+++ b/acceptance/setup/common/035_StartPuppetServer.rb
@@ -1,0 +1,2 @@
+# Start puppetserver - this is a separate pre-suite block because many pre-suites don't actually want/need the server running
+on(master, puppet('resource', 'service', 'puppetserver', "ensure=running"))

--- a/acceptance/setup/common/040_ValidateSignCert.rb
+++ b/acceptance/setup/common/040_ValidateSignCert.rb
@@ -1,0 +1,6 @@
+test_name "Validate Sign Cert"
+
+require 'puppet/acceptance/common_utils'
+extend Puppet::Acceptance::CAUtils
+
+initialize_ssl


### PR DESCRIPTION
Remove references to "package" test setup in Rakefile.
Use beaker to install puppet-agent instead of lib code in this repo.
Have agent nodes sign themselves against puppet-server on the master node.