### PR TITLE
(PE-13918) Solaris pxp-agent stopped after 2015.2.3 to 2015.3.x upgrade

### DIFF
--- a/ext/solaris/smf/pxp-agent.xml
+++ b/ext/solaris/smf/pxp-agent.xml
@@ -7,10 +7,6 @@
     <create_default_instance enabled="false"/>
     <single_instance/>
 
-    <dependency name="config-file" grouping="require_all" restart_on="none" type="path">
-      <service_fmri value="file:///etc/puppetlabs/pxp-agent/pxp-agent.conf"/>
-    </dependency>
-
     <dependency name="loopback" grouping="require_all" restart_on="error" type="service">
       <service_fmri value="svc:/network/loopback:default"/>
     </dependency>


### PR DESCRIPTION
Prior to this change the pxp-agent service was configured with a dependancy
on pxp-agent.conf which doesn't exist imediately following an upgrade of PE.
This state results in the service not starting as expected until the first
puppet run following the upgrade.

This commit removes the dependancy on pxp-agent.conf which allows the service
to start.