### PR TITLE
(maint) Remove job_id entry from RPC Error schema

### DIFF
--- a/lib/src/pxp_schemas.cc
+++ b/lib/src/pxp_schemas.cc
@@ -44,7 +44,6 @@ PCPClient::Schema NonBlockingResponseSchema() {
     PCPClient::Schema schema { NON_BLOCKING_RESPONSE_TYPE, C_Type::Json };
     // NB: additionalProperties = false
     schema.addConstraint("transaction_id", T_Constraint::String, true);
-    schema.addConstraint("job_id", T_Constraint::String, true);
     schema.addConstraint("results", T_Constraint::Object, true);
     return schema;
 }


### PR DESCRIPTION
Removing that entry as is not in the specs anymore.

[skip ci]