### PR TITLE
(maint) Set cmake's -DTEST_VIRTUAL for Travis/Appveyor

### DIFF
--- a/.travis_target.sh
+++ b/.travis_target.sh
@@ -33,7 +33,10 @@ cd ..
 if [ ${TRAVIS_TARGET} == DEBUG ]; then
   TARGET_OPTS="-DCMAKE_BUILD_TYPE=Debug -DCOVERALLS=ON"
 fi
-cmake $TARGET_OPTS -DCMAKE_PREFIX_PATH=$USERDIR -DCMAKE_INSTALL_PREFIX=$USERDIR .
+
+# NB: TEST_VIRTUAL enables virtual functions in PXPConnector and the
+# unit tests that rely on them for mocking cpp-pcp-client's Connector.
+cmake $TARGET_OPTS -DCMAKE_PREFIX_PATH=$USERDIR -DCMAKE_INSTALL_PREFIX=$USERDIR -DTEST_VIRTUAL=ON .
 
 if [ ${TRAVIS_TARGET} == CPPLINT ]; then
   make cpplint

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,7 @@ install:
   - cd ..
 
 build_script:
-  - ps: cmake -G "MinGW Makefiles" -DBOOST_ROOT="C:\tools\boost_1_58_0-x86_64_mingw-w64_4.8.3_win32_seh" -DBOOST_STATIC=ON -DCURL_STATIC=ON -Wno-dev -DCMAKE_PREFIX_PATH="C:\tools\leatherman;C:\tools\curl-7.42.1-x86_64_mingw-w64_4.8.3_win32_seh;C:\tools;C:\tools\bin" -DCMAKE_INSTALL_PREFIX=C:\tools .
+  - ps: cmake -G "MinGW Makefiles" -DBOOST_ROOT="C:\tools\boost_1_58_0-x86_64_mingw-w64_4.8.3_win32_seh" -DBOOST_STATIC=ON -DCURL_STATIC=ON -Wno-dev -DCMAKE_PREFIX_PATH="C:\tools\leatherman;C:\tools\curl-7.42.1-x86_64_mingw-w64_4.8.3_win32_seh;C:\tools;C:\tools\bin" -DCMAKE_INSTALL_PREFIX=C:\tools -DTEST_VIRTUAL=ON .
   - ps: mingw32-make install
 
 test_script:


### PR DESCRIPTION
Flagging the build option that enables virtual functions of PXPConnector
and related unit tests that rely on mocking the PCP Connector logic.