### PR TITLE
(maint) Refactor Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Dependencies
  - Boost
  - OpenSSL
  - ruby (2.0 and newer)
- - [leatherman][leatherman] (0.3.5 or newer)
+ - [leatherman][leatherman] (0.4.2 or newer)
  - [cpp-pcp-client][cpp-pcp-client] (master)
 
 Initial Setup

--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ The following will install most required tools and libraries:
 
 #### Setup on Windows
 
-[MinGW-w64][MinGW-w64] is used for full C++11 support, and [Chocolatey][Chocolatey] can be used to install. You should have at least 2GB of memory for compilation.
+[MinGW-w64][MinGW-w64] is used for full C++11 support, and
+[Chocolatey][Chocolatey] can be used to install. You should have at least 2GB of
+memory for compilation.
 
 * install [CMake][CMake-choco] & [7zip][7zip-choco]
 
@@ -57,7 +59,9 @@ The following will install most required tools and libraries:
 
         choco install mingw --params "/threads:win32"
 
-For the remaining tasks, build commands can be executed in the shell from Start > MinGW-w64 project > Run Terminal
+For the remaining tasks, build commands can be executed in the shell from:
+
+        Start > MinGW-w64 project > Run Terminal
 
 * select an install location for dependencies, such as C:\\tools or cmake\\release\\ext; we'll refer to it as $install
 

--- a/lib/inc/pxp-agent/configuration.hpp
+++ b/lib/inc/pxp-agent/configuration.hpp
@@ -15,8 +15,6 @@
 
 namespace PXPAgent {
 
-namespace HW = HorseWhisperer;
-
 //
 // Tokens
 //
@@ -153,7 +151,7 @@ class Configuration
     /// Throw a Configuration::Error: if it fails to parse the CLI
     /// arguments; if the specified config file cannot be parsed or
     /// has any invalid JSON entry.
-    HW::ParseResult parseOptions(int argc, char *argv[]);
+    HorseWhisperer::ParseResult parseOptions(int argc, char *argv[]);
 
     /// Validate logging configuration options and enable logging.
     /// Throw a Configuration::Error: in case of invalid the specified
@@ -177,8 +175,8 @@ class Configuration
     {
         if (valid_) {
             try {
-                return HW::GetFlag<T>(flagname);
-            } catch (HW::undefined_flag_error& e) {
+                return HorseWhisperer::GetFlag<T>(flagname);
+            } catch (HorseWhisperer::undefined_flag_error& e) {
                 throw Configuration::Error { std::string { e.what() } };
             }
         }
@@ -208,10 +206,10 @@ class Configuration
         }
 
         try {
-            HW::SetFlag<T>(flagname, value);
-        } catch (HW::flag_validation_error) {
+            HorseWhisperer::SetFlag<T>(flagname, value);
+        } catch (HorseWhisperer::flag_validation_error) {
             throw Configuration::Error { "invalid value for " + flagname };
-        } catch (HW::undefined_flag_error) {
+        } catch (HorseWhisperer::undefined_flag_error) {
             throw Configuration::Error { "unknown flag name: " + flagname };
         }
     }

--- a/lib/inc/pxp-agent/configuration.hpp
+++ b/lib/inc/pxp-agent/configuration.hpp
@@ -29,7 +29,8 @@ extern const std::string DEFAULT_SPOOL_DIR;     // used by unit tests
 
 enum Types { Integer, String, Bool, Double };
 
-struct EntryBase {
+struct EntryBase
+{
     // Config option name
     // HERE: must match one of the flag names and config file option
     std::string name;
@@ -51,7 +52,8 @@ struct EntryBase {
 };
 
 template <typename T>
-struct Entry : EntryBase {
+struct Entry : EntryBase
+{
     // Default value
     T value;
 
@@ -107,18 +109,22 @@ void configure_platform_file_logging();
 // Configuration (singleton)
 //
 
-class Configuration {
+class Configuration
+{
   public:
-    struct Error : public std::runtime_error {
+    struct Error : public std::runtime_error
+    {
         explicit Error(std::string const& msg) : std::runtime_error(msg) {}
     };
 
-    static Configuration& Instance() {
+    static Configuration& Instance()
+    {
         static Configuration instance {};
         return instance;
     }
 
-    struct Agent {
+    struct Agent
+    {
         std::string modules_dir;
         std::string broker_ws_uri;
         std::string ca;
@@ -167,7 +173,8 @@ class Configuration {
     /// value in case nd the requested flag is known or throw a
     /// Configuration::Error otherwise.
     template <typename T>
-    T get(std::string flagname) {
+    T get(std::string flagname)
+    {
         if (valid_) {
             try {
                 return HW::GetFlag<T>(flagname);
@@ -193,7 +200,8 @@ class Configuration {
     /// Throw a Configuration::Error in case the specified flag is
     /// unknown or the value is invalid.
     template<typename T>
-    void set(std::string flagname, T value) {
+    void set(std::string flagname, T value)
+    {
         if (!valid_) {
             throw Configuration::Error { "cannot set configuration value until "
                                          "configuration is validated" };

--- a/lib/src/configuration.cc
+++ b/lib/src/configuration.cc
@@ -34,6 +34,8 @@
 
 namespace PXPAgent {
 
+namespace HW = HorseWhisperer;
+
 namespace fs = boost::filesystem;
 namespace lth_file = leatherman::file_util;
 namespace lth_jc = leatherman::json_container;

--- a/lib/src/configuration.cc
+++ b/lib/src/configuration.cc
@@ -693,21 +693,24 @@ void Configuration::validateAndNormalizeOtherSettings() {
             fs::remove_all(tmp_path);
         }
     } catch (const std::exception& e) {
-        LOG_DEBUG("Failed to create the test dir in spool path during"
-                  "configuration validation: %1%", e.what());
+        LOG_DEBUG("Failed to create the test dir in spool path '%1%' during"
+                  "configuration validation: %2%",
+                  spool_dir_path.string(), e.what());
     }
 
     if (!is_writable) {
-        throw Configuration::Error { "--spool-dir '"
-            + spool_dir_path.string() + "' is not writable" };
+        throw Configuration::Error {
+                (boost::format("the spool-dir '%1%' is not writable")
+                    % spool_dir_path.string()).str() };
     }
 
 #ifndef _WIN32
     if (!HW::GetFlag<bool>("foreground")) {
         auto pid_file = lth_file::tilde_expand(HW::GetFlag<std::string>("pidfile"));
         if (fs::exists(pid_file) && !(fs::is_regular_file(pid_file))) {
-            throw Configuration::Error { "the PID file '" + pid_file
-                                         + "' is not a regular file" };
+            throw Configuration::Error {
+                    (boost::format("the PID file '%1%' is not a regular file")
+                        % pid_file).str() };
         }
 
         auto pid_dir = fs::path(pid_file).parent_path().string();
@@ -722,18 +725,22 @@ void Configuration::validateAndNormalizeOtherSettings() {
                 fs::create_directories(pid_dir);
             } catch (const std::exception& e) {
                 LOG_DEBUG("Failed to create '%1%' directory: %2%", pid_dir, e.what());
-                throw Configuration::Error { "failed to create the PID file directory" };
+                throw Configuration::Error {
+                        "failed to create the PID file directory" };
             }
         }
 
         if (fs::exists(pid_dir)) {
             if (!fs::is_directory(pid_dir)) {
-                throw Configuration::Error { "the PID directory '" + pid_dir
-                                             + "' is not a directory" };
+                throw Configuration::Error {
+                        (boost::format("'%1%' is not a directory")
+                            % pid_dir).str() };
             }
         } else {
-            throw Configuration::Error { "the PID directory '" + pid_dir + "' "
-                                         "does not exist; cannot create PID file" };
+            throw Configuration::Error {
+                    (boost::format("the PID directory '%1%' does not exist; "
+                                   "cannot create the PID file")
+                        % pid_dir).str() };
         }
 
         HW::SetFlag<std::string>("pidfile", pid_file);

--- a/lib/src/configuration.cc
+++ b/lib/src/configuration.cc
@@ -102,7 +102,8 @@ static const std::string AGENT_CLIENT_TYPE { "agent" };
 //
 
 void Configuration::initialize(
-        std::function<int(std::vector<std::string>)> start_function) {
+        std::function<int(std::vector<std::string>)> start_function)
+{
     // Ensure the state is reset (useful for testing)
     HW::Reset();
     HW::SetAppName("pxp-agent");
@@ -127,7 +128,8 @@ void Configuration::initialize(
                      start_function);               // callback
 }
 
-HW::ParseResult parseArguments(const int argc, char* const argv[]) {
+HW::ParseResult parseArguments(const int argc, char* const argv[])
+{
     // manipulate argc and v to make start the default action.
     // TODO(ploubser): Add ability to specify default action to HorseWhisperer
     int modified_argc = argc + 1;
@@ -142,7 +144,8 @@ HW::ParseResult parseArguments(const int argc, char* const argv[]) {
     return HW::Parse(modified_argc, modified_argv);
 }
 
-HW::ParseResult Configuration::parseOptions(int argc, char *argv[]) {
+HW::ParseResult Configuration::parseOptions(int argc, char *argv[])
+{
     auto parse_result = parseArguments(argc, argv);
 
     if (parse_result == HW::ParseResult::FAILURE
@@ -162,7 +165,8 @@ HW::ParseResult Configuration::parseOptions(int argc, char *argv[]) {
     return parse_result;
 }
 
-static void validateLogDirPath(const std::string& logfile) {
+static void validateLogDirPath(const std::string& logfile)
+{
     auto logdir_path = fs::path(logfile).parent_path();
 
     if (fs::exists(logdir_path)) {
@@ -178,7 +182,8 @@ static void validateLogDirPath(const std::string& logfile) {
     }
 }
 
-void Configuration::setupLogging() {
+void Configuration::setupLogging()
+{
     logfile_ = HW::GetFlag<std::string>("logfile");
     auto log_on_stdout = (logfile_ == "-");
     auto loglevel = HW::GetFlag<std::string>("loglevel");
@@ -253,13 +258,15 @@ void Configuration::setupLogging() {
     }
 }
 
-void Configuration::validate() {
+void Configuration::validate()
+{
     validateAndNormalizeWebsocketSettings();
     validateAndNormalizeOtherSettings();
     valid_ = true;
 }
 
-const Configuration::Agent& Configuration::getAgentConfiguration() const {
+const Configuration::Agent& Configuration::getAgentConfiguration() const
+{
     assert(valid_);
     agent_configuration_ = Configuration::Agent {
         HW::GetFlag<std::string>("modules-dir"),
@@ -275,7 +282,8 @@ const Configuration::Agent& Configuration::getAgentConfiguration() const {
     return agent_configuration_;
 }
 
-void Configuration::reopenLogfile() const {
+void Configuration::reopenLogfile() const
+{
     if (!logfile_.empty() && logfile_ != "-") {
         try {
             logfile_fstream_.close();
@@ -299,11 +307,13 @@ Configuration::Configuration() : valid_ { false },
                                  config_file_ { "" },
                                  agent_configuration_ {},
                                  logfile_ { "" },
-                                 logfile_fstream_ {} {
+                                 logfile_fstream_ {}
+{
     defineDefaultValues();
 }
 
-void Configuration::defineDefaultValues() {
+void Configuration::defineDefaultValues()
+{
     defaults_.insert(
         Option { "config-file",
                  Base_ptr { new Entry<std::string>(
@@ -445,7 +455,8 @@ void Configuration::defineDefaultValues() {
 #endif
 }
 
-void Configuration::setDefaultValues() {
+void Configuration::setDefaultValues()
+{
     for (auto opt_idx = defaults_.get<Option::ByInsertion>().begin();
          opt_idx != defaults_.get<Option::ByInsertion>().end();
          ++opt_idx) {
@@ -499,7 +510,8 @@ void Configuration::setDefaultValues() {
     }
 }
 
-void Configuration::parseConfigFile() {
+void Configuration::parseConfigFile()
+{
     lth_jc::JsonContainer config_json;
 
     if (!lth_file::file_readable(config_file_)) {

--- a/lib/tests/unit/configuration_test.cc
+++ b/lib/tests/unit/configuration_test.cc
@@ -187,7 +187,7 @@ TEST_CASE("Configuration::get", "[configuration]") {
 #endif
             Configuration::Instance().validate();
 
-            REQUIRE(Configuration::Instance().get<bool>("foreground") == false);
+            REQUIRE_FALSE(Configuration::Instance().get<bool>("foreground"));
         }
 
         SECTION("return the correct value after the flag has been set") {

--- a/lib/tests/unit/util/posix/pid_file_test.cc
+++ b/lib/tests/unit/util/posix/pid_file_test.cc
@@ -290,7 +290,7 @@ TEST_CASE("PIDFile::unlockFile", "[util]") {
         FAIL("failed to create spool directory");
     }
 
-    SECTION("it unlock a locked file") {
+    SECTION("it unlocks a locked file") {
         auto first_fd = open(LOCK_PATH.data(), O_RDWR | O_CREAT, 0640);
         if (first_fd == -1) FAIL(std::string { "failed to open " } + LOCK_PATH);
         PIDFile::lockFile(first_fd, F_WRLCK);


### PR DESCRIPTION
 - README change: required leatherman version
 - Style changes
 - Remove HW alias from Configuration header
 - Use boost::format for error messages, to make things clearer
 - Remove duplicated code from Configuration functions