### PR TITLE
(maint) Fix dependencies on AIX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ endif()
 
 find_package(Leatherman REQUIRED COMPONENTS ${LEATHERMAN_COMPONENTS})
 find_package(Boost 1.54 REQUIRED
-  COMPONENTS filesystem system date_time thread log regex random)
+  COMPONENTS filesystem chrono system date_time thread log regex random)
 find_package(OpenSSL REQUIRED)
 find_package(cpp-pcp-client REQUIRED)
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -52,9 +52,11 @@ set (LIBS
     ${LEATHERMAN_LIBRARIES}
 )
 
-if (CMAKE_SYSTEM_NAME MATCHES "Linux" OR CMAKE_SYSTEM_NAME MATCHES "SunOS")
-    # On some platforms Boost.Thread has a dependency on clock_gettime.
-    list(APPEND LIBS rt)
+if (CMAKE_SYSTEM_NAME MATCHES "Linux" OR CMAKE_SYSTEM_NAME MATCHES "SunOS" OR CMAKE_SYSTEM_NAME MATCHES "AIX")
+    # On some platforms Boost.Thread has a dependency on clock_gettime. It also depends on pthread,
+    # and FindBoost in CMake 3.2.3 doesn't include that dependency.
+    find_package(Threads)
+    list(APPEND LIBS rt ${CMAKE_THREAD_LIBS_INIT})
 endif()
 
 add_library(libpxp-agent STATIC ${LIBRARY_COMMON_SOURCES} ${LIBRARY_STANDARD_SOURCES})


### PR DESCRIPTION
librt and Boost.Chrono are dependencies of pxp-agent, which need to be
included explicitly on AIX.