### PR TITLE
(maint) Look for .dylib in Findcpp-pcp-client.cmake

### DIFF
--- a/cmake/Findcpp-pcp-client.cmake
+++ b/cmake/Findcpp-pcp-client.cmake
@@ -2,5 +2,5 @@ include(FindDependency)
 find_dependency(cpp-pcp-client
     DISPLAY "cpp-pcp-client"
     HEADERS "cpp-pcp-client/connector/connection.hpp"
-    LIBRARIES "libcpp-pcp-client.so" "cpp-pcp-client"
+    LIBRARIES "libcpp-pcp-client.so" "libcpp-pcp-client.dylib" "cpp-pcp-client"
     REQUIRED)


### PR DESCRIPTION
This is needed on OS X after PCP-372.