### PR TITLE
(PCP-196) Fix log rotation on Ubuntu 14.04 LTS

### DIFF
--- a/ext/pxp-agent.logrotate
+++ b/ext/pxp-agent.logrotate
@@ -6,6 +6,6 @@
     notifempty
     sharedscripts
     postrotate
-        [ -s /var/run/puppetlabs/pxp-agent.pid ] && kill -USR2 `cat /var/run/puppetlabs/pxp-agent.pid`
+        if [ -s /var/run/puppetlabs/pxp-agent.pid ]; then kill -USR2 `cat /var/run/puppetlabs/pxp-agent.pid`; fi
     endscript
 }


### PR DESCRIPTION
This cherry-picks 3dcb89ad985a8bc77cbd2aa62fa90cd78028c2a9 from master to stable.