### PR TITLE
(PCP-270) Remove outsourced pthread dependency

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -61,10 +61,8 @@ if (WIN32)
 endif()
 
 if (CMAKE_SYSTEM_NAME MATCHES "Linux" OR CMAKE_SYSTEM_NAME MATCHES "SunOS" OR CMAKE_SYSTEM_NAME MATCHES "AIX")
-    # On some platforms Boost.Thread has a dependency on clock_gettime. It also depends on pthread,
-    # and FindBoost in CMake 3.2.3 doesn't include that dependency.
-    find_package(Threads)
-    list(APPEND LIBS rt ${CMAKE_THREAD_LIBS_INIT})
+    # On some platforms Boost.Thread has a dependency on clock_gettime.
+    list(APPEND LIBS rt)
 endif()
 
 add_library(libpxp-agent STATIC ${LIBRARY_COMMON_SOURCES} ${LIBRARY_STANDARD_SOURCES})


### PR DESCRIPTION
Fixes in Leatherman made explicit pthread dependencies unnecessary.
Remove them.