### PR TITLE
(PCP-317) flush output of test modules explicitly

### DIFF
--- a/lib/tests/resources/modules/check_output.rb
+++ b/lib/tests/resources/modules/check_output.rb
@@ -17,6 +17,8 @@ def check_output_files(args)
     else
       1
     end
+    $stdout.fsync
+    $stderr.fsync
     File.open(output_files["exitcode"], 'w') do |f|
       f.puts(status)
     end


### PR DESCRIPTION
Implement the same change as was recently added to the pxp-module-puppet.