### PR TITLE
(maint) Acceptance - Workaround for PCP-253 (PCP client.connect)

### DIFF
--- a/acceptance/lib/pxp-agent/test_helper.rb
+++ b/acceptance/lib/pxp-agent/test_helper.rb
@@ -93,7 +93,10 @@ def rpc_blocking_request(broker, targets,
     end
   end
 
-  client.connect()
+  if !client.connect(5)
+    raise "Controller PCP client failed to connect with pcp-broker on #{broker}"
+  end
+  
   if !client.associated?
     raise "Controller PCP client failed to associate with pcp-broker on #{broker}"
   end


### PR DESCRIPTION
When ruby-pcp-client has client.connect() called with the default timeout (0), it might fail due to thread logic.
The workaround (this commit) is to specify a non-zero timeout value.
Also add checking of the result of connect and raise an exception if it doesn't return true.