### PR TITLE
(maint) Improve PCP broker and client usage in acceptance

### DIFF
--- a/acceptance/lib/pxp-agent/test_helper.rb
+++ b/acceptance/lib/pxp-agent/test_helper.rb
@@ -276,7 +276,8 @@ def connect_pcp_client(broker)
   client = PCP::Client.new({
     :server => broker_ws_uri(broker),
     :ssl_cert => "../test-resources/ssl/certs/controller01.example.com.pem",
-    :ssl_key => "../test-resources/ssl/private_keys/controller01.example.com.pem"
+    :ssl_key => "../test-resources/ssl/private_keys/controller01.example.com.pem",
+    :loglevel => logger.is_debug? ? Logger::DEBUG : Logger::WARN
   })
 
   retries = 0

--- a/acceptance/lib/pxp-agent/test_helper.rb
+++ b/acceptance/lib/pxp-agent/test_helper.rb
@@ -6,6 +6,9 @@ require 'json'
 
 # This file contains general test helper methods for pxp-agent acceptance tests
 
+# The standard path for git checkouts is where pcp-broker will be
+GIT_CLONE_FOLDER = '/opt/puppet-git-repos'
+
 # Some helpers for working with the log file
 PXP_LOG_FILE_CYGPATH = '/cygdrive/c/ProgramData/PuppetLabs/pxp-agent/var/log/pxp-agent.log'
 PXP_LOG_FILE_POSIX = '/var/log/puppetlabs/pxp-agent/pxp-agent.log'
@@ -40,7 +43,7 @@ end
 
 # Some helpers for working with a pcp-broker 'lein tk' instance
 def run_pcp_broker(host)
-  on(host, 'cd /opt/puppet-git-repos/pcp-broker; export LEIN_ROOT=ok; lein tk </dev/null >/var/log/pcp-broker.log 2>&1 &')
+  on(host, "cd #{GIT_CLONE_FOLDER}/pcp-broker; export LEIN_ROOT=ok; lein tk </dev/null >/var/log/pcp-broker.log 2>&1 &"")
   assert(port_open_within?(host, PCP_BROKER_PORT, 60),
          "pcp-broker port #{PCP_BROKER_PORT.to_s} not open within 1 minutes of starting the broker")
   broker_state = nil

--- a/acceptance/setup/common/010_Setup_Broker.rb
+++ b/acceptance/setup/common/010_Setup_Broker.rb
@@ -1,9 +1,6 @@
 require 'puppet/acceptance/install_utils'
 extend Puppet::Acceptance::InstallUtils
-
-pcp_broker_port = 8142
-pcp_broker_minutes_to_start = 2
-GIT_CLONE_FOLDER = '/opt/puppet-git-repos'
+require 'pxp-agent/test_helper'
 
 step 'Install build dependencies on master' do
   MASTER_PACKAGES = {
@@ -35,9 +32,6 @@ step 'Run lein deps to download dependencies' do
   on master, "cd #{GIT_CLONE_FOLDER}/pcp-broker; export LEIN_ROOT=ok; lein deps"
 end
 
-step "Run pcp-broker in trapperkeeper in background and wait for port #{pcp_broker_port.to_s}" do
-  on master, "cd #{GIT_CLONE_FOLDER}/pcp-broker; export LEIN_ROOT=ok; lein tk </dev/null >/var/log/pcp-broker.log 2>&1 &"
-  assert(port_open_within?(master, pcp_broker_port, 60 * pcp_broker_minutes_to_start),
-         "pcp-broker port #{pcp_broker_port.to_s} not open within " \
-         "#{pcp_broker_minutes_to_start.to_s} minutes of starting the broker")
+step "Run pcp-broker in trapperkeeper in background and wait for it to report status 'running'" do
+  run_pcp_broker(master)
 end


### PR DESCRIPTION
A couple of minor improvements:
 * pcp-client should be set to debug loglevel if beaker is using debug logging
 * The pre-suite code should not have its own code for starting pcp-broker; especially now that the helper lib has code to test pcp-broker on startup