### PR TITLE
PCP-355 show logs on failures

### DIFF
--- a/acceptance/lib/pxp-agent/test_helper.rb
+++ b/acceptance/lib/pxp-agent/test_helper.rb
@@ -43,6 +43,29 @@ def expect_file_on_host_to_contain(host, file, expected, seconds=30)
   end
 end
 
+# Show the logs of the broker and agents - useful to see why a test failed
+def show_pcp_logs
+  puts "---- Broker log -----"
+  on(master, "cat /var/log/pcp-broker.log") do |result|
+    puts result.stdout
+  end
+
+  agents.each do |agent|
+    puts "----- agent #{agent} log -----"
+    on(agent, "cat #{logfile(agent)}") do |result|
+      puts result.stdout
+    end
+  end
+end
+
+# Evaluate the block, show logs if test assertions were triggered
+def show_pcp_logs_on_failure(&block)
+  yield
+rescue MiniTest::Assertion => exception
+  show_pcp_logs
+  raise exception
+end
+
 # Some helpers for working with a pcp-broker 'lein tk' instance
 def run_pcp_broker(host)
   on(host, "cd #{GIT_CLONE_FOLDER}/pcp-broker; export LEIN_ROOT=ok; lein tk </dev/null >/var/log/pcp-broker.log 2>&1 &")

--- a/acceptance/lib/pxp-agent/test_helper.rb
+++ b/acceptance/lib/pxp-agent/test_helper.rb
@@ -62,6 +62,8 @@ end
 def show_pcp_logs_on_failure(&block)
   yield
 rescue MiniTest::Assertion => exception
+  logger.notify "Assertion failed in test: #{exception}"
+  logger.notify "Fetching logs for inspection"
   show_pcp_logs
   raise exception
 end

--- a/acceptance/lib/pxp-agent/test_helper.rb
+++ b/acceptance/lib/pxp-agent/test_helper.rb
@@ -45,15 +45,15 @@ end
 
 # Show the logs of the broker and agents - useful to see why a test failed
 def show_pcp_logs
-  puts "---- Broker log -----"
+  logger.notify "---- Broker log -----"
   on(master, "cat /var/log/pcp-broker.log") do |result|
-    puts result.stdout
+    logger.notify result.stdout
   end
 
   agents.each do |agent|
-    puts "----- agent #{agent} log -----"
+    logger.notify "----- agent #{agent} log -----"
     on(agent, "cat #{logfile(agent)}") do |result|
-      puts result.stdout
+      logger.notify result.stdout
     end
   end
 end

--- a/acceptance/tests/invalid_ssl_config.rb
+++ b/acceptance/tests/invalid_ssl_config.rb
@@ -95,9 +95,11 @@ agents.each_with_index do |agent, i|
 
     step 'Start pxp-agent and assert that it does not connect to pcp-broker'
     on agent, puppet('resource service pxp-agent ensure=running')
-    assert(is_not_associated?(master, "pcp://#{agent}/agent"),
-           "Agent identity pcp://#{agent}/agent for agent host #{agent} should not appear in pcp-broker's inventory " \
-           "when pxp-agent is using the wrong CA cert")
+    show_pcp_logs_on_failure do
+      assert(is_not_associated?(master, "pcp://#{agent}/agent"),
+             "Agent identity pcp://#{agent}/agent for agent host #{agent} should not appear in pcp-broker's inventory " \
+             "when pxp-agent is using the wrong CA cert")
+    end
     expect_file_on_host_to_contain(agent, logfile(agent), 'TLS handshake failed')
   end
 
@@ -113,9 +115,11 @@ agents.each_with_index do |agent, i|
 
     step 'Start pxp-agent and assert that it does not connect to broker'
     on agent, puppet('resource service pxp-agent ensure=running')
-    assert(is_not_associated?(master, "pcp://#{agent}/agent"),
-           "Agent identity pcp://#{agent}/agent for agent host #{agent} should not appear in pcp-broker's inventory " \
-           "when pxp-agent attempts to connect by broker IP instead of broker certified hostname")
+    show_pcp_logs_on_failure do
+      assert(is_not_associated?(master, "pcp://#{agent}/agent"),
+             "Agent identity pcp://#{agent}/agent for agent host #{agent} should not appear in pcp-broker's inventory " \
+             "when pxp-agent attempts to connect by broker IP instead of broker certified hostname")
+    end
     expect_file_on_host_to_contain(agent, logfile(agent), 'TLS handshake failed')
   end
 end

--- a/acceptance/tests/pxp-module-puppet/run_puppet.rb
+++ b/acceptance/tests/pxp-module-puppet/run_puppet.rb
@@ -7,8 +7,10 @@ test_name 'C95972 - pxp-module-puppet run' do
       on agent, puppet('resource service pxp-agent ensure=stopped')
       create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
       on agent, puppet('resource service pxp-agent ensure=running')
-      assert(is_associated?(master, "pcp://#{agent}/agent"),
-             "Agent #{agent} with PCP identity pcp://#{agent}/agent should be associated with pcp-broker")
+      show_pcp_logs_on_failure do
+        assert(is_associated?(master, "pcp://#{agent}/agent"),
+               "Agent #{agent} with PCP identity pcp://#{agent}/agent should be associated with pcp-broker")
+      end
     end
   end
 

--- a/acceptance/tests/pxp-module-puppet/run_puppet_agent_disabled.rb
+++ b/acceptance/tests/pxp-module-puppet/run_puppet_agent_disabled.rb
@@ -10,8 +10,10 @@ test_name 'C93065 - Run puppet and expect puppet agent disabled' do
       on agent, puppet('resource service pxp-agent ensure=stopped')
       create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
       on agent, puppet('resource service pxp-agent ensure=running')
-      assert(is_associated?(master, "pcp://#{agent}/agent"),
-             "At the start of the test, #{agent} (with PCP identity pcp://#{agent}/agent ) should be associated with pcp-broker")
+      show_pcp_logs_on_failure do
+        assert(is_associated?(master, "pcp://#{agent}/agent"),
+               "At the start of the test, #{agent} (with PCP identity pcp://#{agent}/agent ) should be associated with pcp-broker")
+      end
     end
   end
 

--- a/acceptance/tests/pxp-module-puppet/run_puppet_result_changed.rb
+++ b/acceptance/tests/pxp-module-puppet/run_puppet_result_changed.rb
@@ -21,8 +21,10 @@ SITEPP
       on agent, puppet('resource service pxp-agent ensure=stopped')
       create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
       on agent, puppet('resource service pxp-agent ensure=running')
-      assert(is_associated?(master, "pcp://#{agent}/agent"),
-             "Agent #{agent} with PCP identity pcp://#{agent}/agent should be associated with pcp-broker")
+      show_pcp_logs_on_failure do
+        assert(is_associated?(master, "pcp://#{agent}/agent"),
+               "Agent #{agent} with PCP identity pcp://#{agent}/agent should be associated with pcp-broker")
+      end
     end
   end
 

--- a/acceptance/tests/pxp_agent_associate.rb
+++ b/acceptance/tests/pxp_agent_associate.rb
@@ -11,9 +11,11 @@ agents.each do |agent|
   end
 
   step 'Assert that the agent is not listed in pcp-broker inventory' do
-    assert(is_not_associated?(master, "pcp://#{agent}/agent"),
-           "Agent identity pcp://#{agent}/agent for agent host #{agent} appears in pcp-broker's client inventory " \
-           "but pxp-agent service is supposed to be stopped")
+    show_pcp_logs_on_failure do
+      assert(is_not_associated?(master, "pcp://#{agent}/agent"),
+             "Agent identity pcp://#{agent}/agent for agent host #{agent} appears in pcp-broker's client inventory " \
+             "but pxp-agent service is supposed to be stopped")
+    end
   end
 
   step 'Start pxp-agent service' do
@@ -21,7 +23,9 @@ agents.each do |agent|
   end
 
   step 'Assert that agent is listed in pcp-broker inventory' do
-    assert(is_associated?(master, "pcp://#{agent}/agent"),
-           "Agent identity pcp://#{agent}/agent for agent host #{agent} does not appear in pcp-broker's client inventory")
+    show_pcp_logs_on_failure do
+      assert(is_associated?(master, "pcp://#{agent}/agent"),
+             "Agent identity pcp://#{agent}/agent for agent host #{agent} does not appear in pcp-broker's client inventory")
+    end
   end
 end

--- a/acceptance/tests/reconnect_after_broker_unavailable.rb
+++ b/acceptance/tests/reconnect_after_broker_unavailable.rb
@@ -9,8 +9,10 @@ step 'Ensure each agent host has pxp-agent running and associated' do
     create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
     on(agent, "rm -rf #{logfile(agent)}")
     on agent, puppet('resource service pxp-agent ensure=running')
-    assert(is_associated?(master, "pcp://#{agent}/agent"),
-           "Agent identity pcp://#{agent}/agent for agent host #{agent} does not appear in pcp-broker's client inventory")
+    show_pcp_logs_on_failure do
+      assert(is_associated?(master, "pcp://#{agent}/agent"),
+             "Agent identity pcp://#{agent}/agent for agent host #{agent} does not appear in pcp-broker's client inventory")
+    end
   end
 end
 

--- a/acceptance/tests/restart_host_run_puppet.rb
+++ b/acceptance/tests/restart_host_run_puppet.rb
@@ -13,8 +13,10 @@ test_name 'C94777 - Ensure pxp-agent functions after agent host restart' do
       cert_dir = configure_std_certs_on_host(agent)
       create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
       on agent, puppet('resource service pxp-agent ensure=running enable=true')
-      assert(is_associated?(master, "pcp://#{agent}/agent"),
-             "Agent #{agent} with PCP identity pcp://#{agent}/agent should be associated with pcp-broker")
+      show_pcp_logs_on_failure do
+        assert(is_associated?(master, "pcp://#{agent}/agent"),
+               "Agent #{agent} with PCP identity pcp://#{agent}/agent should be associated with pcp-broker")
+      end
     end
   end
 


### PR DESCRIPTION
Here we add a helper to show logs on assertion failures, and wrap the `is_not_associated?` `is_associated?` `assert` calls in it, to add context to the periodic failures we are tracking.