### PR TITLE
PCP-362 use PCP::Client#close rather than EM weirdness

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -16,7 +16,7 @@ gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 2.19')
 gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.2")
 gem 'rake'
 gem 'scooter', '~> 3.1.1'
-gem 'pcp-client', '~> 0.2.0'
+gem 'pcp-client', '~> 0.3.0'
 
 group(:test) do
   gem 'rspec', '~> 2.14.0', :require => false

--- a/acceptance/lib/pxp-agent/test_helper.rb
+++ b/acceptance/lib/pxp-agent/test_helper.rb
@@ -84,10 +84,8 @@ end
 
 # Start an eventmachine reactor in a thread
 # @return Thread object where the EM reactor should be running
-def start_eventmachine_thread
+def assert_eventmachine_thread_running
   if EventMachine.reactor_running?
-    puts "EventMachine already running!"
-    puts caller
     return EventMachine.reactor_thread
   end
 
@@ -104,18 +102,6 @@ def start_eventmachine_thread
   em_thread
 end
 
-# Stop the eventmachine reactor
-# @param thread  The thread the EM reactor should be running in
-def stop_eventmachine_thread(thread)
-  unless EventMachine.reactor_running?
-    puts "EventMachine is not running!"
-    puts caller
-  end
-
-  EventMachine.stop_event_loop
-  thread.join
-end
-
 # Query pcp-broker's inventory of associated clients
 # Reference: https://github.com/puppetlabs/pcp-specifications/blob/master/pcp/inventory.md
 # @param broker hostname or beaker host object of the pcp-broker host
@@ -126,7 +112,7 @@ end
 def pcp_broker_inventory(broker, query)
   # Event machine is required by the ruby-pcp-client gem
   # https://github.com/puppetlabs/ruby-pcp-client
-  em_thread = start_eventmachine_thread
+  assert_eventmachine_thread_running
 
   mutex = Mutex.new
   have_response = ConditionVariable.new
@@ -172,7 +158,7 @@ def pcp_broker_inventory(broker, query)
   rescue Timeout::Error
     raise "Didn't receive a response for PCP inventory request"
   ensure
-    stop_eventmachine_thread(em_thread)
+    client.close
   end # wait for message
 
   if(!response.has_key?(:data))
@@ -241,7 +227,7 @@ def rpc_blocking_request(broker, targets,
                          params)
   # Event machine is required by the ruby-pcp-client gem
   # https://github.com/puppetlabs/ruby-pcp-client
-  em_thread = start_eventmachine_thread
+  assert_eventmachine_thread_running
 
   mutex = Mutex.new
   have_response = ConditionVariable.new
@@ -297,7 +283,7 @@ def rpc_blocking_request(broker, targets,
       end
     end
   ensure
-    stop_eventmachine_thread(em_thread)
+    client.close
   end # wait for message
 
   responses
@@ -325,9 +311,11 @@ def connect_pcp_client(broker)
     retries += 1
   end
   if !connected
+    client.close
     raise "Controller PCP client failed to connect with pcp-broker on #{broker} after #{max_retries} attempts: #{client.inspect}"
   end
   if !client.associated?
+    client.close
     raise "Controller PCP client failed to associate with pcp-broker on #{broker} #{client.inspect}"
   end
 

--- a/acceptance/lib/pxp-agent/test_helper.rb
+++ b/acceptance/lib/pxp-agent/test_helper.rb
@@ -82,7 +82,7 @@ def get_pcp_broker_status(host)
   end
 end
 
-# Start an eventmachine reactor in a thread
+# Start an eventmachine reactor in a thread, if one is not already running
 # @return Thread object where the EM reactor should be running
 def assert_eventmachine_thread_running
   if EventMachine.reactor_running?


### PR DESCRIPTION
ruby-pcp-client 0.3.0 adds a long-missing PCP::Client#close method
to shut down a client after we're done with it.

Here we switch to using this close method with a long-running
eventmachine reactor thread, avoiding the painful races caused by
trying to manage client lifecycle by restarting the supervising
eventmachine.