### PR TITLE
(PCP-375) Remove usage of test fixture SSL files from acceptance tests

### DIFF
--- a/acceptance/tests/restart_host_run_puppet.rb
+++ b/acceptance/tests/restart_host_run_puppet.rb
@@ -10,7 +10,6 @@ test_name 'C94777 - Ensure pxp-agent functions after agent host restart' do
   step 'Ensure each agent host has pxp-agent service running and enabled' do
     applicable_agents.each do |agent|
       on agent, puppet('resource service pxp-agent ensure=stopped')
-      cert_dir = configure_std_certs_on_host(agent)
       create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
       on agent, puppet('resource service pxp-agent ensure=running enable=true')
       show_pcp_logs_on_failure do


### PR DESCRIPTION
PCP-370 will remove the test fixture SSL certs in the test-resources folder. This PR removes all usage of those certs from the pxp-agent acceptance tests