### PR TITLE
(PCP-376) Acceptance - do not attempt timesync on OSX

### DIFF
--- a/acceptance/setup/common/005_SyncTime.rb
+++ b/acceptance/setup/common/005_SyncTime.rb
@@ -4,4 +4,6 @@ extend Beaker::HostPrebuiltSteps
 # Note: QENG-3641 would allow beaker to take care of this for us
 test_name 'Ensure hosts have synchronized clocks'
 
-timesync(hosts, {:logger => logger})
+# QENG-3786 - OSX is already running ntpd and manually running ntpdate will return 1
+applicable_hosts = hosts.select{|host| host['platform'] !~ /osx/}
+timesync(applicable_hosts, {:logger => logger})


### PR DESCRIPTION
QENG-3786 is a bug with beaker's timesync method - it will fail on OSX due to ntpd service already running.
Until QENG-3786 is fixed, this commit skips attempting timesync on OSX hosts.
[skip ci]