### PR TITLE
(PCP-345) Create spool dir if needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,8 @@ The location where the outcome of non-blocking requests will be stored; the
 default location is:
  - \*nix: */opt/puppetlabs/pxp-agent/spool*
  - Windows: *C:\ProgramData\PuppetLabs\pxp-agent\var\spool*
+Note that if the specified spool directory does not exist, pxp-agent will create
+it when starting.
 
 **spool-dir-purge-ttl (optional)**
 

--- a/lib/tests/unit/configuration_test.cc
+++ b/lib/tests/unit/configuration_test.cc
@@ -282,10 +282,40 @@ TEST_CASE("Configuration::validate", "[configuration]") {
                           Configuration::Error);
     }
 
-    SECTION("it fails when --spool-dir is empty") {
+    SECTION("it fails when --modules-dir does not exist") {
+        auto test_modules = SPOOL_DIR + "/testing_modules";
+        HW::SetFlag<std::string>("modules-dir", test_modules);
+        REQUIRE_THROWS_AS(Configuration::Instance().validate(),
+                          Configuration::Error);
+    }
+
+    SECTION("it fails when --modules-config-dir is not a directory") {
+        HW::SetFlag<std::string>("modules-dir", CONFIG);
+        REQUIRE_THROWS_AS(Configuration::Instance().validate(),
+                          Configuration::Error);
+    }
+
+        SECTION("it fails when --spool-dir is empty") {
         HW::SetFlag<std::string>("spool-dir", "");
         REQUIRE_THROWS_AS(Configuration::Instance().validate(),
                           Configuration::Error);
+    }
+
+    SECTION("it fails when --spool-dir exists but is not a directory") {
+        HW::SetFlag<std::string>("spool-dir", CONFIG);
+        REQUIRE_THROWS_AS(Configuration::Instance().validate(),
+                          Configuration::Error);
+    }
+
+    SECTION("it creates --spool-dir when needed") {
+        auto test_spool = SPOOL_DIR + "/testing_creation";
+        HW::SetFlag<std::string>("spool-dir", test_spool);
+
+        REQUIRE_FALSE(fs::exists(test_spool));
+        REQUIRE_NOTHROW(Configuration::Instance().validate());
+        REQUIRE(fs::exists(test_spool));
+
+        fs::remove_all(test_spool);
     }
 }
 


### PR DESCRIPTION
Creating the spool directory at start if it doesn't exist.

This is done in order to facilitate running pxp-agent without super user
privileges.

Also, new unit tests are added.