### PR TITLE
(PCP-252) Let external modules write their output

### DIFF
--- a/lib/inc/pxp-agent/external_module.hpp
+++ b/lib/inc/pxp-agent/external_module.hpp
@@ -69,10 +69,15 @@ class ExternalModule : public Module {
 
     void registerAction(const lth_jc::JsonContainer& action);
 
-    /// Returns a string in JSON format, containing the "params" entry
-    /// of the PXP request and the module configuration (both are
-    /// JSON objects).
-    std::string getRequestInput(const ActionRequest& request);
+    /// Returns a string containing the arguments, in JSON format, for
+    /// the requested action.
+    /// The arguments of the PXP request will be added to an "input"
+    /// entry.
+    /// In case a configuration file was previously loaded for this
+    /// action, its content will be added to a "configuration" entry.
+    /// If the request's type is RequestType::NonBlocking, the paths
+    /// to the output files will be added to an "output_files" entry.
+    std::string getActionArguments(const ActionRequest& request);
 
     /// Log information about the outcome of the performed action
     /// while checking the exit code and validating the JSON format

--- a/lib/inc/pxp-agent/external_module.hpp
+++ b/lib/inc/pxp-agent/external_module.hpp
@@ -91,6 +91,8 @@ class ExternalModule : public Module {
 
     ActionOutcome callBlockingAction(const ActionRequest& request);
 
+    /// Throws a ProcessingError in case the module fails to write
+    /// the action output to file.
     ActionOutcome callNonBlockingAction(const ActionRequest& request);
 
     ActionOutcome callAction(const ActionRequest& request);

--- a/lib/inc/pxp-agent/module.hpp
+++ b/lib/inc/pxp-agent/module.hpp
@@ -36,7 +36,7 @@ class Module {
     std::vector<std::string> actions;
     PCPClient::Validator config_validator_;
     PCPClient::Validator input_validator_;
-    PCPClient::Validator output_validator_;
+    PCPClient::Validator results_validator_;
 
     Module();
 

--- a/lib/src/external_module.cc
+++ b/lib/src/external_module.cc
@@ -226,7 +226,7 @@ void ExternalModule::registerAction(const lth_jc::JsonContainer& action) {
         LOG_DEBUG("Action '%1% %2%' has been validated", module_name, action_name);
         actions.push_back(action_name);
         input_validator_.registerSchema(input_schema);
-        output_validator_.registerSchema(output_schema);
+        results_validator_.registerSchema(results_schema);
     } catch (PCPClient::schema_error& e) {
         LOG_ERROR("Failed to parse metadata schemas of action '%1% %2%': %3%",
                   module_name, action_name, e.what());

--- a/lib/src/module.cc
+++ b/lib/src/module.cc
@@ -10,7 +10,7 @@ namespace PXPAgent {
 
 Module::Module()
         : input_validator_ {},
-          output_validator_ {} {
+          results_validator_ {} {
 }
 
 bool Module::hasAction(const std::string& action_name) {
@@ -27,7 +27,7 @@ ActionOutcome Module::executeAction(const ActionRequest& request) {
         LOG_DEBUG("Validating the result output for '%1% %2%'",
                   module_name, request.action());
         try {
-            output_validator_.validate(outcome.results, request.action());
+            results_validator_.validate(outcome.results, request.action());
         } catch (PCPClient::validation_error) {
             std::string err_msg { "'" + module_name + " " + request.action()
                                   + "' returned an invalid result" };

--- a/lib/src/modules/echo.cc
+++ b/lib/src/modules/echo.cc
@@ -14,7 +14,7 @@ Echo::Echo() {
     PCPClient::Schema output_schema { ECHO };
 
     input_validator_.registerSchema(input_schema);
-    output_validator_.registerSchema(output_schema);
+    results_validator_.registerSchema(output_schema);
 }
 
 ActionOutcome Echo::callAction(const ActionRequest& request) {

--- a/lib/src/modules/ping.cc
+++ b/lib/src/modules/ping.cc
@@ -23,7 +23,7 @@ Ping::Ping() {
     PCPClient::Schema output_schema { PING };
 
     input_validator_.registerSchema(input_schema);
-    output_validator_.registerSchema(output_schema);
+    results_validator_.registerSchema(output_schema);
 }
 
 lth_jc::JsonContainer Ping::ping(const ActionRequest& request) {

--- a/lib/src/modules/status.cc
+++ b/lib/src/modules/status.cc
@@ -45,7 +45,7 @@ Status::Status() {
                                true);
     PCPClient::Schema output_schema { QUERY };
     input_validator_.registerSchema(input_schema);
-    output_validator_.registerSchema(output_schema);
+    results_validator_.registerSchema(output_schema);
 }
 
 class ActionMetadata {

--- a/lib/src/modules/status.cc
+++ b/lib/src/modules/status.cc
@@ -100,6 +100,8 @@ class ActionMetadata {
     std::string file;
 };
 
+// TODO(ale): take advantage of the exitcode file (PCP-208)
+
 //
 //                          STATUS TABLE
 //

--- a/lib/tests/resources/broken_modules/reverse_broken
+++ b/lib/tests/resources/broken_modules/reverse_broken
@@ -10,7 +10,7 @@ def action_metadata
         :input => {
           :type => "string",
         },
-        :output => {
+        :results => {
           :type => "string",
         },
       },

--- a/lib/tests/resources/modules/check_output.rb
+++ b/lib/tests/resources/modules/check_output.rb
@@ -1,0 +1,24 @@
+#!/usr/bin/env ruby
+
+def check_output_files(args)
+  output_files = args["output_files"]
+  if !output_files
+    return
+  end
+
+  $stdout.reopen(File.open(output_files["stdout"], 'w'))
+  $stderr.reopen(File.open(output_files["stderr"], 'w'))
+
+  at_exit do
+    status = if $!.nil?
+      0
+    elsif $!.is_a?(SystemExit)
+      $!.status
+    else
+      1
+    end
+    File.open(output_files["exitcode"], 'w') do |f|
+      f.puts(status)
+    end
+  end
+end

--- a/lib/tests/resources/modules/failures_test
+++ b/lib/tests/resources/modules/failures_test
@@ -16,7 +16,7 @@ def action_metadata
           },
           :required => [ :argument ],
         },
-        :output => {
+        :results => {
           :type => "object",
           :properties => {
             :output => {
@@ -37,7 +37,7 @@ def action_metadata
           },
           :required => [ :argument ],
         },
-        :output => {
+        :results => {
           :type => "object",
           :properties => {
             :output => {

--- a/lib/tests/resources/modules/failures_test
+++ b/lib/tests/resources/modules/failures_test
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 require 'json'
+require_relative './check_output'
 
 def action_metadata
    metadata = {
@@ -54,10 +55,15 @@ def action_metadata
 end
 
 def action_get_an_invalid_result
+  args = JSON.load($stdin)
+  check_output_files(args)
   puts "not valid JSON - it will not be parsed successfully!"
 end
 
 def action_broken_action
+  args = JSON.load($stdin)
+  check_output_files(args)
+  $stderr.puts "we failed, sorry :("
   raise "ops, we failed!"
 end
 

--- a/lib/tests/resources/modules/reverse_valid
+++ b/lib/tests/resources/modules/reverse_valid
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 require 'json'
+require_relative './check_output'
 
 def action_metadata
    metadata = {
@@ -47,7 +48,7 @@ def action_metadata
         :input => {
           :type => "object",
           :properties => {
-            :input => {
+            :the_input => {
               :type => 'string',
             },
           },
@@ -56,10 +57,10 @@ def action_metadata
         :results => {
           :type => "object",
           :properties => {
-            :input => {
+            :the_input => {
               :type => 'string',
             },
-            :output => {
+            :the_output => {
               :type => 'string',
             },
           },
@@ -73,15 +74,19 @@ def action_metadata
 end
 
 def action_string
-  input_args = JSON.load($stdin)["input"]
+  args = JSON.load($stdin)
+  check_output_files(args)
+  input_args = args['input']
   results = { :output => input_args['argument'].reverse }
   puts results.to_json
 end
 
 def action_hash
-  input_args = JSON.load($stdin)["input"]
-  hash['output'] = input_args['input'].reverse
-  puts hash.to_json
+  args = JSON.load($stdin)
+  check_output_files(args)
+  input_args = args['input']
+  input_args['the_output'] = input_args['the_input'].reverse
+  puts input_args.to_json
 end
 
 action = ARGV.shift || 'metadata'

--- a/lib/tests/resources/modules/reverse_valid
+++ b/lib/tests/resources/modules/reverse_valid
@@ -32,7 +32,7 @@ def action_metadata
           },
           :required => [ :argument ],
         },
-        :output => {
+        :results => {
           :type => "object",
           :properties => {
             :output => {
@@ -53,7 +53,7 @@ def action_metadata
           },
           :required => [ :input ],
         },
-        :output => {
+        :results => {
           :type => "object",
           :properties => {
             :input => {
@@ -73,14 +73,14 @@ def action_metadata
 end
 
 def action_string
-  params = JSON.load($stdin)["params"]
-  output = { :output => params['argument'].reverse }
-  puts output.to_json
+  input_args = JSON.load($stdin)["input"]
+  results = { :output => input_args['argument'].reverse }
+  puts results.to_json
 end
 
 def action_hash
-  hash = JSON.load($stdin)["params"]
-  hash['output'] = hash['input'].reverse
+  input_args = JSON.load($stdin)["input"]
+  hash['output'] = input_args['input'].reverse
   puts hash.to_json
 end
 

--- a/lib/tests/unit/external_module_test.cc
+++ b/lib/tests/unit/external_module_test.cc
@@ -13,8 +13,6 @@
 
 #include <boost/filesystem/operations.hpp>
 
-#include <horsewhisperer/horsewhisperer.h>
-
 #include <catch.hpp>
 
 #include <string>
@@ -30,7 +28,6 @@
 namespace PXPAgent {
 
 namespace fs = boost::filesystem;
-namespace HW = HorseWhisperer;
 namespace lth_jc = leatherman::json_container;
 namespace lth_util = leatherman::util;
 namespace lth_file = leatherman::file_util;
@@ -146,7 +143,6 @@ static void configureTest() {
         [](std::vector<std::string>) {
             return EXIT_SUCCESS;
         });
-    HW::SetFlag<std::string>("spool-dir", SPOOL_DIR);
 }
 
 static void resetTest() {
@@ -223,7 +219,9 @@ TEST_CASE("ExternalModule::callAction - non blocking", "[modules]") {
                              EXTENSION };
         ActionRequest request { RequestType::NonBlocking, NON_BLOCKING_CONTENT };
         fs::path spool_path { SPOOL_DIR };
-        fs::create_directories(spool_path / request.transactionId());
+        auto results_dir = (spool_path / request.transactionId()).string();
+        fs::create_directories(results_dir);
+        request.setResultsDir(results_dir);
         auto pid_path = spool_path / request.transactionId() / "pid";
 
         REQUIRE_NOTHROW(e_m.executeAction(request));

--- a/lib/tests/unit/modules/status_test.cc
+++ b/lib/tests/unit/modules/status_test.cc
@@ -136,8 +136,10 @@ TEST_CASE("Modules::Status::executeAction", "[modules]") {
 
             fs::path dest { SPOOL_DIR };
             dest /= symlink_name;
+            request.setResultsDir(dest.string());
+
             if (!fs::exists(dest) && !fs::create_directories(dest)) {
-                FAIL("Failed to create test directory");
+                FAIL("Failed to create the results directory");
             }
 
             try {


### PR DESCRIPTION
With this PR, we rely on external modules for writing action output to file,
in case of non-blocking requests.

This is achieved by using the new interface for external modules.

ExternalModule now uses the leatherman::execution::execute variant
that only processes PID, without processing stdout/stderr.