### PR TITLE
(maint) Acceptance tests need to allow time for agent association with broker

### DIFF
--- a/acceptance/tests/pxp_agent_associate.rb
+++ b/acceptance/tests/pxp_agent_associate.rb
@@ -12,7 +12,7 @@ agents.each_with_index do |agent, i|
   end
 
   step 'Assert that the agent is not listed in pcp-broker inventory' do
-    assert(!is_associated?(master, "pcp://client0#{i+1}.example.com/agent"),
+    assert(is_not_associated?(master, "pcp://client0#{i+1}.example.com/agent"),
            "Agent identity pcp://client0#{i+1}.example.com/agent for agent host #{agent} appears in pcp-broker's client inventory " \
            "but pxp-agent service is supposed to be stopped")
   end


### PR DESCRIPTION
PCP-167 changed the tests to check assocation with pcp-broker instead of grepping pxp-agent log for association log entries.
This occasionally fails in CI as the agent does not appear as associated with the broker.
This commit adds retry logic so that the pcp-broker inventory is checked a number of times before failing.

[skip ci]