### PR TITLE
PCP-288 When stopping pxp-agent, only stop the agent

### DIFF
--- a/ext/systemd/pxp-agent.service
+++ b/ext/systemd/pxp-agent.service
@@ -6,6 +6,7 @@ After=syslog.target network.target
 EnvironmentFile=-/etc/sysconfig/pxp-agent
 EnvironmentFile=-/etc/default/pxp-agent
 ExecStart=/opt/puppetlabs/puppet/bin/pxp-agent $PXP_AGENT_OPTIONS --foreground
+KillMode=process
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The behavioural changes around PCP-207 and its testing in PCP-230
expect that the pxp-agent will be able to spawn long-running processes
to run actions in which have a life independent of the pxp-agent
process that spawned them.

This is defeated by systemd's default KillMode being control-group,
which will kill these long-running processes when shutting down the main agent
process.

Here we switch KillMode to process, so we only kill the pxp-agent as intended.

https://www.freedesktop.org/software/systemd/man/systemd.kill.html#KillMode=