### PR TITLE
(PCP-379) Store expanded --spool-dir in HW singleton

### DIFF
--- a/lib/src/configuration.cc
+++ b/lib/src/configuration.cc
@@ -696,6 +696,8 @@ void Configuration::validateAndNormalizeOtherSettings()
                     % spool_dir_path.string()).str() };
     }
 
+    HW::SetFlag<std::string>("spool-dir", spool_dir_path.string());
+
 #ifndef _WIN32
     if (!HW::GetFlag<bool>("foreground")) {
         auto pid_file = lth_file::tilde_expand(HW::GetFlag<std::string>("pidfile"));


### PR DESCRIPTION
After changes for PCP-345, Configuration did not update the spool-dir
entry with the expanded path in the HorseWhisperer singleton; this
was causing external modules runs to fail to write in the results
directory.