### PR TITLE
(PCP-276) Create new process group for ext mod on Windows

### DIFF
--- a/lib/src/external_module.cc
+++ b/lib/src/external_module.cc
@@ -341,6 +341,10 @@ ActionResponse ExternalModule::callNonBlockingAction(const ActionRequest& reques
              request.prettyLabel(), request.resultsDir());
     LOG_TRACE("Input for the %1%: %2%", request.prettyLabel(), input_txt);
 
+    // NOTE(ale): to avoid terminating the entire process tree when
+    // the pxp-agent service stops, on Solaris we use ctrun and on
+    // Windows we create a new Process Group for the child process
+
     auto exec = lth_exec::execute(
 #if defined(_WIN32)
         "cmd.exe", { "/c", path_, action_name },
@@ -349,14 +353,19 @@ ActionResponse ExternalModule::callNonBlockingAction(const ActionRequest& reques
 #else
         path_, { action_name },
 #endif
-        input_txt,  // input
+        input_txt,  // input arguments, passed via stdin
         std::map<std::string, std::string>(),  // environment
         [results_dir_path](size_t pid) {
             auto pid_file = (results_dir_path / "pid").string();
             lth_file::atomic_write_to_file(std::to_string(pid) + "\n", pid_file);
         },          // pid callback
         0,          // timeout
-        { lth_exec::execution_options::merge_environment });  // options
+#if defined(_WIN32)
+        { lth_exec::execution_options::merge_environment,  // options
+          lth_exec::execution_options::create_new_process_group });
+#else
+        { lth_exec::execution_options::merge_environment });
+#endif
 
     LOG_INFO("The task for the %1% has completed", request.prettyLabel());
 


### PR DESCRIPTION
To avoid teminating the entire pxp-agent process tree when the pxp-agent
service is stopped on Windows, we use the leatherman::execution's option
for creating a new process group for external module child processes,
within a non-blocking request task.