### PR TITLE
(maint) Download CMake from our S3 bucket

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
   # Use a predefined install location; cppcheck requires the cfg location is defined at compile-time.
   - mkdir -p $USERDIR
   # grab a pre-built cmake 3.2.3
-  - wget --no-check-certificate https://www.cmake.org/files/v3.2/cmake-3.2.3-Linux-x86_64.tar.gz
+  - wget https://s3.amazonaws.com/kylo-pl-bucket/cmake-3.2.3-Linux-x86_64.tar.gz
   - tar xzvf cmake-3.2.3-Linux-x86_64.tar.gz --strip 1 -C $USERDIR
   # Install pxp-agent's dependencies
   - wget https://github.com/puppetlabs/leatherman/releases/download/${LEATHERMAN_VERSION}/leatherman.tar.gz


### PR DESCRIPTION
It's much faster than downloading from cmake.org.