### PR TITLE
(maint) Add dependency on librt

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -52,6 +52,11 @@ set (LIBS
     ${LEATHERMAN_LIBRARIES}
 )
 
+if (CMAKE_SYSTEM_NAME MATCHES "Linux" OR CMAKE_SYSTEM_NAME MATCHES "SunOS")
+    # On some platforms Boost.Thread has a dependency on clock_gettime.
+    list(APPEND LIBS rt)
+endif()
+
 add_library(libpxp-agent STATIC ${LIBRARY_COMMON_SOURCES} ${LIBRARY_STANDARD_SOURCES})
 target_link_libraries(libpxp-agent ${LIBS})
 set_target_properties(libpxp-agent PROPERTIES PREFIX "" IMPORT_PREFIX "")


### PR DESCRIPTION
pxp-agent uses Boost.Thread directly, which on some platforms has a
dependency on librt. Previously it picked up the dependency as a
side-effect of using Leatherman, which is fragile when using Leatherman
shared libraries and Boost static libraries.