### PR TITLE
(PCP-306) run report in tempfile

### DIFF
--- a/modules/pxp-module-puppet
+++ b/modules/pxp-module-puppet
@@ -37,7 +37,7 @@ def is_win?
   return !!File::ALT_SEPARATOR
 end
 
-def last_run_result(exitcode)
+def run_result(exitcode)
   return {"kind"             => "unknown",
           "time"             => "unknown",
           "transaction_uuid" => "unknown",
@@ -73,42 +73,42 @@ def make_command_array(config, action_input)
 end
 
 def make_error_result(exitcode, error_type, error_message)
-  result = last_run_result(exitcode)
+  result = run_result(exitcode)
   result["error_type"] = error_type
   result["error"] = error_message
   return result
 end
 
 def get_result_from_report(exitcode, config)
-  last_run_report = config["run_report_tempfile"].path
+  run_report = config["run_report_tempfile"].path
 
-  if !File.exist?(last_run_report)
+  if !File.exist?(run_report)
     return make_error_result(exitcode, Errors::NoLastRunReport,
-                             "#{last_run_report} doesn't exist")
+                             "#{run_report} doesn't exist")
   end
 
-  last_run_report_yaml = {}
+  run_report_yaml = {}
 
   begin
-    last_run_report_yaml = YAML.load_file(last_run_report)
+    run_report_yaml = YAML.load_file(run_report)
   rescue => e
     return make_error_result(exitcode, Errors::InvalidLastRunReport,
-                             "#{last_run_report} could not be loaded: #{e}")
+                             "#{run_report} could not be loaded: #{e}")
   end
 
   if exitcode == 0
-    run_result = last_run_result(exitcode)
+    run_result = run_result(exitcode)
   else
     run_result = make_error_result(exitcode, Errors::NonZeroExit,
                                    "Puppet agent exited with a non 0 exitcode")
   end
 
-  if last_run_report_yaml
-    run_result["kind"] = last_run_report_yaml.kind
-    run_result["time"] = last_run_report_yaml.time
-    run_result["transaction_uuid"] = last_run_report_yaml.transaction_uuid
-    run_result["environment"] = last_run_report_yaml.environment
-    run_result["status"] = last_run_report_yaml.status
+  if run_report_yaml
+    run_result["kind"] = run_report_yaml.kind
+    run_result["time"] = run_report_yaml.time
+    run_result["transaction_uuid"] = run_report_yaml.transaction_uuid
+    run_result["environment"] = run_report_yaml.environment
+    run_result["status"] = run_report_yaml.status
   end
 
   return run_result

--- a/modules/pxp-module-puppet
+++ b/modules/pxp-module-puppet
@@ -3,6 +3,7 @@
 require 'json'
 require 'yaml'
 require 'puppet'
+require 'tempfile'
 
 module Errors
   InvalidJson = "invalid_json"
@@ -46,12 +47,6 @@ def last_run_result(exitcode)
           "version"          => 1}
 end
 
-def check_config_print(cli_arg, config)
-  command_array = [config["puppet_bin"], "agent", "--configprint", cli_arg]
-  process_output = Puppet::Util::Execution.execute(command_array)
-  return process_output.to_s.chomp
-end
-
 def running?(run_result)
   !!(run_result =~ /Run of Puppet configuration client already in progress/)
 end
@@ -72,7 +67,8 @@ end
 
 def make_command_array(config, action_input)
   cmd_array = [config["puppet_bin"], "agent"]
-  cmd_array +=  action_input["flags"]
+  cmd_array.concat(action_input["flags"])
+  cmd_array << "--lastrunreport" << config["run_report_tempfile"].path
   return cmd_array
 end
 
@@ -83,12 +79,8 @@ def make_error_result(exitcode, error_type, error_message)
   return result
 end
 
-def get_result_from_report(exitcode, config, start_time)
-  last_run_report = check_config_print("lastrunreport",config)
-  if last_run_report.empty?
-    return make_error_result(exitcode, Errors::NoLastRunReport,
-                             "could not find the location of the last run report")
-  end
+def get_result_from_report(exitcode, config)
+  last_run_report = config["run_report_tempfile"].path
 
   if !File.exist?(last_run_report)
     return make_error_result(exitcode, Errors::NoLastRunReport,
@@ -111,7 +103,7 @@ def get_result_from_report(exitcode, config, start_time)
                                    "Puppet agent exited with a non 0 exitcode")
   end
 
-  if start_time.to_i < last_run_report_yaml.time.to_i
+  if last_run_report_yaml
     run_result["kind"] = last_run_report_yaml.kind
     run_result["time"] = last_run_report_yaml.time
     run_result["transaction_uuid"] = last_run_report_yaml.transaction_uuid
@@ -147,7 +139,7 @@ def start_run(config, action_input)
                              "Puppet agent is already performing a run")
   end
 
-  return get_result_from_report(exitcode, config, start_time)
+  return get_result_from_report(exitcode, config)
 end
 
 def metadata()
@@ -209,6 +201,9 @@ def metadata()
       :properties => {
         :puppet_bin => {
           :type => "string"
+        },
+        :temp_dir => {
+          :type => "string"
         }
       }
     }
@@ -224,6 +219,12 @@ def run(config, action_input)
   return start_run(config, action_input)
 end
 
+def get_run_report_tempfile(temp_dir)
+  run_report_tempfile = Tempfile.new(["run_report-", ".yaml"], temp_dir)
+  run_report_tempfile.close()
+  run_report_tempfile
+end
+
 def get_configuration(args)
   config = args["configuration"] || {}
 
@@ -235,6 +236,16 @@ def get_configuration(args)
       puppet_bin = File.join(module_path, '..', '..', 'bin', 'puppet.bat')
       config["puppet_bin"] = File.expand_path(puppet_bin)
     end
+  end
+
+  if config["temp_dir"].nil? || config["temp_dir"].empty?
+    config["temp_dir"] = ::Dir.tmpdir()
+  end
+
+  begin
+    config["run_report_tempfile"] = get_run_report_tempfile(config["temp_dir"])
+  rescue => e
+    raise ProcessingError.new(Errors::NoLastRunReport, "Failed to create a temporary last report file: #{e.message}")
   end
 
   config

--- a/modules/spec/unit/modules/puppet_spec.rb
+++ b/modules/spec/unit/modules/puppet_spec.rb
@@ -22,15 +22,15 @@ describe "pxp-module-puppet" do
     {"puppet_bin" => "puppet", "run_report_tempfile" => run_report_tempfile}
   }
 
-  describe "last_run_result" do
+  describe "run_result" do
     it "returns the basic structure with exitcode set" do
-      expect(last_run_result(42)).to be == {"kind"             => "unknown",
-                                            "time"             => "unknown",
-                                            "transaction_uuid" => "unknown",
-                                            "environment"      => "unknown",
-                                            "status"           => "unknown",
-                                            "exitcode"         => 42,
-                                            "version"          => 1}
+      expect(run_result(42)).to be == {"kind"             => "unknown",
+                                       "time"             => "unknown",
+                                       "transaction_uuid" => "unknown",
+                                       "environment"      => "unknown",
+                                       "status"           => "unknown",
+                                       "exitcode"         => 42,
+                                       "version"          => 1}
     end
   end
 
@@ -104,7 +104,7 @@ describe "pxp-module-puppet" do
   end
 
   describe "get_result_from_report" do
-    it "doesn't process the last_run_report if the file doens't exist" do
+    it "doesn't process the run_report if the file doens't exist" do
       allow(File).to receive(:exist?).and_return(false)
       expect(get_result_from_report(0, default_configuration)).to be ==
           {"kind"             => "unknown",
@@ -118,7 +118,7 @@ describe "pxp-module-puppet" do
            "version"          => 1}
     end
 
-    it "doesn't process the last_run_report if the file cant be loaded" do
+    it "doesn't process the run_report if the file cant be loaded" do
       allow(File).to receive(:exist?).and_return(true)
       allow(YAML).to receive(:load_file).and_raise("error")
       expect(get_result_from_report(0, default_configuration)).to be ==
@@ -133,18 +133,18 @@ describe "pxp-module-puppet" do
            "version"          => 1}
     end
 
-    it "correctly processes the last_run_report" do
+    it "correctly processes the run_report" do
       run_time = Time.now + 10
-      last_run_report = double(:last_run_report)
+      run_report = double(:run_report)
 
-      allow(last_run_report).to receive(:kind).and_return("apply")
-      allow(last_run_report).to receive(:time).and_return(run_time)
-      allow(last_run_report).to receive(:transaction_uuid).and_return("ac59acbe-6a0f-49c9-8ece-f781a689fda9")
-      allow(last_run_report).to receive(:environment).and_return("production")
-      allow(last_run_report).to receive(:status).and_return("changed")
+      allow(run_report).to receive(:kind).and_return("apply")
+      allow(run_report).to receive(:time).and_return(run_time)
+      allow(run_report).to receive(:transaction_uuid).and_return("ac59acbe-6a0f-49c9-8ece-f781a689fda9")
+      allow(run_report).to receive(:environment).and_return("production")
+      allow(run_report).to receive(:status).and_return("changed")
 
       allow(File).to receive(:exist?).and_return(true)
-      allow(YAML).to receive(:load_file).and_return(last_run_report)
+      allow(YAML).to receive(:load_file).and_return(run_report)
 
       expect(get_result_from_report(0, default_configuration)).to be ==
           {"kind"             => "apply",

--- a/modules/spec/unit/modules/puppet_spec.rb
+++ b/modules/spec/unit/modules/puppet_spec.rb
@@ -8,8 +8,18 @@ describe "pxp-module-puppet" do
     {"env" => [], "flags" => []}
   }
 
+  let(:temp_dir) {
+    "/foo/bar"
+  }
+
+  let (:run_report_tempfile) {
+    run_report_tempfile = double(Tempfile)
+    allow(run_report_tempfile).to receive(:path).and_return(temp_dir + "/baz.yaml")
+    run_report_tempfile
+  }
+
   let(:default_configuration) {
-    {"puppet_bin" => "puppet"}
+    {"puppet_bin" => "puppet", "run_report_tempfile" => run_report_tempfile}
   }
 
   describe "last_run_result" do
@@ -21,14 +31,6 @@ describe "pxp-module-puppet" do
                                             "status"           => "unknown",
                                             "exitcode"         => 42,
                                             "version"          => 1}
-    end
-  end
-
-  describe "check_config_print" do
-    it "returns the result of configprint" do
-      cli_vec = ["puppet", "agent", "--configprint", "value"]
-      expect(Puppet::Util::Execution).to receive(:execute).with(cli_vec).and_return("value\n")
-      expect(check_config_print("value", default_configuration)).to be == "value"
     end
   end
 
@@ -75,14 +77,14 @@ describe "pxp-module-puppet" do
     it "should correctly append the executable and action" do
       input = default_input
       expect(make_command_array(default_configuration, input)).to be ==
-        ["puppet", "agent"]
+        ["puppet", "agent", "--lastrunreport", run_report_tempfile.path]
     end
 
     it "should correctly append any flags" do
       input = default_input
       input["flags"] = ["--noop", "--verbose"]
       expect(make_command_array(default_configuration, input)).to be ==
-        ["puppet", "agent", "--noop", "--verbose"]
+        ["puppet", "agent", "--noop", "--verbose", "--lastrunreport", run_report_tempfile.path]
     end
   end
 
@@ -104,91 +106,34 @@ describe "pxp-module-puppet" do
   describe "get_result_from_report" do
     it "doesn't process the last_run_report if the file doens't exist" do
       allow(File).to receive(:exist?).and_return(false)
-      allow_any_instance_of(Object).to receive(:check_config_print).and_return("/opt/puppetlabs/puppet/cache/state/last_run_report.yaml")
-      expect(get_result_from_report(0, default_configuration, Time.now)).to be ==
+      expect(get_result_from_report(0, default_configuration)).to be ==
           {"kind"             => "unknown",
            "time"             => "unknown",
            "transaction_uuid" => "unknown",
            "environment"      => "unknown",
            "status"           => "unknown",
            "error_type"       => "no_last_run_report",
-           "error"            => "/opt/puppetlabs/puppet/cache/state/last_run_report.yaml doesn't exist",
+           "error"            => "/foo/bar/baz.yaml doesn't exist",
            "exitcode"         => 0,
            "version"          => 1}
     end
 
     it "doesn't process the last_run_report if the file cant be loaded" do
       allow(File).to receive(:exist?).and_return(true)
-      allow_any_instance_of(Object).to receive(:check_config_print).and_return("/opt/puppetlabs/puppet/cache/state/last_run_report.yaml")
       allow(YAML).to receive(:load_file).and_raise("error")
-      expect(get_result_from_report(0, default_configuration, Time.now)).to be ==
+      expect(get_result_from_report(0, default_configuration)).to be ==
           {"kind"             => "unknown",
            "time"             => "unknown",
            "transaction_uuid" => "unknown",
            "environment"      => "unknown",
            "status"           => "unknown",
            "error_type"       => "invalid_last_run_report",
-           "error"            => "/opt/puppetlabs/puppet/cache/state/last_run_report.yaml could not be loaded: error",
+           "error"            =>  "/foo/bar/baz.yaml could not be loaded: error",
            "exitcode"         => 0,
            "version"          => 1}
     end
 
-    it "doesn't process the last_run_report if it hasn't been updated after the run was kicked" do
-      start_time = Time.now
-      run_time = Time.now - 10
-      last_run_report = double(:last_run_report)
-
-      allow(last_run_report).to receive(:kind).and_return("apply")
-      allow(last_run_report).to receive(:time).and_return(run_time)
-      allow(last_run_report).to receive(:transaction_uuid).and_return("ac59acbe-6a0f-49c9-8ece-f781a689fda9")
-      allow(last_run_report).to receive(:environment).and_return("production")
-      allow(last_run_report).to receive(:status).and_return("changed")
-
-      allow(File).to receive(:exist?).and_return(true)
-      allow_any_instance_of(Object).to receive(:check_config_print).and_return("/opt/puppetlabs/puppet/cache/state/last_run_report.yaml")
-      allow(YAML).to receive(:load_file).and_return(last_run_report)
-
-      expect(get_result_from_report(-1, default_configuration, start_time)).to be ==
-          {"kind"             => "unknown",
-           "time"             => "unknown",
-           "transaction_uuid" => "unknown",
-           "environment"      => "unknown",
-           "status"           => "unknown",
-           "error_type"       => "agent_exit_non_zero",
-           "error"            => "Puppet agent exited with a non 0 exitcode",
-           "exitcode"         => -1,
-           "version"          => 1}
-    end
-
-    it "processes the last_run_report if it has been updated after the run was kicked" do
-      start_time = Time.now
-      run_time = Time.now + 10
-      last_run_report = double(:last_run_report)
-
-      allow(last_run_report).to receive(:kind).and_return("apply")
-      allow(last_run_report).to receive(:time).and_return(run_time)
-      allow(last_run_report).to receive(:transaction_uuid).and_return("ac59acbe-6a0f-49c9-8ece-f781a689fda9")
-      allow(last_run_report).to receive(:environment).and_return("production")
-      allow(last_run_report).to receive(:status).and_return("changed")
-
-      allow(File).to receive(:exist?).and_return(true)
-      allow_any_instance_of(Object).to receive(:check_config_print).and_return("/opt/puppetlabs/puppet/cache/state/last_run_report.yaml")
-      allow(YAML).to receive(:load_file).and_return(last_run_report)
-
-      expect(get_result_from_report(-1, default_configuration, start_time)).to be ==
-          {"kind"             => "apply",
-           "time"             => run_time,
-           "transaction_uuid" => "ac59acbe-6a0f-49c9-8ece-f781a689fda9",
-           "environment"      => "production",
-           "status"           => "changed",
-           "error_type"       => "agent_exit_non_zero",
-           "error"            => "Puppet agent exited with a non 0 exitcode",
-           "exitcode"         => -1,
-           "version"          => 1}
-    end
-
     it "correctly processes the last_run_report" do
-      start_time = Time.now
       run_time = Time.now + 10
       last_run_report = double(:last_run_report)
 
@@ -199,10 +144,9 @@ describe "pxp-module-puppet" do
       allow(last_run_report).to receive(:status).and_return("changed")
 
       allow(File).to receive(:exist?).and_return(true)
-      allow_any_instance_of(Object).to receive(:check_config_print).and_return("/opt/puppetlabs/puppet/cache/state/last_run_report.yaml")
       allow(YAML).to receive(:load_file).and_return(last_run_report)
 
-      expect(get_result_from_report(0, default_configuration, start_time)).to be ==
+      expect(get_result_from_report(0, default_configuration)).to be ==
           {"kind"             => "apply",
            "time"             => run_time,
            "transaction_uuid" => "ac59acbe-6a0f-49c9-8ece-f781a689fda9",
@@ -221,14 +165,14 @@ describe "pxp-module-puppet" do
     it "populates output when it terminated normally" do
       allow(Puppet::Util::Execution).to receive(:execute).and_return(runoutcome)
       allow(runoutcome).to receive(:exitstatus).and_return(0)
-      expect_any_instance_of(Object).to receive(:get_result_from_report).with(0, default_configuration, anything)
+      expect_any_instance_of(Object).to receive(:get_result_from_report).with(0, default_configuration)
       start_run(default_configuration, default_input)
     end
 
     it "populates output when it terminated with a non 0 code" do
       allow(Puppet::Util::Execution).to receive(:execute).and_return(runoutcome)
       allow(runoutcome).to receive(:exitstatus).and_return(1)
-      expect_any_instance_of(Object).to receive(:get_result_from_report).with(1, default_configuration, anything)
+      expect_any_instance_of(Object).to receive(:get_result_from_report).with(1, default_configuration)
       start_run(default_configuration, default_input)
     end
 
@@ -316,10 +260,44 @@ describe "pxp-module-puppet" do
           :properties => {
             :puppet_bin => {
               :type => "string"
+            },
+            :temp_dir => {
+              :type => "string"
             }
           }
         }
       }
+    end
+  end
+
+  describe "get_configuration" do
+    context "when temp_dir parameter is specified in the configuration" do
+      it "leaves the parameter unchanged" do
+        expect(Dir).to receive(:tmpdir).never
+        allow(Tempfile).to receive(:new).with(anything, "/configured/temp/dir").and_return(run_report_tempfile)
+        allow(run_report_tempfile).to receive(:close)
+        default_configuration["temp_dir"] = "/configured/temp/dir"
+        expect(get_configuration({"configuration" => default_configuration, "input" => default_input})["temp_dir"]).to be ==
+          "/configured/temp/dir"
+      end
+    end
+
+    context "when temp_dir parameter is NOT specified in the configuration" do
+      it "set the parameter to the platform temp directory" do
+        expect(Dir).to receive(:tmpdir).and_return(temp_dir)
+        allow(Tempfile).to receive(:new).with(anything, temp_dir).and_return(run_report_tempfile)
+        allow(run_report_tempfile).to receive(:close)
+        expect(get_configuration({"configuration" => default_configuration, "input" => default_input})["temp_dir"]).to be ==
+          temp_dir
+      end
+    end
+
+    it "sets the run_report_tempfile parameter to a tempfile created in the temp_dir directory" do
+      allow(Dir).to receive(:tmpdir).and_return(temp_dir)
+      expect(Tempfile).to receive(:new).with(anything, temp_dir).and_return(run_report_tempfile)
+      allow(run_report_tempfile).to receive(:close)
+      expect(get_configuration({"configuration" => default_configuration, "input" => default_input})["run_report_tempfile"]).to be ==
+        run_report_tempfile
     end
   end
 
@@ -335,6 +313,7 @@ describe "pxp-module-puppet" do
     end
 
     it "fails when the passed json data doesn't contain the 'input' key" do
+      expect(self).to receive(:get_configuration).and_return(default_configuration)
       expect(action_run("{\"input\": null}")["error"]).to be ==
           "The json received on STDIN did not contain a valid 'input' key: {\"input\"=>nil}"
     end
@@ -345,8 +324,8 @@ describe "pxp-module-puppet" do
       allow(File).to receive(:exist?).and_return(true)
       allow_any_instance_of(Object).to receive(:running?).and_return(false)
       allow_any_instance_of(Object).to receive(:disabled?).and_return(false)
-      expect_any_instance_of(Object).to receive(:start_run).with(default_configuration,
-                                                                 expected_input)
+      expect(self).to receive(:get_configuration).and_return(default_configuration)
+      expect(self).to receive(:start_run).with(default_configuration, expected_input)
       action_run({"configuration" => default_configuration, "input" => default_input}.to_json)
     end
 
@@ -358,13 +337,14 @@ describe "pxp-module-puppet" do
       allow(File).to receive(:exist?).and_return(true)
       allow_any_instance_of(Object).to receive(:running?).and_return(false)
       allow_any_instance_of(Object).to receive(:disabled?).and_return(false)
-      expect_any_instance_of(Object).to receive(:start_run).with(default_configuration,
-                                                                 expected_input)
+      expect(self).to receive(:get_configuration).and_return(default_configuration)
+      expect(self).to receive(:start_run).with(default_configuration, expected_input)
       action_run({"configuration" => default_configuration, "input" => passed_input}.to_json)
     end
 
     it "fails when puppet_bin doesn't exist" do
       allow(File).to receive(:exist?).and_return(false)
+      expect(self).to receive(:get_configuration).and_return(default_configuration)
       expect(action_run({"configuration" => default_configuration, "input" => default_input}.to_json)["error"]).to be ==
           "Puppet executable 'puppet' does not exist"
     end
@@ -373,7 +353,8 @@ describe "pxp-module-puppet" do
       allow(File).to receive(:exist?).and_return(true)
       allow_any_instance_of(Object).to receive(:running?).and_return(false)
       allow_any_instance_of(Object).to receive(:disabled?).and_return(false)
-      expect_any_instance_of(Object).to receive(:start_run)
+      expect(self).to receive(:get_configuration).and_return(default_configuration)
+      expect(self).to receive(:start_run)
       action_run({"configuration" => default_configuration, "input" => default_input}.to_json)
     end
   end


### PR DESCRIPTION
Before this commit we let puppet runs executed from px-module-puppet write their run reports to the default location. Since the file is overwritten on every puppet run, we could never be sure when reading the file whether it was produced by the puppet run triggered by pxp-module-puppet or by a concurrent puppet run.
To avoid this, we update the pxp-module-puppet in this commit such that it ensures (by passing the ```--lastrunreport``` option) that the puppet runs it triggers write their run reports to uniquely named temporary files rather than to the default location.