### PR TITLE
WIP (maint) Update ruby-pcp-client to 0.4.0

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -16,7 +16,7 @@ gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 2.19')
 gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.2")
 gem 'rake'
 gem 'scooter', '~> 3.1.1'
-gem 'pcp-client', '~> 0.3', '>= 0.3.1'
+gem 'pcp-client', '~> 0.4'
 
 group(:test) do
   gem 'rspec', '~> 2.14.0', :require => false

--- a/acceptance/lib/pxp-agent/test_helper.rb
+++ b/acceptance/lib/pxp-agent/test_helper.rb
@@ -323,6 +323,7 @@ def connect_pcp_client(broker)
 
     client = PCP::Client.new({
       :server => broker_ws_uri(broker),
+      :ssl_ca_cert => "tmp/ssl/certs/ca.pem",
       :ssl_cert => "tmp/ssl/certs/#{hostname.downcase}.pem",
       :ssl_key => "tmp/ssl/private_keys/#{hostname.downcase}.pem",
       :logger => PCP::SimpleLogger.new,


### PR DESCRIPTION
0.4.0 adds ssl verification, so we need to pass the ssl_ca_cert when we
construct the PCP::Client