### PR TITLE
(PCP-364) Acceptance - sync system time on hosts

### DIFF
--- a/acceptance/config/aio/options.rb
+++ b/acceptance/config/aio/options.rb
@@ -5,6 +5,7 @@
   :'puppetserver-confdir' => '/etc/puppetlabs/puppetserver/conf.d',
   :pre_suite => [
     'setup/common/000-delete-puppet-when-none.rb',
+    'setup/common/005_SyncTime.rb',
     'setup/aio/pre-suite/010_Install.rb',
     'setup/aio/021_InstallAristaModule.rb',
     'setup/common/035_StartPuppetServer.rb',

--- a/acceptance/setup/common/005_SyncTime.rb
+++ b/acceptance/setup/common/005_SyncTime.rb
@@ -1,0 +1,7 @@
+require 'beaker/host_prebuilt_steps'
+extend Beaker::HostPrebuiltSteps
+
+# Note: QENG-3641 would allow beaker to take care of this for us
+test_name 'Ensure hosts have synchronized clocks'
+
+timesync(hosts, {:logger => logger})


### PR DESCRIPTION
As part of the pre-suite for the acceptance tests, ensure that all hosts have their time synced.

[skip ci]