### PR TITLE
(PCP-296) Acceptance tests should use Puppet generated SSL certs

### DIFF
--- a/acceptance/config/aio/options.rb
+++ b/acceptance/config/aio/options.rb
@@ -7,8 +7,9 @@
     'setup/common/000-delete-puppet-when-none.rb',
     'setup/aio/pre-suite/010_Install.rb',
     'setup/aio/021_InstallAristaModule.rb',
-    'setup/common/010_Setup_Broker.rb',
     'setup/common/035_StartPuppetServer.rb',
     'setup/common/040_ValidateSignCert.rb',
+    'setup/common/050_Setup_Broker.rb',
+    'setup/common/060_Setup_PCP_Client.rb',
   ],
 }

--- a/acceptance/lib/pxp-agent/config_helper.rb
+++ b/acceptance/lib/pxp-agent/config_helper.rb
@@ -86,6 +86,21 @@ def pxp_config_hash_using_test_certs(broker, agent, client_number, base_path)
   }
 end
 
+def pxp_config_json_using_puppet_certs(broker, agent)
+  pxp_config_hash_using_puppet_certs(broker, agent).to_json
+end
+
+def pxp_config_hash_using_puppet_certs(broker, agent)
+  on(agent, puppet('config print ssldir')) do |result|
+    puppet_ssldir = result.stdout.chomp
+    return { "broker-ws-uri" => "#{broker_ws_uri(broker)}",
+      "ssl-key" => "#{puppet_ssldir}/private_keys/#{agent}.pem",
+      "ssl-ca-cert" => "#{puppet_ssldir}/certs/ca.pem",
+      "ssl-cert" => "#{puppet_ssldir}/certs/#{agent}.pem"
+    }
+  end
+end
+
 # @param broker_host the host name or beaker host object for the pcp-broker host
 # @return the broker-ws-uri config string
 def broker_ws_uri(broker_host)

--- a/acceptance/lib/pxp-agent/test_helper.rb
+++ b/acceptance/lib/pxp-agent/test_helper.rb
@@ -3,6 +3,7 @@ require 'pcp/client'
 require 'pcp/simple_logger'
 require 'net/http'
 require 'openssl'
+require 'socket'
 require 'json'
 
 # This file contains general test helper methods for pxp-agent acceptance tests
@@ -311,11 +312,12 @@ def connect_pcp_client(broker)
   retries = 0
   max_retries = 10
   connected = false
+  hostname = Socket.gethostname
   until (connected || retries == max_retries) do
     client = PCP::Client.new({
       :server => broker_ws_uri(broker),
-      :ssl_cert => "../test-resources/ssl/certs/controller01.example.com.pem",
-      :ssl_key => "../test-resources/ssl/private_keys/controller01.example.com.pem",
+      :ssl_cert => "tmp/ssl/certs/#{hostname.downcase}.pem",
+      :ssl_key => "tmp/ssl/private_keys/#{hostname.downcase}.pem",
       :logger => PCP::SimpleLogger.new,
       :loglevel => logger.is_debug? ? Logger::DEBUG : Logger::WARN
     })

--- a/acceptance/setup/common/050_Setup_Broker.rb
+++ b/acceptance/setup/common/050_Setup_Broker.rb
@@ -32,6 +32,17 @@ step 'Run lein deps to download dependencies' do
   on master, "cd #{GIT_CLONE_FOLDER}/pcp-broker; export LEIN_ROOT=ok; lein deps"
 end
 
+step 'Replace PCP test certs with the Puppet certs of this SUT' do
+  on(master, puppet('config print ssldir')) do |result|
+    puppet_ssldir = result.stdout.chomp
+    broker_ssldir = "#{GIT_CLONE_FOLDER}/pcp-broker/test-resources/ssl"
+    on master, "\\cp #{puppet_ssldir}/certs/#{master}.pem #{broker_ssldir}/certs/broker.example.com.pem"
+    on master, "\\cp #{puppet_ssldir}/private_keys/#{master}.pem #{broker_ssldir}/private_keys/broker.example.com.pem"
+    on master, "\\cp #{puppet_ssldir}/ca/ca_crt.pem #{broker_ssldir}/ca/ca_crt.pem"
+    on master, "\\cp #{puppet_ssldir}/ca/ca_crl.pem #{broker_ssldir}/ca/ca_crl.pem"
+  end
+end
+
 step "Run pcp-broker in trapperkeeper in background and wait for it to report status 'running'" do
   run_pcp_broker(master)
 end

--- a/acceptance/setup/common/060_Setup_PCP_Client.rb
+++ b/acceptance/setup/common/060_Setup_PCP_Client.rb
@@ -1,0 +1,19 @@
+require 'pxp-agent/test_helper'
+require 'socket'
+test_name 'Set up SSL certs for pcp-client to use'
+
+step 'On master create certs for the host running pcp-client' do
+  hostname = Socket.gethostname
+  on master, puppet("cert generate #{hostname}")
+  on(master, puppet('config print ssldir')) do |result|
+    puppet_ssldir = result.stdout.chomp
+    if !Dir.exists?('tmp/ssl') then Dir.mkdir('tmp/ssl') end
+    if !Dir.exists?('tmp/ssl/private_keys') then Dir.mkdir('tmp/ssl/private_keys') end
+    if !Dir.exists?('tmp/ssl/public_keys') then Dir.mkdir('tmp/ssl/public_keys') end
+    if !Dir.exists?('tmp/ssl/certs') then Dir.mkdir('tmp/ssl/certs') end
+    scp_from(master, "#{puppet_ssldir}/private_keys/#{hostname.downcase}.pem", 'tmp/ssl/private_keys')
+    scp_from(master, "#{puppet_ssldir}/public_keys/#{hostname.downcase}.pem", 'tmp/ssl/public_keys')
+    scp_from(master, "#{puppet_ssldir}/certs/#{hostname.downcase}.pem", 'tmp/ssl/certs')
+    scp_from(master, "#{puppet_ssldir}/certs/ca.pem", 'tmp/ssl/certs')
+  end
+end

--- a/acceptance/tests/pxp-module-puppet/run_puppet.rb
+++ b/acceptance/tests/pxp-module-puppet/run_puppet.rb
@@ -3,20 +3,19 @@ require 'pxp-agent/test_helper.rb'
 test_name 'C95972 - pxp-module-puppet run' do
 
   step 'Ensure each agent host has pxp-agent running and associated' do
-    agents.each_with_index do |agent, i|
+    agents.each do |agent|
       on agent, puppet('resource service pxp-agent ensure=stopped')
-      cert_dir = configure_std_certs_on_host(agent)
-      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_test_certs(master, agent, i + 1, cert_dir).to_s)
+      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
       on agent, puppet('resource service pxp-agent ensure=running')
-      assert(is_associated?(master, "pcp://client0#{i+1}.example.com/agent"),
-             "Agent #{agent} with PCP identity pcp://client0#{i+1}.example.com/agent should be associated with pcp-broker")
+      assert(is_associated?(master, "pcp://#{agent}/agent"),
+             "Agent #{agent} with PCP identity pcp://#{agent}/agent should be associated with pcp-broker")
     end
   end
 
   step "Send an rpc_blocking_request to all agents" do
     target_identities = []
-    agents.each_with_index do |agent, i|
-      target_identities << "pcp://client0#{i+1}.example.com/agent"
+    agents.each do |agent|
+      target_identities << "pcp://#{agent}/agent"
     end
     responses = nil # Declare here so not local to begin/rescue below
     begin
@@ -29,9 +28,9 @@ test_name 'C95972 - pxp-module-puppet run' do
     rescue => exception
       fail("Exception occurred when trying to run Puppet on all agents: #{exception.message}")
     end
-    agents.each_with_index do |agent, i|
+    agents.each do |agent|
       step "Check Run Puppet response for #{agent}" do
-        identity = "pcp://client0#{i+1}.example.com/agent"
+        identity = "pcp://#{agent}/agent"
         response = responses[identity]
         assert(response.has_key?(:envelope), "Response from PCP for #{agent} is missing :envelope")
         assert(response[:envelope].has_key?(:message_type), "Response from PCP for #{agent} is missing "\

--- a/acceptance/tests/pxp_agent_associate.rb
+++ b/acceptance/tests/pxp_agent_associate.rb
@@ -2,18 +2,17 @@ require 'pxp-agent/test_helper.rb'
 
 test_name 'C93807 - Associate pxp-agent with a PCP broker'
 
-agents.each_with_index do |agent, i|
+agents.each do |agent|
 
-  cert_dir = configure_std_certs_on_host(agent)
-  create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_test_certs(master, agent, i + 1, cert_dir).to_s)
+  create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
 
   step 'Stop pxp-agent if it is currently running' do
     on agent, puppet('resource service pxp-agent ensure=stopped')
   end
 
   step 'Assert that the agent is not listed in pcp-broker inventory' do
-    assert(is_not_associated?(master, "pcp://client0#{i+1}.example.com/agent"),
-           "Agent identity pcp://client0#{i+1}.example.com/agent for agent host #{agent} appears in pcp-broker's client inventory " \
+    assert(is_not_associated?(master, "pcp://#{agent}/agent"),
+           "Agent identity pcp://#{agent}/agent for agent host #{agent} appears in pcp-broker's client inventory " \
            "but pxp-agent service is supposed to be stopped")
   end
 
@@ -22,7 +21,7 @@ agents.each_with_index do |agent, i|
   end
 
   step 'Assert that agent is listed in pcp-broker inventory' do
-    assert(is_associated?(master, "pcp://client0#{i+1}.example.com/agent"),
-           "Agent identity pcp://client0#{i+1}.example.com/agent for agent host #{agent} does not appear in pcp-broker's client inventory")
+    assert(is_associated?(master, "pcp://#{agent}/agent"),
+           "Agent identity pcp://#{agent}/agent for agent host #{agent} does not appear in pcp-broker's client inventory")
   end
 end

--- a/acceptance/tests/reconnect_after_broker_unavailable.rb
+++ b/acceptance/tests/reconnect_after_broker_unavailable.rb
@@ -4,14 +4,13 @@ require 'pxp-agent/test_helper.rb'
 test_name 'C94789 - An associated agent should automatically reconnect when the broker was temporarily unavailable'
 
 step 'Ensure each agent host has pxp-agent running and associated' do
-  agents.each_with_index do |agent, i|
+  agents.each do |agent|
     on agent, puppet('resource service pxp-agent ensure=stopped')
-    cert_dir = configure_std_certs_on_host(agent)
-    create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_test_certs(master, agent, i + 1, cert_dir).to_s)
+    create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
     on(agent, "rm -rf #{logfile(agent)}")
     on agent, puppet('resource service pxp-agent ensure=running')
-    assert(is_associated?(master, "pcp://client0#{i+1}.example.com/agent"),
-           "Agent identity pcp://client0#{i+1}.example.com/agent for agent host #{agent} does not appear in pcp-broker's client inventory")
+    assert(is_associated?(master, "pcp://#{agent}/agent"),
+           "Agent identity pcp://#{agent}/agent for agent host #{agent} does not appear in pcp-broker's client inventory")
   end
 end
 
@@ -21,8 +20,8 @@ step 'On master, stop then restart the broker' do
 end
 
 step 'On each agent, test that a 2nd association has occurred' do
-  agents.each_with_index do |agent, i|
-    assert(is_associated?(master, "pcp://client0#{i+1}.example.com/agent"),
-           "Agent identity pcp://client0#{i+1}.example.com/agent for agent host #{agent} does not appear in pcp-broker's client inventory")
+  agents.each_with_index do |agent|
+    assert(is_associated?(master, "pcp://#{agent}/agent"),
+           "Agent identity pcp://#{agent}/agent for agent host #{agent} does not appear in pcp-broker's client inventory")
   end
 end

--- a/acceptance/tests/service_stop_start.rb
+++ b/acceptance/tests/service_stop_start.rb
@@ -38,8 +38,7 @@ end
 agents.each_with_index do |agent, i|
   @agent = agent
 
-  cert_dir = configure_std_certs_on_host(@agent)
-  create_remote_file(@agent, pxp_agent_config_file(@agent), pxp_config_json_using_test_certs(master, @agent, i + 1, cert_dir).to_s)
+  create_remote_file(@agent, pxp_agent_config_file(@agent), pxp_config_json_using_puppet_certs(master, @agent).to_s)
 
   step 'C93070 - Service Start (from stopped, with configuration)' do
     stop_service


### PR DESCRIPTION
Change the acceptance tests to use Puppet generated SSL certs instead of our test fixture certs.
For pcp-broker; the puppet certs are copied onto the standard test cert paths so that no change to pcp-broker code is needed.
Adds a pre-suite class to generate certs for the test executor so that it can certify itself when connecting pcp-client.

[skip ci]