### PR TITLE
(PCP-305) Acceptance tests on OSX should not expect a stopped service

### DIFF
--- a/acceptance/tests/service_stop_start.rb
+++ b/acceptance/tests/service_stop_start.rb
@@ -57,7 +57,11 @@ agents.each_with_index do |agent, i|
   # See: https://github.com/puppetlabs/pxp-agent/blob/stable/ext/solaris/smf/pxp-agent.xml#L10-L12
   #
   # Therefore, the un-configured test steps need to be skipped on Solaris
-  unless (@agent['platform'] =~ /solaris/) then
+  #
+  # Also needs skipped on OSX, as the pxp-agent executable will exit but the service will
+  # continue running and will re-execute pxp-agent every 10 seconds. Ref: PCP-305 
+  #
+  unless (@agent['platform'] =~ /solaris|osx/) then
     step 'Remove configuration' do
       stop_service
       on(@agent, "mv #{pxp_agent_config_file(@agent)} #{@pxp_temp_file}")


### PR DESCRIPTION
On OSX, the pxp-agent service remains running even if the executable exits.
Therefore our acceptance tests for invalid pxp-agent.conf values should not expect the pxp-agent service to be stopped.

[skip ci]