### PR TITLE
(PCP-167) Change acceptance tests to not rely on logs to assert association

### DIFF
--- a/acceptance/lib/pxp-agent/test_helper.rb
+++ b/acceptance/lib/pxp-agent/test_helper.rb
@@ -7,9 +7,6 @@ require 'pcp/client'
 PXP_LOG_FILE_CYGPATH = '/cygdrive/c/ProgramData/PuppetLabs/pxp-agent/var/log/pxp-agent.log'
 PXP_LOG_FILE_POSIX = '/var/log/puppetlabs/pxp-agent/pxp-agent.log'
 
-PXP_AGENT_LOG_ENTRY_WEBSOCKET_SUCCESS = 'INFO.*Successfully established a WebSocket connection with the PCP broker.*'
-PXP_AGENT_LOG_ENTRY_ASSOCIATION_SUCCESS = 'INFO.*Received associate session response.*success'
-
 # @param host the beaker host you want the path to the log file on
 # @return The path to the log file on the host. For Windows, a cygpath is returned
 def logfile(host)

--- a/acceptance/tests/pxp-module-puppet/run_puppet.rb
+++ b/acceptance/tests/pxp-module-puppet/run_puppet.rb
@@ -8,7 +8,8 @@ test_name 'C95972 - pxp-module-puppet run' do
       cert_dir = configure_std_certs_on_host(agent)
       create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_test_certs(master, agent, i + 1, cert_dir).to_s)
       on agent, puppet('resource service pxp-agent ensure=running')
-      expect_file_on_host_to_contain(agent, logfile(agent), PXP_AGENT_LOG_ENTRY_ASSOCIATION_SUCCESS, seconds_to_wait = 60)
+      assert(is_associated?(master, "pcp://client0#{i+1}.example.com/agent"),
+             "Agent #{agent} with PCP identity pcp://client0#{i+1}.example.com/agent should be associated with pcp-broker")
     end
   end
 


### PR DESCRIPTION
Check pcp-broker's inventory to see if pxp-agent is included; instead of grepping pxp-agent.log, which is subject to change at any time
[skip ci]