### PR TITLE
(maint) Enable builds with static cpp-pcp-client

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -54,6 +54,12 @@ set (LIBS
     ${LEATHERMAN_LIBRARIES}
 )
 
+if (WIN32)
+    # Necessary when statically linking cpp-pcp-client on Windows.
+    # Shouldn't hurt when cpp-pcp-client is a DLL.
+    list(APPEND LIBS Ws2_32)
+endif()
+
 if (CMAKE_SYSTEM_NAME MATCHES "Linux" OR CMAKE_SYSTEM_NAME MATCHES "SunOS" OR CMAKE_SYSTEM_NAME MATCHES "AIX")
     # On some platforms Boost.Thread has a dependency on clock_gettime. It also depends on pthread,
     # and FindBoost in CMake 3.2.3 doesn't include that dependency.


### PR DESCRIPTION
On Windows, Leatherman's logging/locale libraries need to be contained in
the same DLL. That can be done by either making them shared libraries, or
by creating a monolithic pxp-agent binary.

Currently our packaging makes it messy to use shared Leatherman DLLs, and
they don't bring us any advantages. Make it simple to use cpp-pcp-client
as a static library instead so we can produce a smaller package.