### PR TITLE
(PCP-251) support for saving stdout/stderr/exitcode to files

### DIFF
--- a/modules/pxp-module-puppet
+++ b/modules/pxp-module-puppet
@@ -51,9 +51,9 @@ def disabled?(run_result)
   !!(run_result =~ /disabled(.*?)Use 'puppet agent --enable' to re-enable/m)
 end
 
-def make_environment_hash(params)
+def make_environment_hash(action_input)
   env_hash = {}
-  params["env"].each do |entry|
+  action_input["env"].each do |entry|
     key, value = entry.split('=')
     env_hash[key] = value
   end
@@ -61,9 +61,9 @@ def make_environment_hash(params)
   return env_hash
 end
 
-def make_command_array(config, params)
+def make_command_array(config, action_input)
   cmd_array = [config["puppet_bin"], "agent"]
-  cmd_array +=  params["flags"]
+  cmd_array +=  action_input["flags"]
   return cmd_array
 end
 
@@ -76,6 +76,10 @@ end
 
 def get_result_from_report(exitcode, config, start_time)
   last_run_report = check_config_print("lastrunreport",config)
+  if last_run_report.empty?
+    return make_error_result(exitcode, Errors::NoLastRunReport,
+                             "could not find the location of the last run report")
+  end
 
   if !File.exist?(last_run_report)
     return make_error_result(exitcode, Errors::NoLastRunReport,
@@ -91,9 +95,9 @@ def get_result_from_report(exitcode, config, start_time)
                              "#{last_run_report} could not be loaded: #{e}")
   end
 
-  run_result = last_run_result(exitcode)
-
-  if exitcode != 0
+  if exitcode == 0
+    run_result = last_run_result(exitcode)
+  else
     run_result = make_error_result(exitcode, Errors::NonZeroExit,
                                    "Puppet agent exited with a non 0 exitcode")
   end
@@ -109,10 +113,10 @@ def get_result_from_report(exitcode, config, start_time)
   return run_result
 end
 
-def start_run(config, params)
+def start_run(config, action_input)
   exitcode = DEFAULT_EXITCODE
-  cmd = make_command_array(config, params)
-  env = make_environment_hash(params)
+  cmd = make_command_array(config, action_input)
+  env = make_environment_hash(action_input)
   start_time = Time.now
 
   run_result = Puppet::Util::Execution.execute(cmd, {:failonfail => false,
@@ -124,11 +128,12 @@ def start_run(config, params)
   end
 
   exitcode = run_result.exitstatus
+  puppet_output = run_result.to_s
 
-  if disabled?(run_result.to_s)
+  if disabled?(puppet_output)
     return make_error_result(exitcode, Errors::Disabled,
                              "Puppet agent is disabled")
-  elsif running?(run_result.to_s)
+  elsif running?(puppet_output)
     return make_error_result(exitcode, Errors::AlreadyRunning,
                              "Puppet agent is already performing a run")
   end
@@ -154,7 +159,7 @@ def metadata()
           },
           :required => [:env, :flags]
         },
-        :output => {
+        :results => {
           :type => "object",
           :properties => {
             :kind => {
@@ -201,15 +206,17 @@ def metadata()
   }
 end
 
-def run(params_and_config)
-  if !params_and_config
-    return make_error_result(DEFAULT_EXITCODE, Errors::InvalidJson,
-                             "Invalid json parsed on STDIN. Cannot start run action")
+def run(config, action_input)
+  if !File.exist?(config["puppet_bin"])
+    return make_error_result(DEFAULT_EXITCODE, Errors::NoPuppetBin,
+                             "Puppet executable '#{config["puppet_bin"]}' does not exist")
   end
 
-  params = params_and_config["params"]
-  config = params_and_config["config"]
-  params["flags"] = params["flags"] | ["--onetime", "--no-daemonize", "--verbose"]
+  return start_run(config, action_input)
+end
+
+def get_configuration(args)
+  config = args["configuration"] || {}
 
   if config["puppet_bin"].nil? || config["puppet_bin"].empty?
     if !is_win?
@@ -221,12 +228,59 @@ def run(params_and_config)
     end
   end
 
-  if !File.exist?(config["puppet_bin"])
-    return make_error_result(DEFAULT_EXITCODE, Errors::NoPuppetBin,
-                             "Puppet executable '#{config["puppet_bin"]}' does not exist")
+  config
+end
+
+def get_action_input(args)
+  action_input = args["input"]
+  action_input["flags"] = action_input["flags"] | ["--onetime", "--no-daemonize", "--verbose"]
+  action_input
+end
+
+def action_run(args)
+  if !args
+    return make_error_result(DEFAULT_EXITCODE, Errors::InvalidJson,
+                             "Invalid json parsed on STDIN. Cannot start run action")
   end
 
-  return start_run(config, params)
+  output_files = args["output_files"]
+  if output_files
+    begin
+      $stdout.reopen(File.open(output_files["stdout"], 'w'))
+      $stderr.reopen(File.open(output_files["stderr"], 'w'))
+    rescue => e
+      print make_error_result(DEFAULT_EXITCODE, Errors::InvalidJson,
+                              "Could not open output files: #{e.message}").to_json
+      exit 5 # this exit code is reserved for problems with opening
+             # of the output_files
+    end
+
+    at_exit do
+      status = if $!.nil?
+        0
+      elsif $!.is_a?(SystemExit)
+        $!.status
+      else
+        1
+      end
+
+      begin
+        File.open(output_files["exitcode"], 'w') do |f|
+          f.puts(status)
+        end
+      rescue => e
+        print make_error_result(DEFAULT_EXITCODE, Errors::InvalidJson,
+                                "Could not open exit code file: #{e.message}").to_json
+        exit 5 # this exit code is reserved for problems with opening
+               # of the output_files
+      end
+    end
+  end
+
+  config = get_configuration(args)
+  action_input = get_action_input(args)
+
+  run(config, action_input)
 end
 
 if __FILE__ == $0
@@ -235,12 +289,12 @@ if __FILE__ == $0
   if action == 'metadata'
     puts metadata.to_json
   else
-    params_and_config = JSON.parse($stdin.read.chomp) rescue nil
+    args = JSON.parse($stdin.read.chomp) rescue nil
 
-    run_result = run(params_and_config)
-    puts run_result.to_json
+    action_results = action_run(args)
+    print action_results.to_json
 
-    if !run_result["error"].nil?
+    unless action_results["error"].nil?
       exit 1
     end
   end

--- a/modules/spec/unit/modules/puppet_spec.rb
+++ b/modules/spec/unit/modules/puppet_spec.rb
@@ -4,11 +4,11 @@ load File.join(File.dirname(__FILE__), "../", "../", "../", "pxp-module-puppet")
 
 describe "pxp-module-puppet" do
 
-  let(:default_params) {
+  let(:default_input) {
     {"env" => [], "flags" => []}
   }
 
-  let(:default_config) {
+  let(:default_configuration) {
     {"puppet_bin" => "puppet"}
   }
 
@@ -28,7 +28,7 @@ describe "pxp-module-puppet" do
     it "returns the result of configprint" do
       cli_vec = ["puppet", "agent", "--configprint", "value"]
       expect(Puppet::Util::Execution).to receive(:execute).with(cli_vec).and_return("value\n")
-      expect(check_config_print("value", default_config)).to be == "value"
+      expect(check_config_print("value", default_configuration)).to be == "value"
     end
   end
 
@@ -64,24 +64,24 @@ describe "pxp-module-puppet" do
 
   describe "make_environment_hash" do
     it "should correctly add the env entries" do
-      params = default_params
-      params["env"] = ["FOO=bar", "BAR=foo"]
-      expect(make_environment_hash(params)).to be ==
+      input = default_input
+      input["env"] = ["FOO=bar", "BAR=foo"]
+      expect(make_environment_hash(input)).to be ==
         {"FOO" => "bar", "BAR" => "foo"}
     end
   end
 
   describe "make_command_array" do
     it "should correctly append the executable and action" do
-      params = default_params
-      expect(make_command_array(default_config, params)).to be ==
+      input = default_input
+      expect(make_command_array(default_configuration, input)).to be ==
         ["puppet", "agent"]
     end
 
     it "should correctly append any flags" do
-      params = default_params
-      params["flags"] = ["--noop", "--verbose"]
-      expect(make_command_array(default_config, params)).to be ==
+      input = default_input
+      input["flags"] = ["--noop", "--verbose"]
+      expect(make_command_array(default_configuration, input)).to be ==
         ["puppet", "agent", "--noop", "--verbose"]
     end
   end
@@ -105,7 +105,7 @@ describe "pxp-module-puppet" do
     it "doesn't process the last_run_report if the file doens't exist" do
       allow(File).to receive(:exist?).and_return(false)
       allow_any_instance_of(Object).to receive(:check_config_print).and_return("/opt/puppetlabs/puppet/cache/state/last_run_report.yaml")
-      expect(get_result_from_report(0, default_config, Time.now)).to be ==
+      expect(get_result_from_report(0, default_configuration, Time.now)).to be ==
           {"kind"             => "unknown",
            "time"             => "unknown",
            "transaction_uuid" => "unknown",
@@ -121,7 +121,7 @@ describe "pxp-module-puppet" do
       allow(File).to receive(:exist?).and_return(true)
       allow_any_instance_of(Object).to receive(:check_config_print).and_return("/opt/puppetlabs/puppet/cache/state/last_run_report.yaml")
       allow(YAML).to receive(:load_file).and_raise("error")
-      expect(get_result_from_report(0, default_config, Time.now)).to be ==
+      expect(get_result_from_report(0, default_configuration, Time.now)).to be ==
           {"kind"             => "unknown",
            "time"             => "unknown",
            "transaction_uuid" => "unknown",
@@ -148,7 +148,7 @@ describe "pxp-module-puppet" do
       allow_any_instance_of(Object).to receive(:check_config_print).and_return("/opt/puppetlabs/puppet/cache/state/last_run_report.yaml")
       allow(YAML).to receive(:load_file).and_return(last_run_report)
 
-      expect(get_result_from_report(-1, default_config, start_time)).to be ==
+      expect(get_result_from_report(-1, default_configuration, start_time)).to be ==
           {"kind"             => "unknown",
            "time"             => "unknown",
            "transaction_uuid" => "unknown",
@@ -175,7 +175,7 @@ describe "pxp-module-puppet" do
       allow_any_instance_of(Object).to receive(:check_config_print).and_return("/opt/puppetlabs/puppet/cache/state/last_run_report.yaml")
       allow(YAML).to receive(:load_file).and_return(last_run_report)
 
-      expect(get_result_from_report(-1, default_config, start_time)).to be ==
+      expect(get_result_from_report(-1, default_configuration, start_time)).to be ==
           {"kind"             => "apply",
            "time"             => run_time,
            "transaction_uuid" => "ac59acbe-6a0f-49c9-8ece-f781a689fda9",
@@ -202,7 +202,7 @@ describe "pxp-module-puppet" do
       allow_any_instance_of(Object).to receive(:check_config_print).and_return("/opt/puppetlabs/puppet/cache/state/last_run_report.yaml")
       allow(YAML).to receive(:load_file).and_return(last_run_report)
 
-      expect(get_result_from_report(0, default_config, start_time)).to be ==
+      expect(get_result_from_report(0, default_configuration, start_time)).to be ==
           {"kind"             => "apply",
            "time"             => run_time,
            "transaction_uuid" => "ac59acbe-6a0f-49c9-8ece-f781a689fda9",
@@ -221,21 +221,21 @@ describe "pxp-module-puppet" do
     it "populates output when it terminated normally" do
       allow(Puppet::Util::Execution).to receive(:execute).and_return(runoutcome)
       allow(runoutcome).to receive(:exitstatus).and_return(0)
-      expect_any_instance_of(Object).to receive(:get_result_from_report).with(0, default_config, anything)
-      start_run(default_config, default_params)
+      expect_any_instance_of(Object).to receive(:get_result_from_report).with(0, default_configuration, anything)
+      start_run(default_configuration, default_input)
     end
 
     it "populates output when it terminated with a non 0 code" do
       allow(Puppet::Util::Execution).to receive(:execute).and_return(runoutcome)
       allow(runoutcome).to receive(:exitstatus).and_return(1)
-      expect_any_instance_of(Object).to receive(:get_result_from_report).with(1, default_config, anything)
-      start_run(default_config, default_params)
+      expect_any_instance_of(Object).to receive(:get_result_from_report).with(1, default_configuration, anything)
+      start_run(default_configuration, default_input)
     end
 
     it "populates output when it couldn't start" do
       allow(Puppet::Util::Execution).to receive(:execute).and_return(nil)
       expect_any_instance_of(Object).to receive(:make_error_result).with(-1, Errors::FailedToStart, anything)
-      start_run(default_config, default_params)
+      start_run(default_configuration, default_input)
     end
 
     it "populates the output if puppet is disabled" do
@@ -243,7 +243,7 @@ describe "pxp-module-puppet" do
       allow(runoutcome).to receive(:exitstatus).and_return(1)
       allow_any_instance_of(Object).to receive(:disabled?).and_return(true)
       expect_any_instance_of(Object).to receive(:make_error_result).with(1, Errors::Disabled, anything)
-      start_run(default_config, default_params)
+      start_run(default_configuration, default_input)
     end
 
     it "populates the output when puppet is alreaady running" do
@@ -252,7 +252,7 @@ describe "pxp-module-puppet" do
       allow_any_instance_of(Object).to receive(:disabled?).and_return(false)
       allow_any_instance_of(Object).to receive(:running?).and_return(true)
       expect_any_instance_of(Object).to receive(:make_error_result).with(1, Errors::AlreadyRunning, anything)
-      start_run(default_config, default_params)
+      start_run(default_configuration, default_input)
     end
   end
 
@@ -275,7 +275,7 @@ describe "pxp-module-puppet" do
               },
               :required => [:env, :flags]
             },
-            :output => {
+            :results => {
               :type => "object",
               :properties => {
                 :kind => {
@@ -323,42 +323,42 @@ describe "pxp-module-puppet" do
     end
   end
 
-  describe "run" do
+  describe "action_run" do
     it "fails when puppet_bin doesn't exist" do
       allow(File).to receive(:exist?).and_return(false)
-      expect(run({"config" => default_config, "params" => default_params})["error"]).to be ==
+      expect(action_run({"configuration" => default_configuration, "input" => default_input})["error"]).to be ==
           "Puppet executable 'puppet' does not exist"
     end
 
     it "fails when invalid json is passed" do
       # JSON is parsed when the action is invoked. Any invalid json will call run
       # with nil
-      expect(run(nil)["error"]).to be ==
+      expect(action_run(nil)["error"]).to be ==
           "Invalid json parsed on STDIN. Cannot start run action"
     end
 
     it "populates flags with the correct defaults" do
-      expected_params = {"env" => [],
-                         "flags" => ["--onetime", "--no-daemonize", "--verbose"]}
+      expected_input = {"env" => [],
+                        "flags" => ["--onetime", "--no-daemonize", "--verbose"]}
       allow(File).to receive(:exist?).and_return(true)
       allow_any_instance_of(Object).to receive(:running?).and_return(false)
       allow_any_instance_of(Object).to receive(:disabled?).and_return(false)
-      expect_any_instance_of(Object).to receive(:start_run).with(default_config,
-                                                                 expected_params)
-      run({"config" => default_config, "params" => default_params})
+      expect_any_instance_of(Object).to receive(:start_run).with(default_configuration,
+                                                                 expected_input)
+      action_run({"configuration" => default_configuration, "input" => default_input})
     end
 
     it "does not add flag defaults if they have been passed" do
-      expected_params = {"env" => [],
-                         "flags" => ["--squirrels", "--onetime", "--no-daemonize", "--verbose"]}
-      passed_params = {"env" => [],
-                       "flags" => ["--squirrels", "--onetime", "--no-daemonize"]}
+      expected_input = {"env" => [],
+                        "flags" => ["--squirrels", "--onetime", "--no-daemonize", "--verbose"]}
+      passed_input = {"env" => [],
+                      "flags" => ["--squirrels", "--onetime", "--no-daemonize"]}
       allow(File).to receive(:exist?).and_return(true)
       allow_any_instance_of(Object).to receive(:running?).and_return(false)
       allow_any_instance_of(Object).to receive(:disabled?).and_return(false)
-      expect_any_instance_of(Object).to receive(:start_run).with(default_config,
-                                                                 expected_params)
-      run({"config" => default_config, "params" => passed_params})
+      expect_any_instance_of(Object).to receive(:start_run).with(default_configuration,
+                                                                 expected_input)
+      action_run({"configuration" => default_configuration, "input" => passed_input})
     end
 
     it "starts the run" do
@@ -366,7 +366,7 @@ describe "pxp-module-puppet" do
       allow_any_instance_of(Object).to receive(:running?).and_return(false)
       allow_any_instance_of(Object).to receive(:disabled?).and_return(false)
       expect_any_instance_of(Object).to receive(:start_run)
-      run({"config" => default_config, "params" => default_params})
+      action_run({"configuration" => default_configuration, "input" => default_input})
     end
   end
 end


### PR DESCRIPTION
The pxp-module-puppet's run action can now save its standard output / standard error / exit code to files specified in the action's input.