### PR TITLE
(maint) Fix acceptance to reflect changes between master and stable

### DIFF
--- a/acceptance/lib/pxp-agent/test_helper.rb
+++ b/acceptance/lib/pxp-agent/test_helper.rb
@@ -8,7 +8,7 @@ PXP_LOG_FILE_CYGPATH = '/cygdrive/c/ProgramData/PuppetLabs/pxp-agent/var/log/pxp
 PXP_LOG_FILE_POSIX = '/var/log/puppetlabs/pxp-agent/pxp-agent.log'
 
 PXP_AGENT_LOG_ENTRY_WEBSOCKET_SUCCESS = 'INFO.*Successfully established a WebSocket connection with the PCP broker.*'
-PXP_AGENT_LOG_ENTRY_ASSOCIATION_SUCCESS = 'INFO.*Received associate session response.*success'
+PXP_AGENT_LOG_ENTRY_ASSOCIATION_SUCCESS = 'INFO.*Received Associate Session response.*success'
 
 # @param host the beaker host you want the path to the log file on
 # @return The path to the log file on the host. For Windows, a cygpath is returned

--- a/acceptance/tests/service_stop_start.rb
+++ b/acceptance/tests/service_stop_start.rb
@@ -66,11 +66,6 @@ agents.each_with_index do |agent, i|
 
     step 'C94686 - Service Start (from stopped, un-configured)' do
       start_service
-      assert_running
-    end
-
-    step 'C94687 - Service Stop (from running, un-configured)' do
-      stop_service
       assert_stopped
     end
 


### PR DESCRIPTION
Master currently has the same acceptance code as stable, but pxp-agent has different behaviour on these branches. This commit:
 * Has the stop/start service test expect service stopped instead of running (unconfigured) in the case of no config file
 * Expect the capitalisation of the assocation success log message that pxp-agent will actually use