### PR TITLE
(PCP-359) Fix confusion between EL and CentOS in acceptance host generation

### DIFF
--- a/acceptance/Rakefile
+++ b/acceptance/Rakefile
@@ -242,7 +242,7 @@ def config
       ENV['TEST_TARGET'] = "redhat7-64m-#{ENV['TEST_TARGET']}"
       puts "Adding Redhat 7 master to ENV['TEST_TARGET']. Value is now '#{ENV['TEST_TARGET']}'"
     end
-    cli = BeakerHostGenerator::CLI.new([ENV['TEST_TARGET'], '--disable-default-role'])
+    cli = BeakerHostGenerator::CLI.new([ENV['TEST_TARGET'], '--disable-default-role', '--osinfo-version', '1'])
     ENV['CONFIG'] = "tmp/#{ENV['TEST_TARGET']}-#{SecureRandom.uuid}.yaml"
     FileUtils.mkdir_p('tmp')
     File.open(ENV['CONFIG'], 'w') do |fh|


### PR DESCRIPTION
The current version of beaker-hostgenerator (0.x) assumes EL if you request CentOS.
This will be fixed in the next major release (1.0) of beaker-hostgenerator.
In the meantime, we need to add an option to explicitly use v1.0's OS handling.
This fixes PCP-359 where the acceptance tests failed on CentOS4 because beaker-hostgenerator gave us el4 instead, and beaker refused to install puppet-agent.
[skip ci]