### PR TITLE
PCP-249 pin version of pcp-broker

### DIFF
--- a/acceptance/setup/common/010_Setup_Broker.rb
+++ b/acceptance/setup/common/010_Setup_Broker.rb
@@ -1,9 +1,11 @@
 pcp_broker_port = 8142
 pcp_broker_minutes_to_start = 2
 
-step 'Clone pcp-broker to master'
-on master, puppet('resource package git ensure=present')
-on master, 'git clone https://github.com/puppetlabs/pcp-broker.git'
+step 'Clone pcp-broker to master' do
+  on master, puppet('resource package git ensure=present')
+  on master, 'git clone https://github.com/puppetlabs/pcp-broker.git'
+  on master, 'cd ~/pcp-broker ; git checkout 602c003'
+end
 
 step 'Install Java'
 on master, puppet('resource package java ensure=present')


### PR DESCRIPTION
Here we pin pcp-broker's version to master just before the merge of
PCP-195

PCP-195 starts populating the optional 'in-reply-to' header, which
pcp-cpp-client:stable doesn't allow for.