### PR TITLE
(PCP-196) Fix log rotation on Ubuntu 14.04 LTS

### DIFF
--- a/ext/pxp-agent.logrotate
+++ b/ext/pxp-agent.logrotate
@@ -6,6 +6,6 @@
     notifempty
     sharedscripts
     postrotate
-        [ -s /var/run/puppetlabs/pxp-agent.pid ] && kill -USR2 `cat /var/run/puppetlabs/pxp-agent.pid`
+        if [ -s /var/run/puppetlabs/pxp-agent.pid ]; then kill -USR2 `cat /var/run/puppetlabs/pxp-agent.pid`; fi
     endscript
 }


### PR DESCRIPTION
In absence of /var/run/puppetlabs/pxp-agent.pid, log rotation used to exit 1.
A valid shell conditional now prevents this false negative.