### PR TITLE
(PCP-284) In modules interface, specify "metadata" arg

### DIFF
--- a/modules/README.md
+++ b/modules/README.md
@@ -2,8 +2,8 @@
 
 ### Metadata
 
-When a module is invoked with no arguments, it must write its `metadata` to
-stdout.
+When a module is invoked with the "metadata" argument, it must write its
+`metadata` to stdout.
 
 The `metadata` of a module is a JSON object that contains a number of JSON
 schemas for specifying its configuration options and actions. It contains:


### PR DESCRIPTION
For external modules, require that the metadata action is executed when
the module is invoked with "metadata" as its only argument.