### PR TITLE
(PCP-338) Handle Associate Session errors

### DIFF
--- a/exe/main.cc
+++ b/exe/main.cc
@@ -66,9 +66,12 @@ int startAgent(std::vector<std::string> arguments) {
     try {
         Agent agent { Configuration::Instance().getAgentConfiguration() };
         agent.start();
+    } catch (const Agent::PCPConfigurationError& e) {
+        exit_code = PXP_AGENT_CONFIGURATION_FAILURE;
+        LOG_ERROR("PCP configuration error: %1%", e.what());
     } catch (const Agent::WebSocketConfigurationError& e) {
         exit_code = PXP_AGENT_CONFIGURATION_FAILURE;
-        LOG_ERROR("WebSocket configuration  rror: %1%", e.what());
+        LOG_ERROR("WebSocket configuration error: %1%", e.what());
     } catch (const Agent::Error& e) {
         exit_code = PXP_AGENT_GENERAL_FAILURE;
         LOG_ERROR("Fatal error: %1%", e.what());

--- a/lib/inc/pxp-agent/agent.hpp
+++ b/lib/inc/pxp-agent/agent.hpp
@@ -19,6 +19,10 @@ class Agent {
         explicit Error(std::string const& msg) : std::runtime_error(msg) {}
     };
 
+    struct PCPConfigurationError : public Error {
+        explicit PCPConfigurationError(std::string const& msg) : Error(msg) {}
+    };
+
     struct WebSocketConfigurationError : public Error {
         explicit WebSocketConfigurationError(std::string const& msg) : Error(msg) {}
     };

--- a/lib/src/agent.cc
+++ b/lib/src/agent.cc
@@ -3,12 +3,22 @@
 
 #include <cpp-pcp-client/protocol/schemas.hpp>
 
+#include <cpp-pcp-client/util/thread.hpp>   // this_thread::sleep_for
+#include <cpp-pcp-client/util/chrono.hpp>
+
 #define LEATHERMAN_LOGGING_NAMESPACE "puppetlabs.pxp_agent.agent"
 #include <leatherman/logging/logging.hpp>
 
 #include <vector>
+#include <stdint.h>
+#include <random>
 
 namespace PXPAgent {
+
+namespace pcp_util = PCPClient::Util;
+
+// Pause between PCP connection attempts after Association errors
+static const uint32_t ASSOCIATE_SESSION_TIMEOUT_PAUSE_S { 5 };
 
 Agent::Agent(const Configuration::Agent& agent_configuration)
         try
@@ -37,8 +47,26 @@ void Agent::start() {
             ttlExpiredCallback(parsed_chunks);
         });
 
+    int num_seconds {};
+    std::random_device rd {};
+    std::default_random_engine engine { rd() };
+    std::uniform_int_distribution<int> dist { ASSOCIATE_SESSION_TIMEOUT_PAUSE_S,
+                                              2 * ASSOCIATE_SESSION_TIMEOUT_PAUSE_S };
+
     try {
-        connector_ptr_->connect();
+        do {
+            try {
+                connector_ptr_->connect();
+                break;
+            } catch (const PCPClient::connection_association_error& e) {
+                num_seconds = dist(engine);
+                LOG_WARNING("Error during the PCP Session Association (%1%); "
+                            "will retry to connect in %2% s",
+                            e.what(), num_seconds);
+                pcp_util::this_thread::sleep_for(
+                    pcp_util::chrono::seconds(num_seconds));
+            }
+        } while (true);
 
         // The agent is now connected and the request handlers are
         // set; we can now call the monitoring method that will block
@@ -49,8 +77,13 @@ void Agent::start() {
         LOG_DEBUG("PCP connection established; about to start monitoring it");
         connector_ptr_->monitorConnection();
     } catch (const PCPClient::connection_config_error& e) {
-        // Failed to configure WebSocket on our end
+        // WebSocket configuration failure
         throw Agent::WebSocketConfigurationError { e.what() };
+    } catch (const PCPClient::connection_association_response_failure& e) {
+        // Associate Session failure; this should be due to a
+        // configuration mismatch with the broker (incompatible
+        // PCP versions?)
+        throw Agent::PCPConfigurationError { e.what() };
     } catch (const PCPClient::connection_fatal_error& e) {
         // Unexpected, as we're not limiting the num retries, for
         // both connect() and monitorConnection() calls

--- a/lib/src/configuration.cc
+++ b/lib/src/configuration.cc
@@ -23,11 +23,12 @@
 
 #include <boost/nowide/iostream.hpp>
 
+#include <boost/format.hpp>
+
 #ifdef _WIN32
     #include <leatherman/windows/system_error.hpp>
     #include <leatherman/windows/windows.hpp>
     #undef ERROR
-    #include <boost/format.hpp>
     #include <Shlobj.h>
 #endif
 

--- a/lib/tests/main.cc
+++ b/lib/tests/main.cc
@@ -8,7 +8,7 @@
 // #define ENABLE_LOGGING
 
 #ifdef ENABLE_LOGGING
-#define LEATHERMAN_LOGGING_NAMESPACE "puppetlabs.pegasus.test"
+#define LEATHERMAN_LOGGING_NAMESPACE "puppetlabs.pxp-agent.test"
 #include <leatherman/logging/logging.hpp>
 #endif
 


### PR DESCRIPTION
Retrying to connect in case of errors during Session Association; that
is done after a random pause in the  [5 s, 10 s] interval.

Handling Session Association failures.