### PR TITLE
(PCP-329) Update ruby-pcp-client to pick up EventMachine improvements

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -16,7 +16,7 @@ gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 2.19')
 gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.2")
 gem 'rake'
 gem 'scooter', '~> 3.1.1'
-gem 'pcp-client', '~> 0.3.0'
+gem 'pcp-client', '~> 0.3', '>= 0.3.1'
 
 group(:test) do
   gem 'rspec', '~> 2.14.0', :require => false


### PR DESCRIPTION
Update the acceptance Gemfile to use at least version 0.3.1 of ruby-pcp-client.
That version contains improvements to the usage of EventMachine.
[skip ci]