### PR TITLE
Make use of ruby-pcp-client 0.2.0

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -16,7 +16,7 @@ gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 2.19')
 gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.2")
 gem 'rake'
 gem 'scooter', '~> 3.1.1'
-gem 'pcp-client', :source => 'https://rubygems.org'
+gem 'pcp-client', '~> 0.2.0'
 
 group(:test) do
   gem 'rspec', '~> 2.14.0', :require => false

--- a/acceptance/lib/pxp-agent/test_helper.rb
+++ b/acceptance/lib/pxp-agent/test_helper.rb
@@ -1,5 +1,6 @@
 require 'pxp-agent/config_helper.rb'
 require 'pcp/client'
+require 'pcp/simple_logger'
 require 'net/http'
 require 'openssl'
 require 'json'
@@ -285,6 +286,7 @@ def connect_pcp_client(broker)
       :server => broker_ws_uri(broker),
       :ssl_cert => "../test-resources/ssl/certs/controller01.example.com.pem",
       :ssl_key => "../test-resources/ssl/private_keys/controller01.example.com.pem",
+      :logger => PCP::SimpleLogger.new,
       :loglevel => logger.is_debug? ? Logger::DEBUG : Logger::WARN
     })
     connected = client.connect(5)

--- a/acceptance/lib/pxp-agent/test_helper.rb
+++ b/acceptance/lib/pxp-agent/test_helper.rb
@@ -291,10 +291,10 @@ def connect_pcp_client(broker)
     retries += 1
   end
   if !connected
-    raise "Controller PCP client failed to connect with pcp-broker on #{broker} after #{max_retries} attempts"
+    raise "Controller PCP client failed to connect with pcp-broker on #{broker} after #{max_retries} attempts: #{client.inspect}"
   end
   if !client.associated?
-    raise "Controller PCP client failed to associate with pcp-broker on #{broker}"
+    raise "Controller PCP client failed to associate with pcp-broker on #{broker} #{client.inspect}"
   end
 
   client


### PR DESCRIPTION
Make use of the (not yet released) 0.2.0 feature of `PCP::SimpleLogger` so we can inspect the state of the client object should it not be connected and give more context as to why the connection failed.