### PR TITLE
(PCP-206) clearer structure of pxp-module-puppet output

### DIFF
--- a/modules/pxp-module-puppet
+++ b/modules/pxp-module-puppet
@@ -28,13 +28,13 @@ def is_win?
 end
 
 def last_run_result(exitcode)
-  return {"kind"             => "unknown",
-          "time"             => "unknown",
-          "transaction_uuid" => "unknown",
-          "environment"      => "unknown",
-          "status"           => "unknown",
-          "exitcode"         => exitcode,
-          "version"          => 1}
+  return {"report"   => {"kind"             => "unknown",
+                         "time"             => "unknown",
+                         "transaction_uuid" => "unknown",
+                         "environment"      => "unknown",
+                         "status"           => "unknown"},
+          "exitcode" => exitcode,
+          "version"  => 1}
 end
 
 def check_config_print(cli_arg, config)
@@ -103,11 +103,12 @@ def get_result_from_report(exitcode, config, start_time)
   end
 
   if start_time.to_i < last_run_report_yaml.time.to_i
-    run_result["kind"] = last_run_report_yaml.kind
-    run_result["time"] = last_run_report_yaml.time
-    run_result["transaction_uuid"] = last_run_report_yaml.transaction_uuid
-    run_result["environment"] = last_run_report_yaml.environment
-    run_result["status"] = last_run_report_yaml.status
+    report = run_result["report"]
+    report["kind"] = last_run_report_yaml.kind
+    report["time"] = last_run_report_yaml.time
+    report["transaction_uuid"] = last_run_report_yaml.transaction_uuid
+    report["environment"] = last_run_report_yaml.environment
+    report["status"] = last_run_report_yaml.status
   end
 
   return run_result
@@ -162,20 +163,26 @@ def metadata()
         :results => {
           :type => "object",
           :properties => {
-            :kind => {
-              :type => "string"
-            },
-            :time => {
-              :type => "string"
-            },
-            :transaction_uuid => {
-              :type => "string"
-            },
-            :environment => {
-              :type => "string"
-            },
-            :status => {
-              :type => "string"
+            :report => {
+              :type => "object",
+              :properties => {
+                :kind => {
+                  :type => "string"
+                },
+                :time => {
+                  :type => "string"
+                },
+                :transaction_uuid => {
+                  :type => "string"
+                },
+                :environment => {
+                  :type => "string"
+                },
+                :status => {
+                  :type => "string"
+                }
+              },
+              :required => [:kind, :time, :transaction_uuid, :environment, :status]
             },
             :error_type => {
               :type => "string"
@@ -190,8 +197,7 @@ def metadata()
               :type => "number"
             }
           },
-          :required => [:kind, :time, :transaction_uuid, :environment, :status,
-                        :exitcode, :version]
+          :required => [:report, :exitcode, :version]
         }
       }
     ],
@@ -291,10 +297,10 @@ if __FILE__ == $0
   else
     args = JSON.parse($stdin.read.chomp) rescue nil
 
-    action_results = action_run(args)
-    print action_results.to_json
+    action_output = action_run(args)
+    print action_output.to_json
 
-    unless action_results["error"].nil?
+    unless action_output["error"].nil?
       exit 1
     end
   end

--- a/modules/pxp-module-puppet.md
+++ b/modules/pxp-module-puppet.md
@@ -63,32 +63,50 @@ C:\Program Files\Puppet Labs\Puppet\pxp-agent\modules>echo {"input":{"env":[],"f
 ## Output
 
 On successful completion of a Puppet run the module will print a JSON document to
-stdout. The JSON document will have the following fields.
+stdout. The JSON document will conform to the following JSON schema:
 
-- `kind` : The value of `kind` in last_run_report.yaml
-- `time` : The value of `time` in last_run_report.yaml
-- `transaction_uuid` : The value of `transaction_uuid` in last_run_report.yaml
-- `environment` : The value of `environment` in last_run_report.yaml
-- `status` : The value of `status` in last_run_report.yaml
-- `error_type` : A string containing the machine readable error type
-- `error` : A string containing an error description if one occurred when trying to run Puppet
-- `exitcode` : The exitcode of the Puppet run
-- `version` : The version of pxp-module-puppet output schema
+```
+{
+    "type" : "object",
+    "description" : "pxp-module-puppet output structure",
+    "properties" : {
+        "version" : { "type" : "number", "description" : "The version of pxp-module-puppet output schema" },
+        "report" : {
+            "type" : "object",
+            "description" : "Selected fields from the `last_run_report.yaml` file",
+            "properties" : {
+                "kind" : { "type" : "string", "desription" : "The value of `kind` in `last_run_report.yaml`" },
+                "time" : { "type" : "string", "desription" : "The value of `time` in `last_run_report.yaml`" },
+                "transaction_uuid" : { "type" : "string", "desription" : "The value of `transaction_uuid` in `last_run_report.yaml`" },
+                "environment" : { "type" : "string", "desription" : "The value of `environment` in `last_run_report.yaml`" },
+                "status" : { "type" : "string", "desription" : "The value of `status` in `last_run_report.yaml`" }
+            },
+            "required" : ["kind", "time", "transaction_uuid", "environment", "status"],
+            "additionalProperties" : false
+        },
+        "exitcode" : { "type" : "number", "description" : "The exitcode of the Puppet run" },
+        "error_type" : { "type" : "string", "description" : "A machine readable error type if one occurred when trying to run Puppet" },
+        "error" : { "type" : "string", "description" : "A human readable description of the error if one occurred when trying to run Puppet" }
+    },
+    "required" : ["version", "report", "exitcode"],
+    "additionalProperties" : false
+}
+```
 
 ## Error cases
 
 ### Error Types
 
-If a run fails the `"error_type"` field will be set to one of the following values:
+If a run fails the `error_type` field will be set to one of the following values:
 
-- `"invalid_json"` pxp-module-puppet was called with invalid json on stdin
-- `"no_puppet_bin"` The executable specified by `puppet_bin` doesn't exist
-- `"no_last_run_report"` last_run_report.yaml doesn't exist
-- `"invalid_last_run_report"` last_run_report.yaml could not be parsed
-- `"agent_already_running"` Puppet agent is already performing a run
-- `"agent_disabled"` Puppet agent is disabled
-- `"agent_failed_to_start"` Puppet agent failed to start
-- `"agent_exit_non_zero"` Puppet agent exited with a non-zero exitcode
+- `invalid_json` pxp-module-puppet was called with invalid json on stdin
+- `no_puppet_bin` The executable specified by `puppet_bin` doesn't exist
+- `no_last_run_report` last_run_report.yaml doesn't exist
+- `invalid_last_run_report` last_run_report.yaml could not be parsed
+- `agent_already_running` Puppet agent is already performing a run
+- `agent_disabled` Puppet agent is disabled
+- `agent_failed_to_start` Puppet agent failed to start
+- `agent_exit_non_zero` Puppet agent exited with a non-zero exitcode
 
 ### Example error responses
 
@@ -97,14 +115,17 @@ If a run fails the `"error_type"` field will be set to one of the following valu
 
 ```
 {
-    "kind" : "unknown",
-    "time" : "unknown",
-    "transaction_uuid" : "unknown",
-    "environment" : "unknown",
-    "status" : "unknown",
+    "report" : {
+        "kind" : "unknown",
+        "time" : "unknown",
+        "transaction_uuid" : "unknown",
+        "environment" : "unknown",
+        "status" : "unknown"
+    },
     "error_type" : "no_puppet_bin",
     "error" : "Puppet executable '$puppet_bin' does not exist",
-    "exitcode" : -1
+    "exitcode" : -1,
+    "version" : 1
 }
 ```
 
@@ -112,14 +133,17 @@ If a run fails the `"error_type"` field will be set to one of the following valu
 
 ```
 {
-    "kind" : "unknown",
-    "time" : "unknown",
-    "transaction_uuid" : "unknown",
-    "environment" : "unknown",
-    "status" : "unknown",
+    "report" : {
+        "kind" : "unknown",
+        "time" : "unknown",
+        "transaction_uuid" : "unknown",
+        "environment" : "unknown",
+        "status" : "unknown"
+    },
     "error_type" : "agent_already_running",
-    "error" : "Puppet is already running",
-    "exitcode" : -1
+    "error" : "Puppet agent is already performing a run",
+    "exitcode" : -1,
+    "version" : 1
 }
 ```
 
@@ -127,14 +151,17 @@ If a run fails the `"error_type"` field will be set to one of the following valu
 
 ```
 {
-    "kind" : "unknown",
-    "time" : "unknown",
-    "transaction_uuid" : "unknown",
-    "environment" : "unknown",
-    "status" : "unknown",
+    "report" : {
+        "kind" : "unknown",
+        "time" : "unknown",
+        "transaction_uuid" : "unknown",
+        "environment" : "unknown",
+        "status" : "unknown"
+    },
     "error_type" : "agent_disabled",
-    "error" : "Puppet is disabled",
-    "exitcode" : -1
+    "error" : "Puppet agent is disabled",
+    "exitcode" : -1,
+    "version" : 1
 }
 ```
 
@@ -142,14 +169,17 @@ If a run fails the `"error_type"` field will be set to one of the following valu
 
 ```
 {
-    "kind" : "unknown",
-    "time" : "unknown",
-    "transaction_uuid" : "unknown",
-    "environment" : "unknown",
-    "status" : "unknown",
+    "report" : {
+        "kind" : "unknown",
+        "time" : "unknown",
+        "transaction_uuid" : "unknown",
+        "environment" : "unknown",
+        "status" : "unknown"
+    },
     "error_type" : "invalid_json",
-    "error" : "Invalid json parsed on STDIN",
-    "exitcode" : -1
+    "error" : "Invalid json parsed on STDIN. Cannot start run action",
+    "exitcode" : -1,
+    "version" : 1
 }
 ```
 
@@ -157,14 +187,17 @@ If a run fails the `"error_type"` field will be set to one of the following valu
 
 ```
 {
-    "kind" : "unknown",
-    "time" : "unknown",
-    "transaction_uuid" : "unknown",
-    "environment" : "unknown",
-    "status" : "unknown",
+    "report" : {
+        "kind" : "unknown",
+        "time" : "unknown",
+        "transaction_uuid" : "unknown",
+        "environment" : "unknown",
+        "status" : "unknown"
+    },
     "error_type" : "agent_failed_to_start",
-    "error" : "Failed to start Puppet",
-    "exitcode" : -1
+    "error" : "Failed to start Puppet agent",
+    "exitcode" : -1,
+    "version" : 1
 }
 ```
 
@@ -172,14 +205,17 @@ If a run fails the `"error_type"` field will be set to one of the following valu
 
 ```
 {
-    "kind" : "unknown",
-    "time" : "unknown",
-    "transaction_uuid" : "unknown",
-    "environment" : "unknown",
-    "status" : "unknown",
+    "report" : {
+        "kind" : "unknown",
+        "time" : "unknown",
+        "transaction_uuid" : "unknown",
+        "environment" : "unknown",
+        "status" : "unknown"
+    },
     "error_type" : "agent_exit_non_zero",
-    "error" : "Puppet exited with a non 0 exitcode",
-    "exitcode" : $exitcode
+    "error" : "Puppet agent exited with a non 0 exitcode",
+    "exitcode" : $exitcode,
+    "version" : 1
 }
 ```
 
@@ -187,14 +223,17 @@ If a run fails the `"error_type"` field will be set to one of the following valu
 
 ```
 {
-    "kind" : "unknown",
-    "time" : "unknown",
-    "transaction_uuid" : "unknown",
-    "environment" : "unknown",
-    "status" : "unknown",
+    "report" : {
+        "kind" : "unknown",
+        "time" : "unknown",
+        "transaction_uuid" : "unknown",
+        "environment" : "unknown",
+        "status" : "unknown"
+    },
     "error_type" : "no_last_run_report",
-    "error" : "$last_run_report.yaml doesn't exist",
-    "exitcode" : $exitcode
+    "error" : "$last_run_report doesn't exist",
+    "exitcode" : $exitcode,
+    "version" : 1
 }
 ```
 
@@ -203,13 +242,16 @@ If a run fails the `"error_type"` field will be set to one of the following valu
 
 ```
 {
-    "kind" : "unknown",
-    "time" : "unknown",
-    "transaction_uuid" : "unknown",
-    "environment" : "unknown",
-    "status" : "unknown",
+    "report" : {
+        "kind" : "unknown",
+        "time" : "unknown",
+        "transaction_uuid" : "unknown",
+        "environment" : "unknown",
+        "status" : "unknown"
+    },
     "error_type" : "invalid_last_run_report",
-    "error" : "$last_run_report.yaml isn't valid yaml",
-    "exitcode" : exitcode
+    "error" : "$last_run_report could not be loaded: $error",
+    "exitcode" : $exitcode,
+    "version" : 1
 }
 ```

--- a/modules/spec/unit/modules/puppet_spec.rb
+++ b/modules/spec/unit/modules/puppet_spec.rb
@@ -14,13 +14,13 @@ describe "pxp-module-puppet" do
 
   describe "last_run_result" do
     it "returns the basic structure with exitcode set" do
-      expect(last_run_result(42)).to be == {"kind"             => "unknown",
-                                            "time"             => "unknown",
-                                            "transaction_uuid" => "unknown",
-                                            "environment"      => "unknown",
-                                            "status"           => "unknown",
-                                            "exitcode"         => 42,
-                                            "version"          => 1}
+      expect(last_run_result(42)).to be == {"report"   => {"kind"             => "unknown",
+                                                           "time"             => "unknown",
+                                                           "transaction_uuid" => "unknown",
+                                                           "environment"      => "unknown",
+                                                           "status"           => "unknown"},
+                                            "exitcode" => 42,
+                                            "version"  => 1}
     end
   end
 
@@ -89,15 +89,15 @@ describe "pxp-module-puppet" do
   describe "make_error_result" do
     it "should set the exitcode, error_type and error_message" do
       expect(make_error_result(42, Errors::FailedToStart, "test error")).to be ==
-          {"kind"             => "unknown",
-           "time"             => "unknown",
-           "transaction_uuid" => "unknown",
-           "environment"      => "unknown",
-           "status"           => "unknown",
-           "error_type"       => "agent_failed_to_start",
-           "error"            => "test error",
-           "exitcode"         => 42,
-           "version"          => 1}
+          {"report"     => {"kind"             => "unknown",
+                            "time"             => "unknown",
+                            "transaction_uuid" => "unknown",
+                            "environment"      => "unknown",
+                            "status"           => "unknown"},
+           "error_type" => "agent_failed_to_start",
+           "error"      => "test error",
+           "exitcode"   => 42,
+           "version"    => 1}
     end
   end
 
@@ -106,15 +106,15 @@ describe "pxp-module-puppet" do
       allow(File).to receive(:exist?).and_return(false)
       allow_any_instance_of(Object).to receive(:check_config_print).and_return("/opt/puppetlabs/puppet/cache/state/last_run_report.yaml")
       expect(get_result_from_report(0, default_configuration, Time.now)).to be ==
-          {"kind"             => "unknown",
-           "time"             => "unknown",
-           "transaction_uuid" => "unknown",
-           "environment"      => "unknown",
-           "status"           => "unknown",
-           "error_type"       => "no_last_run_report",
-           "error"            => "/opt/puppetlabs/puppet/cache/state/last_run_report.yaml doesn't exist",
-           "exitcode"         => 0,
-           "version"          => 1}
+          {"report"     => {"kind"             => "unknown",
+                            "time"             => "unknown",
+                            "transaction_uuid" => "unknown",
+                            "environment"      => "unknown",
+                            "status"           => "unknown"},
+           "error_type" => "no_last_run_report",
+           "error"      => "/opt/puppetlabs/puppet/cache/state/last_run_report.yaml doesn't exist",
+           "exitcode"   => 0,
+           "version"    => 1}
     end
 
     it "doesn't process the last_run_report if the file cant be loaded" do
@@ -122,15 +122,15 @@ describe "pxp-module-puppet" do
       allow_any_instance_of(Object).to receive(:check_config_print).and_return("/opt/puppetlabs/puppet/cache/state/last_run_report.yaml")
       allow(YAML).to receive(:load_file).and_raise("error")
       expect(get_result_from_report(0, default_configuration, Time.now)).to be ==
-          {"kind"             => "unknown",
-           "time"             => "unknown",
-           "transaction_uuid" => "unknown",
-           "environment"      => "unknown",
-           "status"           => "unknown",
-           "error_type"       => "invalid_last_run_report",
-           "error"            => "/opt/puppetlabs/puppet/cache/state/last_run_report.yaml could not be loaded: error",
-           "exitcode"         => 0,
-           "version"          => 1}
+          {"report"     => {"kind"             => "unknown",
+                            "time"             => "unknown",
+                            "transaction_uuid" => "unknown",
+                            "environment"      => "unknown",
+                            "status"           => "unknown"},
+           "error_type" => "invalid_last_run_report",
+           "error"      => "/opt/puppetlabs/puppet/cache/state/last_run_report.yaml could not be loaded: error",
+           "exitcode"   => 0,
+           "version"    => 1}
     end
 
     it "doesn't process the last_run_report if it hasn't been updated after the run was kicked" do
@@ -149,15 +149,15 @@ describe "pxp-module-puppet" do
       allow(YAML).to receive(:load_file).and_return(last_run_report)
 
       expect(get_result_from_report(-1, default_configuration, start_time)).to be ==
-          {"kind"             => "unknown",
-           "time"             => "unknown",
-           "transaction_uuid" => "unknown",
-           "environment"      => "unknown",
-           "status"           => "unknown",
-           "error_type"       => "agent_exit_non_zero",
-           "error"            => "Puppet agent exited with a non 0 exitcode",
-           "exitcode"         => -1,
-           "version"          => 1}
+          {"report"     => {"kind"             => "unknown",
+                            "time"             => "unknown",
+                            "transaction_uuid" => "unknown",
+                            "environment"      => "unknown",
+                            "status"           => "unknown"},
+           "error_type" => "agent_exit_non_zero",
+           "error"      => "Puppet agent exited with a non 0 exitcode",
+           "exitcode"   => -1,
+           "version"    => 1}
     end
 
     it "processes the last_run_report if it has been updated after the run was kicked" do
@@ -176,15 +176,15 @@ describe "pxp-module-puppet" do
       allow(YAML).to receive(:load_file).and_return(last_run_report)
 
       expect(get_result_from_report(-1, default_configuration, start_time)).to be ==
-          {"kind"             => "apply",
-           "time"             => run_time,
-           "transaction_uuid" => "ac59acbe-6a0f-49c9-8ece-f781a689fda9",
-           "environment"      => "production",
-           "status"           => "changed",
-           "error_type"       => "agent_exit_non_zero",
-           "error"            => "Puppet agent exited with a non 0 exitcode",
-           "exitcode"         => -1,
-           "version"          => 1}
+          {"report"     => {"kind"             => "apply",
+                            "time"             => run_time,
+                            "transaction_uuid" => "ac59acbe-6a0f-49c9-8ece-f781a689fda9",
+                            "environment"      => "production",
+                            "status"           => "changed"},
+           "error_type" => "agent_exit_non_zero",
+           "error"      => "Puppet agent exited with a non 0 exitcode",
+           "exitcode"   => -1,
+           "version"    => 1}
     end
 
     it "correctly processes the last_run_report" do
@@ -203,13 +203,13 @@ describe "pxp-module-puppet" do
       allow(YAML).to receive(:load_file).and_return(last_run_report)
 
       expect(get_result_from_report(0, default_configuration, start_time)).to be ==
-          {"kind"             => "apply",
-           "time"             => run_time,
-           "transaction_uuid" => "ac59acbe-6a0f-49c9-8ece-f781a689fda9",
-           "environment"      => "production",
-           "status"           => "changed",
-           "exitcode"         => 0,
-           "version"          => 1}
+          {"report"   => {"kind"             => "apply",
+                          "time"             => run_time,
+                          "transaction_uuid" => "ac59acbe-6a0f-49c9-8ece-f781a689fda9",
+                          "environment"      => "production",
+                          "status"           => "changed"},
+           "exitcode" => 0,
+           "version"  => 1}
     end
   end
 
@@ -278,20 +278,26 @@ describe "pxp-module-puppet" do
             :results => {
               :type => "object",
               :properties => {
-                :kind => {
-                  :type => "string"
-                },
-                :time => {
-                  :type => "string"
-                },
-                :transaction_uuid => {
-                  :type => "string"
-                },
-                :environment => {
-                  :type => "string"
-                },
-                :status => {
-                  :type => "string"
+                :report => {
+                  :type => "object",
+                  :properties => {
+                    :kind => {
+                      :type => "string"
+                    },
+                    :time => {
+                      :type => "string"
+                    },
+                    :transaction_uuid => {
+                      :type => "string"
+                    },
+                    :environment => {
+                      :type => "string"
+                    },
+                    :status => {
+                      :type => "string"
+                    }
+                  },
+                  :required => [:kind, :time, :transaction_uuid, :environment, :status]
                 },
                 :error_type => {
                   :type => "string"
@@ -306,8 +312,7 @@ describe "pxp-module-puppet" do
                   :type => "number"
                 }
               },
-              :required => [:kind, :time, :transaction_uuid, :environment, :status,
-                            :exitcode, :version]
+              :required => [:report, :exitcode, :version]
             }
           }
         ],


### PR DESCRIPTION
Information obtained from a puppet run is now separated from messaging by the ```pxp-module-puppet``` in the module's output.