### PR TITLE
(PCP-340) Wait for the module completion in component tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 /build/
 /dev-resources/
 /lib/tests/resources/test_spool/
+/lib/tests/resources/tmp/
 .idea/
 .DS_Store

--- a/lib/tests/common/mock_connector.hpp
+++ b/lib/tests/common/mock_connector.hpp
@@ -23,7 +23,7 @@ static const std::string BAD_FORMAT_MODULES_CONFIG { PXP_AGENT_ROOT_PATH
 static const std::string BROKEN_MODULES_CONFIG { PXP_AGENT_ROOT_PATH
             + std::string { "/lib/tests/resources/modules_config_broken" } };
 static const std::string SPOOL { PXP_AGENT_ROOT_PATH
-            + std::string { "/lib/tests/resources/tmp/" } };
+            + std::string { "/lib/tests/resources/tmp" } };
 
 static Configuration::Agent AGENT_CONFIGURATION { MODULES,
                                                   TEST_BROKER_WS_URI,


### PR DESCRIPTION
With this commit we add a function to check whether the external module
run finished by looking at the exit code file.

Removing the unnecessary pause from the bloking tests.