### PR TITLE
(maint) Remove move() when returning unique_ptr

### DIFF
--- a/lib/src/util/posix/daemonize.cc
+++ b/lib/src/util/posix/daemonize.cc
@@ -264,7 +264,7 @@ std::unique_ptr<PIDFile> daemonize() {
     // Set PIDFile dtor to clean itself up and return pointer for RAII
     pidf_ptr->cleanupWhenDone();
 
-    return std::move(pidf_ptr);
+    return pidf_ptr;
 }
 
 }  // namespace Util


### PR DESCRIPTION
Removing the std::move() call when returning the PIDFile unique_ptr from
the daemonize() function, to avoid clang error during compilation
(clang-703.0.29 seems to be more restrictive). Note that unique_ptr only
supports move assignments, so the std::move() call was redundant.