### PR TITLE
(PCP-308) run modules in own contracts on Solaris

### DIFF
--- a/lib/src/external_module.cc
+++ b/lib/src/external_module.cc
@@ -342,8 +342,10 @@ ActionResponse ExternalModule::callNonBlockingAction(const ActionRequest& reques
     LOG_TRACE("Input for the %1%: %2%", request.prettyLabel(), input_txt);
 
     auto exec = lth_exec::execute(
-#ifdef _WIN32
+#if defined(_WIN32)
         "cmd.exe", { "/c", path_, action_name },
+#elif defined(__sun)
+        "/usr/bin/ctrun", { "-l", "child", path_, action_name },
 #else
         path_, { action_name },
 #endif


### PR DESCRIPTION
Solaris keeps track of the state of the system services by employing so called contracts. A contract is effectively a group of processes. Each service has its own contract. When a service starts a new process it is by default a member of the service's contract. When a service is restarted all processes in its contract are killed (or at least the system waits until they exit).
This behavior isn't the desired one for ```pxp-agent``` as we want the modules it spawns to outlive it in case it is restarted.
The solution is to make sure the modules are executed in their own contracts so that they are not killed when the ```pxp-agent``` service is restarted. In this commit we achieve this be executing the modules via the ```ctrun``` command.