### PR TITLE
(PCP-317) flush pxp-module-puppet output explicitly

### DIFF
--- a/modules/pxp-module-puppet
+++ b/modules/pxp-module-puppet
@@ -282,6 +282,10 @@ def action_run(input)
         1
       end
 
+      # flush the stdout/stderr before writing the exitcode
+      # file to avoid pxp-agent reading incomplete output
+      $stdout.fsync
+      $stderr.fsync
       begin
         File.open(output_files["exitcode"], 'w') do |f|
           f.puts(status)


### PR DESCRIPTION
There was a race condition between creating the exitcode file (which pxp-agent uses to determine if a pxp-module-puppet execution finished) and the actual exit of the pxp-module-puppet process (which implicitly flushes its output). This could lead (and led) to pxp-agent reading incomplete output of the pxp-module-puppet.
To prevent this we flush the output of pxp-module-puppet explicitly before writing the exitcode file.