### PR TITLE
(PCP-360) Acceptance: puppet-agent should use beaker hostname as certname

### DIFF
--- a/acceptance/lib/puppet/acceptance/common_utils.rb
+++ b/acceptance/lib/puppet/acceptance/common_utils.rb
@@ -12,6 +12,8 @@ module Puppet
         agents.each do |agent|
           next if agent == master
 
+          on agent, puppet("config set certname #{agent}")
+
           ssldir = on(agent, puppet('agent --configprint ssldir')).stdout.chomp
           on(agent, "rm -rf '#{ssldir}'")
 


### PR DESCRIPTION
This commit adds puppet-agent config to the acceptance setup, to ensure that puppet agent uses the hostname that beaker is expecting as the agent certname.
This avoids failures when an agent host has multiple hostnames and puppet agent generates certs for a hostname other than what beaker expects.

[skip ci]