### PR TITLE
(maint) ExternalModule deals with empty module's output

### DIFF
--- a/lib/src/external_module.cc
+++ b/lib/src/external_module.cc
@@ -288,7 +288,8 @@ ActionOutcome ExternalModule::processRequestOutcome(const ActionRequest& request
 
     try {
         // Ensure output format is valid JSON by instantiating JsonContainer
-        lth_jc::JsonContainer results { out_txt };
+        // NB: JsonContainer's ctor does not accept empty strings
+        lth_jc::JsonContainer results { (out_txt.empty() ? "null" : out_txt) };
         return ActionOutcome { exit_code, err_txt, out_txt, results };
     } catch (lth_jc::data_parse_error& e) {
         LOG_ERROR("'%1% %2%' output is not valid JSON: %3%",


### PR DESCRIPTION
As external modules can now return "5" in case they fail to write their
output, JsonContainer must be correctly instantiated in case there's no
output.

Also, external modules can return no output in case of error.

Ensuring JsonContainer is instantiated with "null" string in that case.
The validation is performed after that, by the parent Module class.