### PR TITLE
(PCP-371) Spike i18n support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,14 @@ leatherman_logging_line_numbers()
 set(CMAKE_CXX_FLAGS "${LEATHERMAN_CXX_FLAGS}")
 add_definitions(${LEATHERMAN_DEFINITIONS})
 
+# TODO(ale): enable i18n with add_definitions(-DLEATHERMAN_I18N) - PCP-257
+# TODO(ale): enable translation with set(LEATHERMAN_LOCALES "...;...") and
+# gettext_compile(${CMAKE_CURRENT_SOURCE_DIR}/locales share/locale)
+
+# Configure i18n
+file(GLOB_RECURSE PXP_AGENT_SOURCES lib/src/*.cc lib/inc/*.hpp exe/*.cc)
+gettext_templates(${CMAKE_CURRENT_SOURCE_DIR}/locales ${PXP_AGENT_SOURCES})
+
 # Display a summary of the features
 include(FeatureSummary)
 feature_summary(WHAT ALL)

--- a/exe/main.cc
+++ b/exe/main.cc
@@ -6,7 +6,7 @@
 #include <cpp-pcp-client/util/thread.hpp>
 #include <cpp-pcp-client/util/chrono.hpp>
 
-#include <leatherman/file_util/file.hpp>
+#include <leatherman/locale/locale.hpp>
 
 #define LEATHERMAN_LOGGING_NAMESPACE "puppetlabs.pxp_agent.main"
 #include <leatherman/logging/logging.hpp>
@@ -21,7 +21,7 @@
 namespace PXPAgent {
 
 namespace HW = HorseWhisperer;
-namespace lth_file = leatherman::file_util;
+namespace lth_loc = leatherman::locale;
 
 // Exit code returned after a successful execution
 static int PXP_AGENT_SUCCESS = 0;
@@ -54,7 +54,7 @@ int startAgent(std::vector<std::string> arguments) {
 #endif
         }
     } catch (const std::exception& e) {
-        LOG_ERROR("Failed to daemonize: %1%", e.what());
+        LOG_ERROR("Failed to daemonize: {1}", e.what());
         return PXP_AGENT_DAEMONIZATION_FAILURE;
     } catch (...) {
         LOG_ERROR("Failed to daemonize");
@@ -68,16 +68,16 @@ int startAgent(std::vector<std::string> arguments) {
         agent.start();
     } catch (const Agent::PCPConfigurationError& e) {
         exit_code = PXP_AGENT_CONFIGURATION_FAILURE;
-        LOG_ERROR("PCP configuration error: %1%", e.what());
+        LOG_ERROR("PCP configuration error: {1}", e.what());
     } catch (const Agent::WebSocketConfigurationError& e) {
         exit_code = PXP_AGENT_CONFIGURATION_FAILURE;
-        LOG_ERROR("WebSocket configuration error: %1%", e.what());
+        LOG_ERROR("WebSocket configuration error: {1}", e.what());
     } catch (const Agent::Error& e) {
         exit_code = PXP_AGENT_GENERAL_FAILURE;
-        LOG_ERROR("Fatal error: %1%", e.what());
+        LOG_ERROR("Fatal error: {1}", e.what());
     } catch (const std::exception& e) {
         exit_code = PXP_AGENT_GENERAL_FAILURE;
-        LOG_ERROR("Unexpected error: %1%", e.what());
+        LOG_ERROR("Unexpected error: {1}", e.what());
     } catch (...) {
         exit_code = PXP_AGENT_GENERAL_FAILURE;
         LOG_ERROR("Unexpected error");
@@ -124,9 +124,10 @@ int main(int argc, char *argv[]) {
     }
     if (!err_msg.empty()) {
         tryLogError(err_msg);
-        boost::nowide::cout << err_msg
-                            << "\nCannot start pxp-agent"
-                            << std::endl;
+        boost::nowide::cout
+            << err_msg << "\n"
+            << lth_loc::translate("Cannot start pxp-agent")
+            << std::endl;
         return PXP_AGENT_PARSING_FAILURE;
     }
 
@@ -145,11 +146,12 @@ int main(int argc, char *argv[]) {
             // pxp-agent was not configured
             err_msg = "Invalid parse result";
             tryLogError(err_msg);
-            boost::nowide::cout << "An unexpected code was returned when trying "
-                                << "to parse command line arguments - "
-                                << static_cast<int>(parse_result)
-                                << "\nCannot start pxp-agent"
-                                << std::endl;
+            boost::nowide::cout
+                << lth_loc::format("An unexpected code was returned when trying "
+                                   "to parse command line arguments - {1}\n"
+                                   "Cannot start pxp-agent",
+                                   static_cast<int>(parse_result))
+                << std::endl;
             return PXP_AGENT_PARSING_FAILURE;
     }
 
@@ -159,9 +161,10 @@ int main(int argc, char *argv[]) {
         Configuration::Instance().setupLogging();
         LOG_DEBUG("pxp-agent logging has been initialized");
     } catch(const Configuration::Error& e) {
-        boost::nowide::cout << "Failed to configure logging: " << e.what()
-                            << "\nCannot start pxp-agent"
-                            << std::endl;
+        boost::nowide::cout
+            << lth_loc::format("Failed to configure logging: {1}\n"
+                               "Cannot start pxp-agent", e.what())
+            << std::endl;
         return PXP_AGENT_CONFIGURATION_FAILURE;
     }
 
@@ -171,7 +174,7 @@ int main(int argc, char *argv[]) {
         Configuration::Instance().validate();
         LOG_INFO("pxp-agent configuration has been validated");
     } catch(const Configuration::Error& e) {
-        LOG_ERROR("Fatal configuration error: %1%; cannot start pxp-agent",
+        LOG_ERROR("Fatal configuration error: {1}; cannot start pxp-agent",
                   e.what());
         return PXP_AGENT_CONFIGURATION_FAILURE;
     }

--- a/lib/inc/pxp-agent/configuration.hpp
+++ b/lib/inc/pxp-agent/configuration.hpp
@@ -156,6 +156,7 @@ class Configuration
     /// Validate logging configuration options and enable logging.
     /// Throw a Configuration::Error: in case of invalid the specified
     /// log file is in a non-esixtent directory.
+    /// Other execeptions are propagated.
     void setupLogging();
 
     /// Ensure all required values are valid. If necessary, expand

--- a/lib/inc/pxp-agent/configuration.hpp
+++ b/lib/inc/pxp-agent/configuration.hpp
@@ -181,15 +181,10 @@ class Configuration
             }
         }
 
-        // Configuration instance not initialized; get default
-        const auto& opt_idx = defaults_.get<Option::ByName>().find(flagname);
 
-        if (opt_idx == defaults_.get<Option::ByName>().end()) {
-            throw Configuration::Error { "no default value for " + flagname };
-        } else {
-            Entry<T>* entry_ptr = (Entry<T>*) opt_idx->ptr.get();
-            return entry_ptr->value;
-        }
+        const auto& opt_idx = getDefaultIndex(flagname);
+        Entry<T>* entry_ptr = (Entry<T>*) opt_idx->ptr.get();
+        return entry_ptr->value;
     }
 
     /// Set the specified value for a given configuration flag.
@@ -200,17 +195,14 @@ class Configuration
     template<typename T>
     void set(std::string flagname, T value)
     {
-        if (!valid_) {
-            throw Configuration::Error { "cannot set configuration value until "
-                                         "configuration is validated" };
-        }
+        checkValidForSetting();
 
         try {
             HorseWhisperer::SetFlag<T>(flagname, value);
         } catch (HorseWhisperer::flag_validation_error) {
-            throw Configuration::Error { "invalid value for " + flagname };
+            throw Configuration::Error { getInvalidFlagError(flagname) };
         } catch (HorseWhisperer::undefined_flag_error) {
-            throw Configuration::Error { "unknown flag name: " + flagname };
+            throw Configuration::Error { getUnknownFlagError(flagname) };
         }
     }
 
@@ -255,6 +247,10 @@ class Configuration
     void validateAndNormalizeWebsocketSettings();
     void validateAndNormalizeOtherSettings();
     void setAgentConfiguration();
+    const Options::iterator getDefaultIndex(const std::string& flagname);
+    std::string getInvalidFlagError(const std::string& flagname);
+    std::string getUnknownFlagError(const std::string& flagname);
+    void checkValidForSetting();
 };
 
 }  // namespace PXPAgent

--- a/lib/inc/pxp-agent/pxp_schemas.hpp
+++ b/lib/inc/pxp-agent/pxp_schemas.hpp
@@ -3,8 +3,6 @@
 
 #include <cpp-pcp-client/validator/schema.hpp>
 
-// TODO(ale): move this to separate cpp-pxp-client library
-
 namespace PXPAgent {
 namespace PXPSchemas {
 

--- a/lib/src/action_response.cc
+++ b/lib/src/action_response.cc
@@ -5,18 +5,19 @@
 
 #include <leatherman/util/time.hpp>
 
+#include <leatherman/locale/locale.hpp>
+
 #define LEATHERMAN_LOGGING_NAMESPACE "puppetlabs.pxp_agent.action_response"
 #include <leatherman/logging/logging.hpp>
-
-#include <boost/format.hpp>
 
 #include <cassert>
 #include <utility>  // std::forward
 
 namespace PXPAgent {
 
-namespace lth_jc = leatherman::json_container;
+namespace lth_jc   = leatherman::json_container;
 namespace lth_util = leatherman::util;
+namespace lth_loc  = leatherman::locale;
 using R_T = ActionResponse::ResponseType;
 
 const std::string ACTION_METADATA_SCHEMA { "action_metdata_schema" };
@@ -111,7 +112,7 @@ ActionResponse::ActionResponse(ModuleType m_t,
           status_query_transaction()
 {
     if (!valid())
-        throw Error { "invalid action metadata" };
+        throw Error { lth_loc::translate("invalid action metadata") };
 }
 
 void ActionResponse::setStatus(ActionStatus status)
@@ -145,12 +146,11 @@ const std::string& ActionResponse::prettyRequestLabel() const
 {
     if (pretty_request_label_.empty())
         pretty_request_label_ =
-            (boost::format("%1% '%2% %3%' request (transaction %4%)")
-                % REQUEST_TYPE_NAMES.at(request_type)
-                % action_metadata.get<std::string>(MODULE)
-                % action_metadata.get<std::string>(ACTION)
-                % action_metadata.get<std::string>(TRANSACTION_ID))
-            .str();
+            lth_loc::format("{1} '{2} {3}' request (transaction {4})",
+                            REQUEST_TYPE_NAMES.at(request_type),
+                            action_metadata.get<std::string>(MODULE),
+                            action_metadata.get<std::string>(ACTION),
+                            action_metadata.get<std::string>(TRANSACTION_ID));
 
     return pretty_request_label_;
 }
@@ -162,7 +162,7 @@ bool ActionResponse::isValidActionMetadata(const lth_jc::JsonContainer& metadata
         validator.validate(metadata, ACTION_METADATA_SCHEMA);
         return true;
     } catch (const PCPClient::validation_error& e) {
-        LOG_TRACE("Invalid action metadata: %1%", e.what());
+        LOG_TRACE("Invalid action metadata: {1}", e.what());
     }
     return false;
 }

--- a/lib/src/agent.cc
+++ b/lib/src/agent.cc
@@ -54,8 +54,8 @@ void Agent::start() {
                 break;
             } catch (const PCPClient::connection_association_error& e) {
                 num_seconds = dist(engine);
-                LOG_WARNING("Error during the PCP Session Association (%1%); "
-                            "will retry to connect in %2% s",
+                LOG_WARNING("Error during the PCP Session Association ({1}); "
+                            "will retry to connect in {2} s",
                             e.what(), num_seconds);
                 pcp_util::this_thread::sleep_for(
                     pcp_util::chrono::seconds(num_seconds));

--- a/lib/src/configuration.cc
+++ b/lib/src/configuration.cc
@@ -234,7 +234,6 @@ void Configuration::setupLogging()
             lth_loc::format("invalid log level: '{1}'", loglevel) };
     }
 
-
     // Configure logging for pxp-agent
     lth_log::setup_logging(*stream);
     lth_log::set_level(lvl);
@@ -769,7 +768,6 @@ std::string Configuration::getInvalidFlagError(const std::string& flagname)
 std::string Configuration::getUnknownFlagError(const std::string& flagname)
 {
     return lth_loc::format("unknown flag name: {1}", flagname);
-
 }
 
 void Configuration::checkValidForSetting()

--- a/lib/src/configuration/posix/configuration.cc
+++ b/lib/src/configuration/posix/configuration.cc
@@ -1,5 +1,7 @@
 #include <pxp-agent/configuration.hpp>
 
+#include <leatherman/locale/locale.hpp>
+
 #define LEATHERMAN_LOGGING_NAMESPACE "puppetlabs.pxp_agent.configuration.posix.configuration"
 #include <leatherman/logging/logging.hpp>
 
@@ -8,12 +10,14 @@
 
 namespace PXPAgent {
 
+namespace lth_loc = leatherman::locale;
+
 static void sigLogfileReopen(int signal) {
     LOG_INFO("Caught SIGUSR2 signal - reopening log file");
     try {
         Configuration::Instance().reopenLogfile();
     } catch (const std::exception& e) {
-        LOG_ERROR("Failed to reopen logfile: %1%", e.what());
+        LOG_ERROR("Failed to reopen logfile: {1}", e.what());
     }
 }
 
@@ -21,7 +25,8 @@ void configure_platform_file_logging() {
     // Add the SIGUSR2 handler
     // HERE(ale): we expect that daemonize() will not touch this
     if (signal(SIGUSR2, sigLogfileReopen) == SIG_ERR) {
-        throw Configuration::Error { "failed to set the SIGUSR2 handler" };
+        throw Configuration::Error {
+            lth_loc::translate("failed to set the SIGUSR2 handler") };
     } else {
         LOG_DEBUG("Successfully registered the SIGUSR2 handler to reopen "
                   "the logfile");

--- a/lib/src/external_module.cc
+++ b/lib/src/external_module.cc
@@ -3,7 +3,10 @@
 #include <pxp-agent/action_output.hpp>
 
 #include <leatherman/execution/execution.hpp>
+
 #include <leatherman/file_util/file.hpp>
+
+#include <leatherman/locale/locale.hpp>
 
 #define LEATHERMAN_LOGGING_NAMESPACE "puppetlabs.pxp_agent.external_module"
 #include <leatherman/logging/logging.hpp>
@@ -36,7 +39,8 @@ static const int EXTERNAL_MODULE_FILE_ERROR_EC { 5 };
 namespace fs = boost::filesystem;
 namespace lth_exec = leatherman::execution;
 namespace lth_file = leatherman::file_util;
-namespace lth_jc = leatherman::json_container;
+namespace lth_jc   = leatherman::json_container;
+namespace lth_loc  = leatherman::locale;
 namespace pcp_util = PCPClient::Util;
 
 //
@@ -89,15 +93,15 @@ ExternalModule::ExternalModule(const std::string& path,
             registerConfiguration(
                 metadata.get<lth_jc::JsonContainer>(METADATA_CONFIGURATION_ENTRY));
         } else {
-            LOG_DEBUG("Found no configuration schema for module '%1%'", module_name);
+            LOG_DEBUG("Found no configuration schema for module '{1}'", module_name);
         }
 
         registerActions(metadata);
     } catch (lth_jc::data_error& e) {
-        LOG_ERROR("Failed to retrieve metadata of module %1%: %2%",
+        LOG_ERROR("Failed to retrieve metadata of module {1}: {2}",
                   module_name, e.what());
-        std::string err { "invalid metadata of module " + module_name };
-        throw Module::LoadingError { err };
+        throw Module::LoadingError {
+            lth_loc::format("invalid metadata of module {1}", module_name) };
     }
 }
 
@@ -114,10 +118,10 @@ ExternalModule::ExternalModule(const std::string& path,
     try {
        registerActions(metadata);
     } catch (lth_jc::data_error& e) {
-        LOG_ERROR("Failed to retrieve metadata of module %1%: %2%",
+        LOG_ERROR("Failed to retrieve metadata of module {1}: {2}",
                   module_name, e.what());
-        std::string err { "invalid metadata of module " + module_name };
-        throw Module::LoadingError { err };
+        throw Module::LoadingError {
+            lth_loc::format("invalid metadata of module {1}", module_name) };
     }
 }
 
@@ -126,7 +130,7 @@ void ExternalModule::validateConfiguration()
     if (config_validator_.includesSchema(module_name)) {
         config_validator_.validate(config_, module_name);
     } else {
-        LOG_DEBUG("The '%1%' configuration will not be validated; no JSON "
+        LOG_DEBUG("The '{1}' configuration will not be validated; no JSON "
                   "schema is available", module_name);
     }
 }
@@ -140,21 +144,21 @@ const int ExternalModule::OUTPUT_DELAY_MS { 100 };
 void ExternalModule::processOutputAndUpdateMetadata(ActionResponse& response)
 {
     if (response.output.std_out.empty()) {
-        LOG_TRACE("Obtained no results on stdout for the %1%",
+        LOG_TRACE("Obtained no results on stdout for the {1}",
                   response.prettyRequestLabel());
     } else {
-        LOG_TRACE("Results on stdout for the %1%: %2%",
+        LOG_TRACE("Results on stdout for the {1}: {2}",
                   response.prettyRequestLabel(), response.output.std_out);
     }
 
     if (response.output.exitcode != EXIT_SUCCESS) {
-        LOG_TRACE("Execution failure (exit code %1%) for the %2%%3%",
+        LOG_TRACE("Execution failure (exit code {1}) for the {2}{3}",
                   response.output.exitcode, response.prettyRequestLabel(),
                   (response.output.std_err.empty()
-                    ? ""
-                    : "; stderr:\n" + response.output.std_err));
+                        ? ""
+                        : "; stderr:\n" + response.output.std_err));
     } else if (!response.output.std_err.empty()) {
-        LOG_TRACE("Output on stderr for the %1%:\n%2%",
+        LOG_TRACE("Output on stderr for the {1}:\n{2}",
                   response.prettyRequestLabel(), response.output.std_err);
     }
 
@@ -165,17 +169,16 @@ void ExternalModule::processOutputAndUpdateMetadata(ActionResponse& response)
             (response.output.std_out.empty() ? "null" : response.output.std_out) };
         response.setValidResultsAndEnd(std::move(results));
     } catch (lth_jc::data_parse_error& e) {
-        LOG_DEBUG("Obtained invalid JSON on stdout for the %1%; (validation "
-                  "error: %2%); stdout:\n%3%",
+        LOG_DEBUG("Obtained invalid JSON on stdout for the {1}; (validation "
+                  "error: {2}); stdout:\n{3}",
                   response.prettyRequestLabel(), e.what(), response.output.std_out);
-        auto execution_error =
-            (boost::format("The task executed for the %1% returned invalid "
-                           "JSON on stdout - stderr:%2%")
-                % response.prettyRequestLabel()
-                % (response.output.std_err.empty()
-                        ? " (empty)"
-                        : '\n' + response.output.std_err))
-            .str();
+        std::string execution_error {
+            lth_loc::format("The task executed for the {1} returned invalid "
+                            "JSON on stdout - stderr:{2}",
+                            response.prettyRequestLabel(),
+                            (response.output.std_err.empty()
+                                ? lth_loc::translate(" (empty)")
+                                : "\n" + response.output.std_err)) };
         response.setBadResultsAndEnd(execution_error);
     }
 }
@@ -200,27 +203,28 @@ const lth_jc::JsonContainer ExternalModule::getModuleMetadata()
             0, {lth_exec::execution_options::merge_environment});
 
     if (!exec.error.empty()) {
-        LOG_ERROR("Failed to load the external module metadata from %1%: %2%",
+        LOG_ERROR("Failed to load the external module metadata from {1}: {2}",
                   path_, exec.error);
-        throw Module::LoadingError { "failed to load external module metadata" };
+        throw Module::LoadingError {
+            lth_loc::translate("failed to load external module metadata") };
     }
 
     lth_jc::JsonContainer metadata;
 
     try {
         metadata = lth_jc::JsonContainer { exec.output };
-        LOG_DEBUG("External module %1%: metadata is valid JSON", module_name);
+        LOG_DEBUG("External module {1}: metadata is valid JSON", module_name);
     } catch (lth_jc::data_error& e) {
-        throw Module::LoadingError { std::string { "metadata is not in a valid "
-                                        "JSON format: " } + e.what() };
+        throw Module::LoadingError {
+            lth_loc::format("metadata is not in a valid JSON format: {1}", e.what()) };
     }
 
     try {
         metadata_validator_.validate(metadata, METADATA_SCHEMA_NAME);
-        LOG_DEBUG("External module %1%: metadata validation OK", module_name);
+        LOG_DEBUG("External module {1}: metadata validation OK", module_name);
     } catch (PCPClient::validation_error& e) {
-        throw Module::LoadingError { std::string { "metadata validation failure: " }
-                                     + e.what() };
+        throw Module::LoadingError {
+            lth_loc::format("metadata validation failure: {1}", e.what()) };
     }
 
     return metadata;
@@ -230,21 +234,20 @@ void ExternalModule::registerConfiguration(const lth_jc::JsonContainer& config_m
 {
     try {
         PCPClient::Schema configuration_schema { module_name, config_metadata };
-        LOG_DEBUG("Registering module config schema for '%1%'", module_name);
+        LOG_DEBUG("Registering module configuration schema for '{1}'", module_name);
         config_validator_.registerSchema(configuration_schema);
     } catch (PCPClient::schema_error& e) {
-        LOG_ERROR("Failed to parse the configuration schema of module '%1%': %2%",
+        LOG_ERROR("Failed to parse the configuration schema of module '{1}': {2}",
                   module_name, e.what());
-        std::string err { "invalid configuration schema of module " + module_name };
-        throw Module::LoadingError { err };
+        throw Module::LoadingError {
+            lth_loc::format("invalid configuration schema of module {1}", module_name) };
     }
 }
 
 void ExternalModule::registerActions(const lth_jc::JsonContainer& metadata)
 {
     for (auto& action
-            : metadata.get<std::vector<lth_jc::JsonContainer>>(
-                METADATA_ACTIONS_ENTRY))
+            : metadata.get<std::vector<lth_jc::JsonContainer>>(METADATA_ACTIONS_ENTRY))
         registerAction(action);
 }
 
@@ -254,7 +257,7 @@ void ExternalModule::registerAction(const lth_jc::JsonContainer& action)
 {
     // NOTE(ale): name, input, and output are required action entries
     auto action_name = action.get<std::string>("name");
-    LOG_DEBUG("Validating action '%1% %2%'", module_name, action_name);
+    LOG_DEBUG("Validating action '{1} {2}'", module_name, action_name);
 
     try {
         auto input_schema_json = action.get<lth_jc::JsonContainer>("input");
@@ -264,22 +267,20 @@ void ExternalModule::registerAction(const lth_jc::JsonContainer& action)
         PCPClient::Schema results_schema { action_name, results_schema_json };
 
         // Metadata schemas are valid JSON; store metadata
-        LOG_DEBUG("Action '%1% %2%' has been validated", module_name, action_name);
+        LOG_DEBUG("Action '{1} {2}' has been validated", module_name, action_name);
         actions.push_back(action_name);
         input_validator_.registerSchema(input_schema);
         results_validator_.registerSchema(results_schema);
     } catch (PCPClient::schema_error& e) {
-        LOG_ERROR("Failed to parse metadata schemas of action '%1% %2%': %3%",
+        LOG_ERROR("Failed to parse metadata schemas of action '{1} {2}': {3}",
                   module_name, action_name, e.what());
-        std::string err { "invalid schemas of '" + module_name + " "
-                          + action_name + "'" };
-        throw Module::LoadingError { err };
+        throw Module::LoadingError {
+            lth_loc::format("invalid schemas of '{1} {2}'", module_name, action_name) };
     } catch (lth_jc::data_error& e) {
-        LOG_ERROR("Failed to retrieve metadata schemas of action '%1% %2%': %3%",
+        LOG_ERROR("Failed to retrieve metadata schemas of action '{1} {2}': {3}",
                   module_name, action_name, e.what());
-        std::string err { "invalid metadata of '" + module_name + " "
-                          + action_name + "'" };
-        throw Module::LoadingError { err };
+        throw Module::LoadingError {
+            lth_loc::format("invalid metadata of '{1} {2}'", module_name, action_name) };
     }
 }
 
@@ -309,8 +310,8 @@ ActionResponse ExternalModule::callBlockingAction(const ActionRequest& request)
     auto action_name = request.action();
     auto action_args = getActionArguments(request);
 
-    LOG_INFO("Executing the %1%", request.prettyLabel());
-    LOG_TRACE("Input for the %1%: %2%", request.prettyLabel(), action_args);
+    LOG_INFO("Executing the {1}", request.prettyLabel());
+    LOG_TRACE("Input for the {1}: {2}", request.prettyLabel(), action_args);
 
     auto exec = lth_exec::execute(
 #ifdef _WIN32
@@ -337,9 +338,9 @@ ActionResponse ExternalModule::callNonBlockingAction(const ActionRequest& reques
     auto out_file = (results_dir_path / "stdout").string();
     auto err_file = (results_dir_path / "stderr").string();
 
-    LOG_INFO("Starting a task for the %1%; stdout and stderr will be stored in %2%",
+    LOG_INFO("Starting a task for the {1}; stdout and stderr will be stored in {2}",
              request.prettyLabel(), request.resultsDir());
-    LOG_TRACE("Input for the %1%: %2%", request.prettyLabel(), input_txt);
+    LOG_TRACE("Input for the {1}: {2}", request.prettyLabel(), input_txt);
 
     auto exec = lth_exec::execute(
 #if defined(_WIN32)
@@ -358,23 +359,25 @@ ActionResponse ExternalModule::callNonBlockingAction(const ActionRequest& reques
         0,          // timeout
         { lth_exec::execution_options::merge_environment });  // options
 
-    LOG_INFO("The task for the %1% has completed", request.prettyLabel());
+    LOG_INFO("The task for the {1} has completed", request.prettyLabel());
 
     if (exec.exit_code == EXTERNAL_MODULE_FILE_ERROR_EC) {
         // This is unexpected. The output of the task will not be
         // available for future transaction status requests; we cannot
         // provide a reliable ActionResponse.
-        LOG_WARNING("The task process failed to write output on file for the %1%; "
-                    "stdout: %2%; stderr: %3%",
+        std::string empty_label { lth_loc::translate("(empty)") };
+        LOG_WARNING("The task process failed to write output on file for the {1}; "
+                    "stdout: {2}; stderr: {3}",
                     request.prettyLabel(),
-                    (exec.output.empty() ? "(empty)" : exec.output),
-                    (exec.error.empty() ? "(empty)" : exec.error));
-        throw Module::ProcessingError { "failed to write output on file" };
+                    (exec.output.empty() ? empty_label : exec.output),
+                    (exec.error.empty() ? empty_label : exec.error));
+        throw Module::ProcessingError {
+            lth_loc::translate("failed to write output on file") };
     }
 
     // Wait a bit to relax the requirement for the exitcode file being
     // written before the output ones, when the process completes
-    LOG_TRACE("Waiting %1% ms before retrieving the output of %2%",
+    LOG_TRACE("Waiting {1} ms before retrieving the output of {2}",
               OUTPUT_DELAY_MS, request.prettyLabel());
     pcp_util::this_thread::sleep_for(
         pcp_util::chrono::milliseconds(OUTPUT_DELAY_MS));

--- a/lib/src/module.cc
+++ b/lib/src/module.cc
@@ -91,7 +91,7 @@ ActionResponse Module::executeAction(const ActionRequest& request)
     } catch (std::exception& e) {
         err_msg += lth_loc::format("Unexpected error: {1}", e.what());
     } catch (...) {
-        err_msg = lth_loc::translate("Unexpected excption.");
+        err_msg = lth_loc::translate("Unexpected exception.");
     }
 
     std::string execution_error {

--- a/lib/src/modules/ping.cc
+++ b/lib/src/modules/ping.cc
@@ -1,11 +1,10 @@
 #include <pxp-agent/modules/ping.hpp>
-#include <pxp-agent/module_type.hpp>
+
+#include <leatherman/locale/locale.hpp>
 
 #include <boost/date_time/posix_time/posix_time.hpp>
 
-#include <ctime>
 #include <string>
-#include <sstream>
 
 #define LEATHERMAN_LOGGING_NAMESPACE "puppetlabs.pxp_agent.modules.ping"
 #include <leatherman/logging/logging.hpp>
@@ -13,7 +12,8 @@
 namespace PXPAgent {
 namespace Modules {
 
-namespace lth_jc = leatherman::json_container;
+namespace lth_jc  = leatherman::json_container;
+namespace lth_loc = leatherman::locale;
 
 static const std::string PING { "ping" };
 
@@ -34,7 +34,7 @@ lth_jc::JsonContainer Ping::ping(const ActionRequest& request) {
 
     if (request.parsedChunks().debug.empty()) {
         LOG_ERROR("Found no debug entry in the request message");
-        throw Module::ProcessingError { "no debug entry" };
+        throw Module::ProcessingError { lth_loc::translate("no debug entry") };
     }
 
     auto& debug_entry = request.parsedChunks().debug[0];
@@ -44,9 +44,10 @@ lth_jc::JsonContainer Ping::ping(const ActionRequest& request) {
                 "request_hops",
                 debug_entry.get<std::vector<lth_jc::JsonContainer>>("hops"));
     } catch (lth_jc::data_parse_error& e) {
-        LOG_ERROR("Failed to parse debug entry: %1%", e.what());
-        LOG_DEBUG("Debug entry: %1%", debug_entry.toString());
-        throw Module::ProcessingError { "debug entry is not valid JSON" };
+        LOG_ERROR("Failed to parse debug entry: {1}", e.what());
+        LOG_DEBUG("Debug entry: {1}", debug_entry.toString());
+        throw Module::ProcessingError {
+            lth_loc::translate("debug entry is not valid JSON") };
     }
     return data;
 }

--- a/lib/src/pxp_connector.cc
+++ b/lib/src/pxp_connector.cc
@@ -3,8 +3,6 @@
 
 #include <cpp-pcp-client/protocol/schemas.hpp>
 
-#include <leatherman/util/strings.hpp>
-
 #define LEATHERMAN_LOGGING_NAMESPACE "puppetlabs.pxp_agent.pxp_connector"
 #include <leatherman/logging/logging.hpp>
 
@@ -13,7 +11,6 @@
 namespace PXPAgent {
 
 namespace lth_jc = leatherman::json_container;
-namespace lth_util = leatherman::util;
 
 static const int DEFAULT_MSG_TIMEOUT_SEC { 2 };
 
@@ -22,9 +19,9 @@ wrapDebug(const PCPClient::ParsedChunks& parsed_chunks)
 {
     auto request_id = parsed_chunks.envelope.get<std::string>("id");
     if (parsed_chunks.num_invalid_debug) {
-        LOG_WARNING("Message %1% contained %2% bad debug chunk%3%",
-                    request_id, parsed_chunks.num_invalid_debug,
-                    lth_util::plural(parsed_chunks.num_invalid_debug));
+        // TODO(ale): deal with locale & plural (PCP-257)
+        LOG_WARNING("Message {1} contained {2} bad debug chunks",
+                    request_id, parsed_chunks.num_invalid_debug);
     }
     std::vector<lth_jc::JsonContainer> debug {};
     for (auto& debug_entry : parsed_chunks.debug) {
@@ -56,10 +53,10 @@ void PXPConnector::sendPCPError(const std::string& request_id,
              PCPClient::Protocol::ERROR_MSG_TYPE,
              DEFAULT_MSG_TIMEOUT_SEC,
              pcp_error_data);
-        LOG_INFO("Replied to request %1% with a PCP error message",
+        LOG_INFO("Replied to request {1} with a PCP error message",
                  request_id);
     } catch (PCPClient::connection_error& e) {
-        LOG_ERROR("Failed to send PCP error message for request %1%: %3%",
+        LOG_ERROR("Failed to send PCP error message for request {1}: {2}",
                   request_id, e.what());
     }
 }
@@ -76,11 +73,11 @@ void PXPConnector::sendProvisionalResponse(const ActionRequest& request)
              DEFAULT_MSG_TIMEOUT_SEC,
              provisional_data,
              debug);
-        LOG_INFO("Sent provisional response for the %1% by %2%",
+        LOG_INFO("Sent provisional response for the {1} by {2}",
                  request.prettyLabel(), request.sender());
     } catch (PCPClient::connection_error& e) {
-        LOG_ERROR("Failed to send provisional response for the %1% by %2% "
-                  "(no further attempts will be made): %3%",
+        LOG_ERROR("Failed to send provisional response for the {1} by {2} "
+                  "(no further attempts will be made): {3}",
                   request.prettyLabel(), request.sender(), e.what());
     }
 }
@@ -98,11 +95,11 @@ void PXPConnector::sendPXPError(const ActionRequest& request,
              PXPSchemas::PXP_ERROR_MSG_TYPE,
              DEFAULT_MSG_TIMEOUT_SEC,
              pxp_error_data);
-        LOG_INFO("Replied to %1% by %2%, request ID %3%, with a PXP error message",
+        LOG_INFO("Replied to {1} by {2}, request ID {3}, with a PXP error message",
                  request.prettyLabel(), request.sender(), request.id());
     } catch (PCPClient::connection_error& e) {
-        LOG_ERROR("Failed to send a PXP error message for the %1% by %2% "
-                  "(no further sending attempts will be made): %3%",
+        LOG_ERROR("Failed to send a PXP error message for the {1} by {2} "
+                  "(no further sending attempts will be made): {3}",
                   request.prettyLabel(), request.sender(), description);
     }
 }
@@ -117,13 +114,13 @@ void PXPConnector::sendPXPError(const ActionResponse& response)
              PXPSchemas::PXP_ERROR_MSG_TYPE,
              DEFAULT_MSG_TIMEOUT_SEC,
              response.toJSON(ActionResponse::ResponseType::RPCError));
-        LOG_INFO("Replied to %1% by %2%, request ID %3%, with a PXP error message",
+        LOG_INFO("Replied to {1} by {2}, request ID {3}, with a PXP error message",
                  response.prettyRequestLabel(),
                  response.action_metadata.get<std::string>("requester"),
                  response.action_metadata.get<std::string>("request_id"));
     } catch (PCPClient::connection_error& e) {
-        LOG_ERROR("Failed to send a PXP error message for the %1% by %2% "
-                  "(no further sending attempts will be made): %3%",
+        LOG_ERROR("Failed to send a PXP error message for the {1} by {2} "
+                  "(no further sending attempts will be made): {3}",
                   response.prettyRequestLabel(),
                   response.action_metadata.get<std::string>("requester"),
                   response.action_metadata.get<std::string>("execution_error"));
@@ -160,12 +157,12 @@ void PXPConnector::sendNonBlockingResponse(const ActionResponse& response)
              PXPSchemas::NON_BLOCKING_RESPONSE_TYPE,
              DEFAULT_MSG_TIMEOUT_SEC,
              response.toJSON(ActionResponse::ResponseType::NonBlocking));
-        LOG_INFO("Sent response for the %1% by %2%",
+        LOG_INFO("Sent response for the {1} by {2}",
                  response.prettyRequestLabel(),
                  response.action_metadata.get<std::string>("requester"));
     } catch (PCPClient::connection_error& e) {
-        LOG_ERROR("Failed to reply to %1% by %2%, (no further attempts will "
-                  "be made): %3%",
+        LOG_ERROR("Failed to reply to {1} by {2}, (no further attempts will "
+                  "be made): {3}",
                   response.prettyRequestLabel(),
                   response.action_metadata.get<std::string>("requester"),
                   e.what());
@@ -189,10 +186,10 @@ void PXPConnector::sendBlockingResponse_(
              DEFAULT_MSG_TIMEOUT_SEC,
              response.toJSON(response_type),
              debug);
-        LOG_INFO("Sent response for the %1% by %2%",
+        LOG_INFO("Sent response for the {1} by {2}",
                  request.prettyLabel(), request.sender());
     } catch (PCPClient::connection_error& e) {
-        LOG_ERROR("Failed to reply to the %1% by %2%: %3%",
+        LOG_ERROR("Failed to reply to the {1} by {2}: {3}",
                   request.prettyLabel(), request.sender(), e.what());
     }
 }

--- a/lib/src/request_processor.cc
+++ b/lib/src/request_processor.cc
@@ -14,8 +14,8 @@
 #include <leatherman/json_container/json_container.hpp>
 #include <leatherman/file_util/file.hpp>
 #include <leatherman/file_util/directory.hpp>
-#include <leatherman/util/strings.hpp>
 #include <leatherman/util/scope_exit.hpp>
+#include <leatherman/locale/locale.hpp>
 
 #include <cpp-pcp-client/validator/validator.hpp>
 #include <cpp-pcp-client/validator/schema.hpp>
@@ -38,9 +38,10 @@
 namespace PXPAgent {
 
 namespace fs = boost::filesystem;
-namespace lth_jc = leatherman::json_container;
+namespace lth_jc   = leatherman::json_container;
 namespace lth_file = leatherman::file_util;
 namespace lth_util = leatherman::util;
+namespace lth_loc  = leatherman::locale;
 namespace pcp_util = PCPClient::Util;
 
 // Time interval to allow the non-blocking action task to ask for the
@@ -83,7 +84,7 @@ void nonBlockingActionTask(std::shared_ptr<Module> module_ptr,
         ResultsMutex::LockGuard a_l { ResultsMutex::Instance().access_mtx };
         if (ResultsMutex::Instance().exists(request.transactionId())) {
             // Mutex already exists; unexpected
-            LOG_DEBUG("Mutex for transaction ID %1% is already cached",
+            LOG_DEBUG("Mutex for transaction ID {1} is already cached",
                       request.transactionId());
         } else {
             ResultsMutex::Instance().add(request.transactionId());
@@ -92,7 +93,7 @@ void nonBlockingActionTask(std::shared_ptr<Module> module_ptr,
         }
     } catch (const ResultsMutex::Error& e) {
         // This is unexpected
-        LOG_ERROR("Failed to obtain the mutex pointer for transaction %1%: %2%",
+        LOG_ERROR("Failed to obtain the mutex pointer for transaction {1}: {2}",
                   request.transactionId(), e.what());
     }
 
@@ -108,11 +109,11 @@ void nonBlockingActionTask(std::shared_ptr<Module> module_ptr,
                     // Unexpected; if we have a lock pointer it means
                     // that the mutex was cached
                     LOG_ERROR("Failed to remove the mutex pointer for "
-                              "transaction %1%: %2%",
+                              "transaction {1}: {2}",
                               request.transactionId(), e.what());
                 }
                 lck_ptr->unlock();
-                LOG_TRACE("Unlocked transaction mutex %1%",
+                LOG_TRACE("Unlocked transaction mutex {1}",
                           request.transactionId());
             }
 
@@ -125,17 +126,17 @@ void nonBlockingActionTask(std::shared_ptr<Module> module_ptr,
     assert(response.request_type == RequestType::NonBlocking);
 
     if (lck_ptr != nullptr) {
-        LOG_TRACE("Locking transaction mutex %1%", request.transactionId());
+        LOG_TRACE("Locking transaction mutex {1}", request.transactionId());
         lck_ptr->lock();
     } else {
         // This is unexpected
         LOG_TRACE("We previously failed to obtain the mutex pointer for "
-                  "transaction %1%; we will not lock the access to the "
+                  "transaction {1}; we will not lock the access to the "
                   "metadata file", request.transactionId());
     }
 
     if (response.action_metadata.get<bool>("results_are_valid")) {
-        LOG_INFO("The %1%, request ID %2% by %3%, has successfully completed",
+        LOG_INFO("The {1}, request ID {2} by {3}, has successfully completed",
                  request.prettyLabel(), request.id(), request.sender());
     } else {
         LOG_ERROR(response.action_metadata.get<std::string>("execution_error"));
@@ -153,7 +154,7 @@ void nonBlockingActionTask(std::shared_ptr<Module> module_ptr,
         storage_ptr->updateMetadataFile(request.transactionId(),
                                         response.action_metadata);
     } catch (const ResultsStorage::Error& e) {
-        LOG_ERROR("Failed to write metadata of the %1%: %2%",
+        LOG_ERROR("Failed to write metadata of the {1}: {2}",
                   request.prettyLabel(), e.what());
     }
 }
@@ -215,13 +216,13 @@ RequestProcessor::~RequestProcessor()
 void RequestProcessor::processRequest(const RequestType& request_type,
                                       const PCPClient::ParsedChunks& parsed_chunks)
 {
-    LOG_TRACE("About to validate and process PXP request message: %1%",
+    LOG_TRACE("About to validate and process PXP request message: {1}",
               parsed_chunks.toString());
     try {
         // Inspect and validate the request message format
         ActionRequest request { request_type, parsed_chunks };
 
-        LOG_INFO("Processing %1%, request ID %2%, by %3%",
+        LOG_INFO("Processing {1}, request ID {2}, by {3}",
                  request.prettyLabel(), request.id(), request.sender());
 
         try {
@@ -229,14 +230,14 @@ void RequestProcessor::processRequest(const RequestType& request_type,
             validateRequestContent(request);
         } catch (RequestProcessor::Error& e) {
             // Invalid request; send *RPC Error message*
-            LOG_ERROR("Invalid %1%, request ID %2% by %3%. Will reply with an "
-                      "RPC Error message. Error: %4%",
+            LOG_ERROR("Invalid {1}, request ID {2} by {3}. Will reply with an "
+                      "RPC Error message. Error: {4}",
                       request.prettyLabel(), request.id(), request.sender(), e.what());
             connector_ptr_->sendPXPError(request, e.what());
             return;
         }
 
-        LOG_DEBUG("The %1% has been successfully validated", request.prettyLabel());
+        LOG_DEBUG("The {1} has been successfully validated", request.prettyLabel());
 
         try {
             if (isStatusRequest(request)) {
@@ -247,12 +248,12 @@ void RequestProcessor::processRequest(const RequestType& request_type,
                 processNonBlockingRequest(request);
             }
 
-            LOG_DEBUG("The %1%, request ID %2% by %3%, has been successfully processed",
+            LOG_DEBUG("The {1}, request ID {2} by {3}, has been successfully processed",
                       request.prettyLabel(), request.id(), request.sender());
         } catch (std::exception& e) {
             // Process failure; send a *RPC Error message*
-            LOG_ERROR("Failed to process %1%, request ID %2% by %3%. Will reply "
-                      "with an RPC Error message. Error: %4%",
+            LOG_ERROR("Failed to process {1}, request ID {2} by {3}. Will reply "
+                      "with an RPC Error message. Error: {4}",
                       request.prettyLabel(), request.id(), request.sender(), e.what());
             connector_ptr_->sendPXPError(request, e.what());
         }
@@ -262,8 +263,8 @@ void RequestProcessor::processRequest(const RequestType& request_type,
         auto id = parsed_chunks.envelope.get<std::string>("id");
         auto sender = parsed_chunks.envelope.get<std::string>("sender");
         std::vector<std::string> endpoints { sender };
-        LOG_ERROR("Invalid request with ID %1% by %2%. Will reply with a PCP "
-                  "error. Error: %3%",
+        LOG_ERROR("Invalid request with ID {1} by {2}. Will reply with a PCP "
+                  "error. Error: {3}",
                   id, sender, e.what());
         connector_ptr_->sendPCPError(id, e.what(), endpoints);
     }
@@ -283,9 +284,8 @@ std::string RequestProcessor::getModuleConfig(const std::string& module_name) co
 {
     if (!hasModuleConfig(module_name))
         throw RequestProcessor::Error {
-            (boost::format("no configuration loaded for the module '%1%'")
-                % module_name)
-            .str() };
+            lth_loc::format("no configuration loaded for the module '{1}'",
+                            module_name) };
 
     return modules_config_.at(module_name).toString();
 }
@@ -304,12 +304,11 @@ void RequestProcessor::validateRequestContent(const ActionRequest& request) cons
         if (!is_status_request
                 && !modules_.at(request.module())->hasAction(request.action()))
             throw RequestProcessor::Error {
-                (boost::format("unknown action '%1%' for module '%2%'")
-                    % request.action()
-                    % request.module())
-                .str() };
+                lth_loc::format("unknown action '{1}' for module '{2}'",
+                                request.action(), request.module()) };
     } catch (std::out_of_range& e) {
-        throw RequestProcessor::Error { "unknown module: " + request.module() };
+        throw RequestProcessor::Error { lth_loc::format("unknown module: {1}",
+                                                        request.module()) };
     }
 
     // If it's an internal module, the request must be blocking
@@ -319,14 +318,13 @@ void RequestProcessor::validateRequestContent(const ActionRequest& request) cons
             && (is_status_request
                 || modules_.at(request.module())->type() == ModuleType::Internal))
         throw RequestProcessor::Error {
-            (boost::format("the module '%1%' supports only blocking PXP requests")
-                % request.module())
-            .str() };
+            lth_loc::format("the module '{1}' supports only blocking PXP requests",
+                            request.module()) };
 
 
     // Validate request input params
     try {
-        LOG_DEBUG("Validating input parameters of the %1%, request ID %2% by %3%",
+        LOG_DEBUG("Validating input parameters of the {1}, request ID {2} by {3}",
                   request.prettyLabel(), request.id(), request.sender());
 
         // NB: the registred schemas have the same name as the action
@@ -335,9 +333,10 @@ void RequestProcessor::validateRequestContent(const ActionRequest& request) cons
                                 : modules_.at(request.module())->input_validator_);
         validator.validate(request.params(), request.action());
     } catch (PCPClient::validation_error& e) {
-        LOG_DEBUG("Invalid input parameters of the %1%, request ID %2% by %3%: %4%",
+        LOG_DEBUG("Invalid input parameters of the {1}, request ID {2} by {3}: {4}",
                   request.prettyLabel(), request.id(), request.sender(), e.what());
-        throw RequestProcessor::Error { "invalid input for " + request.prettyLabel() };
+        throw RequestProcessor::Error {
+            lth_loc::format("invalid input for {1}", request.prettyLabel()) };
     }
 }
 
@@ -346,7 +345,7 @@ void RequestProcessor::processBlockingRequest(const ActionRequest& request)
     auto response = modules_[request.module()]->executeAction(request);
 
     if (response.action_metadata.get<bool>("results_are_valid")) {
-        LOG_INFO("The %1%, request ID %2% by %3%, has successfully completed",
+        LOG_INFO("The {1}, request ID {2} by {3}, has successfully completed",
                  request.prettyLabel(), request.id(), request.sender());
         connector_ptr_->sendBlockingResponse(response, request);
     } else {
@@ -361,7 +360,7 @@ void RequestProcessor::processNonBlockingRequest(const ActionRequest& request)
         std::move((spool_dir_path_ / request.transactionId()).string()));
     std::string err_msg {};
 
-    LOG_DEBUG("Preparing the task for the %1%, request ID %2% by %3% (using the "
+    LOG_DEBUG("Preparing the task for the {1}, request ID {2} by {3} (using the "
               "transaction ID as identifier)",
               request.prettyLabel(), request.id(), request.sender());
 
@@ -371,8 +370,9 @@ void RequestProcessor::processNonBlockingRequest(const ActionRequest& request)
         pcp_util::lock_guard<pcp_util::mutex> lck { thread_container_mutex_ };
 
         if (thread_container_.find(request.transactionId())) {
-            err_msg += "already exists an ongoing task with transaction id ";
-            err_msg += request.transactionId();
+            err_msg =
+                lth_loc::format("already exists an ongoing task with transaction id {1}",
+                                request.transactionId());
         } else {
             try {
                 // Initialize the action metadata file
@@ -380,8 +380,8 @@ void RequestProcessor::processNonBlockingRequest(const ActionRequest& request)
                 storage_ptr_->initializeMetadataFile(request.transactionId(),
                                                      metadata);
             } catch (const ResultsStorage::Error& e) {
-                err_msg += "Failed to initialize the metadata file: ";
-                err_msg += e.what();
+                err_msg = lth_loc::format("Failed to initialize the metadata file: {1}",
+                                          e.what());
             }
 
             if (err_msg.empty()) {
@@ -403,7 +403,7 @@ void RequestProcessor::processNonBlockingRequest(const ActionRequest& request)
             }
         }
     } catch (const std::exception& e) {
-        LOG_ERROR("Failed to spawn the action job for transaction %1%; error: %2%",
+        LOG_ERROR("Failed to spawn the action job for transaction {1}; error: {2}",
                   request.transactionId(), e.what());
         err_msg += "failed to start action task: ";
         err_msg += e.what();
@@ -458,9 +458,10 @@ void RequestProcessor::processStatusRequest(const ActionRequest& request)
     status_results.set<std::string>("status", AS.at(ActionStatus::Unknown));
 
     if (!storage_ptr_->find(t_id)) {
-        LOG_DEBUG("Found no results for the %1%", request.prettyLabel());
-        status_response.setValidResultsAndEnd(std::move(status_results),
-                                              "found no results directory");
+        LOG_DEBUG("Found no results for the {1}", request.prettyLabel());
+        status_response.setValidResultsAndEnd(
+            std::move(status_results),
+            lth_loc::translate("found no results directory"));
         connector_ptr_->sendStatusResponse(status_response, request);
         return;
     }
@@ -477,11 +478,11 @@ void RequestProcessor::processStatusRequest(const ActionRequest& request)
     bool not_running_by_pid { false };
 
     if (!storage_ptr_->pidFileExists(t_id)) {
-        LOG_DEBUG("The PID file for the transaction %1% task does not exist", t_id);
+        LOG_DEBUG("The PID file for the transaction {1} task does not exist", t_id);
     } else {
         try {
             auto pid = storage_ptr_->getPID(t_id);
-            LOG_DEBUG("The PID of the action process for the transaction %1% is %2%",
+            LOG_DEBUG("The PID of the action process for the transaction {1} is {2}",
                       t_id, pid);
 
             // NOTE(ale): processExists() does not throw
@@ -503,14 +504,14 @@ void RequestProcessor::processStatusRequest(const ActionRequest& request)
                         pcp_util::chrono::milliseconds(METADATA_RACE_MS));
             }
         } catch (const ResultsStorage::Error& e) {
-            LOG_ERROR("Failed to get the PID for transaction %1%: %2%",
+            LOG_ERROR("Failed to get the PID for transaction {1}: {2}",
                       t_id, e.what());
         }
     }
 
     // Retrieve metadata
 
-    LOG_DEBUG("Retrieving metadata and output for the transaction %1%", t_id);
+    LOG_DEBUG("Retrieving metadata and output for the transaction {1}", t_id);
     std::string metadata_retrieval_error {};
     lth_jc::JsonContainer metadata;
 
@@ -538,19 +539,21 @@ void RequestProcessor::processStatusRequest(const ActionRequest& request)
         auto mod = metadata.get<std::string>("module");
         auto act = metadata.get<std::string>("action");
         if (!hasModule(mod) || !modules_.at(mod)->hasAction(act))
-            throw Error { "unknow action stored in metadata file: '"
-                          + mod + " " + act + "'" };
+            throw Error {
+                lth_loc::format("unknow action stored in metadata file: '{1} {2}'",
+                                mod, act) };
     } catch (const ResultsStorage::Error& e) {
-        LOG_ERROR("Cannot access the stored metadata for the transaction %1%: %2%",
+        LOG_ERROR("Cannot access the stored metadata for the transaction {1}: {2}",
                   t_id, e.what());
         metadata_retrieval_error = e.what();
     } catch (const std::exception& e) {
         LOG_ERROR("Unexpected failure while retrieving metadata for the "
-                  "transaction %1%: %2%",
+                  "transaction {1}: {2}",
                   t_id, e.what());
         std::string err_msg { e.what() };
-        metadata_retrieval_error = "unexpected failure while retrieving metadata";
-        metadata_retrieval_error += (err_msg.empty() ? "" : ": " + err_msg);
+        metadata_retrieval_error =
+            lth_loc::format("unexpected failure while retrieving metadata{1}",
+                            (err_msg.empty() ? "" : ": " + err_msg));
     }
 
     if (!metadata_retrieval_error.empty()) {
@@ -566,7 +569,7 @@ void RequestProcessor::processStatusRequest(const ActionRequest& request)
 
     std::string execution_error {};
     auto stored_status = metadata.get<std::string>("status");
-    LOG_TRACE("The status of the transaction %1% is \"%2%\", as reported in its "
+    LOG_TRACE("The status of the transaction {1} is '{2}', as reported in its "
               "metadata file",
               t_id, stored_status);
 
@@ -588,12 +591,12 @@ void RequestProcessor::processStatusRequest(const ActionRequest& request)
             // the metadata says that the results were valid
             if (metadata.includes("results_are_valid")
                 && metadata.get<bool>("results_are_valid")) {
-                LOG_ERROR("Failed to get the output of the trasaction %1%: %2%",
+                LOG_ERROR("Failed to get the output of the trasaction {1}: {2}",
                           t_id, e.what());
-                if (execution_error.empty()) {
-                    execution_error = "failed to retrieve the output: ";
-                    execution_error += e.what();
-                }
+                if (execution_error.empty())
+                    execution_error =
+                        lth_loc::format("failed to retrieve the output: {1}",
+                                        e.what());
             }
         }
 
@@ -610,21 +613,22 @@ void RequestProcessor::processStatusRequest(const ActionRequest& request)
     if (!storage_ptr_->outputIsReady(t_id)) {
         // No output; use the PID information to determine the status
         // and update the metadata if UNDETERMINED
-        LOG_TRACE("The output of the transaction %1% is not ready; using the PID "
+        LOG_TRACE("The output of the transaction {1} is not ready; using the PID "
                   "information to ensure that the action process is running", t_id);
 
         if (running_by_pid) {
             // It's running --> RUNNING
-            LOG_TRACE("The action process of the transaction %1% is running", t_id);
+            LOG_TRACE("The action process of the transaction {1} is running", t_id);
             status_results.set<std::string>("status", AS.at(ActionStatus::Running));
         } else  if (not_running_by_pid) {
             // It's not running --> UNDETERMINED / execution_error
             // TODO(ale): use UNDETERMINED after PXP v2.0 changes
-            LOG_WARNING("The action process of the transaction %1% is not "
-                        "running; updating its status to \"undetermined\" "
+            LOG_WARNING("The action process of the transaction {1} is not "
+                        "running; updating its status to 'undetermined' "
                         "on its metadata file",
                         t_id);
-            execution_error = "task process is not running, but no output is available";
+            execution_error = lth_loc::translate("task process is not running, "
+                                                 "but no output is available");
             metadata.set<std::string>("status", AS.at(ActionStatus::Undetermined));
             if (!metadata.includes("execution_error"))
                 // Update this for the sake of future status requests
@@ -638,16 +642,17 @@ void RequestProcessor::processStatusRequest(const ActionRequest& request)
                 }
             } catch (const ResultsStorage::Error& err) {
                 LOG_ERROR("Failed to update the metadata file of the "
-                          "transaction %1%: %2%",
+                          "transaction {1}: {2}",
                           t_id, err.what());
             }
         } else {
             // We failed to get any indication from the PID file;
             // leave the status as UNKNOWN as the process may finish
             // later and make its output available
-            LOG_WARNING("We cannot determine the status of the transaction %1% "
+            LOG_WARNING("We cannot determine the status of the transaction {1} "
                         "from the action process' PID", t_id);
-            execution_error = "the task PID and output are not available";
+            execution_error = lth_loc::translate("the PID and output of this "
+                                                 "task are not available");
         }
 
         status_response.setValidResultsAndEnd(std::move(status_results),
@@ -664,25 +669,26 @@ void RequestProcessor::processStatusRequest(const ActionRequest& request)
     if (running_by_pid) {
         // Wait a bit to relax the requirement for the exitcode file
         // being written before the output ones
-        LOG_DEBUG("The output for the transaction %1% is now available, but the "
-                  "aciton process was still executing when this handler started; "
-                  "wait for %2% ms before retrieving the output from file",
+        LOG_DEBUG("The output for the transaction {1} is now available, but the "
+                  "action process was still executing when this handler started; "
+                  "wait for {2} ms before retrieving the output from file",
                   t_id, ExternalModule::OUTPUT_DELAY_MS);
         pcp_util::this_thread::sleep_for(
             pcp_util::chrono::milliseconds(ExternalModule::OUTPUT_DELAY_MS));
     } else {
-        LOG_TRACE("Output of %1% is ready; retrieving it", t_id);
+        LOG_TRACE("Output of {1} is ready; retrieving it", t_id);
     }
 
     try {
         status_response.output = storage_ptr_->getOutput(t_id);
     } catch (const ResultsStorage::Error& e) {
-        LOG_ERROR("Failed to get the output of the transaction %1% (it status "
-                  "will be updated to \"undetermined\" on its metadata file): %2%",
+        LOG_ERROR("Failed to get the output of the transaction {1} (it status "
+                  "will be updated to 'undetermined' on its metadata file): {2}",
                   t_id, e.what());
         // TODO(ale): use UNDETERMINED after PXP v2.0 changes
-        status_response.setValidResultsAndEnd(std::move(status_results),
-                                              "found no results directory");
+        status_response.setValidResultsAndEnd(
+                std::move(status_results),
+                lth_loc::translate("found no results directory"));
         connector_ptr_->sendStatusResponse(status_response, request);
 
         // Update the metadata with a final 'status' value
@@ -695,7 +701,7 @@ void RequestProcessor::processStatusRequest(const ActionRequest& request)
                 storage_ptr_->updateMetadataFile(t_id, metadata);
             }
         } catch (const ResultsStorage::Error& err) {
-            LOG_ERROR("Failed to update metadata for the %1%: %2%",
+            LOG_ERROR("Failed to update metadata for the {1}: {2}",
                       request.prettyLabel(), err.what());
         }
         return;
@@ -721,7 +727,7 @@ void RequestProcessor::processStatusRequest(const ActionRequest& request)
         mod_ptr->validateOutputAndUpdateMetadata(a_r);
 
     // Update metadata file while holding the lock (if cached)
-    LOG_INFO("Setting the status of the transaction %1% to \"%2%\" on its "
+    LOG_INFO("Setting the status of the transaction {1} to '{2}' on its "
              "metadata file",
              t_id, a_r.action_metadata.get<std::string>("status"));
     try {
@@ -732,7 +738,7 @@ void RequestProcessor::processStatusRequest(const ActionRequest& request)
             storage_ptr_->updateMetadataFile(t_id, a_r.action_metadata);
         }
     } catch (const ResultsStorage::Error& err) {
-        LOG_ERROR("Failed to update metadata of the transaction %1%: %2%",
+        LOG_ERROR("Failed to update metadata of the transaction {1}: {2}",
                   t_id, err.what());
     }
 
@@ -756,7 +762,7 @@ void RequestProcessor::processStatusRequest(const ActionRequest& request)
 
 void RequestProcessor::loadModulesConfiguration()
 {
-    LOG_INFO("Loading external modules configuration from %1%",
+    LOG_INFO("Loading external modules configuration from {1}",
              modules_config_dir_);
 
     if (fs::is_directory(modules_config_dir_)) {
@@ -772,13 +778,13 @@ void RequestProcessor::loadModulesConfiguration()
                 try {
                     auto config_json = lth_jc::JsonContainer(lth_file::read(s));
                     modules_config_[module_name] = std::move(config_json);
-                    LOG_DEBUG("Loaded module configuration for module '%1%' "
-                              "from %2%", module_name, s);
+                    LOG_DEBUG("Loaded module configuration for module '{1}' "
+                              "from {2}", module_name, s);
                 } catch (lth_jc::data_parse_error& e) {
-                    LOG_WARNING("Cannot load module config file '%1%'; invalid "
+                    LOG_WARNING("Cannot load module config file '{1}'; invalid "
                                 "JSON format. If the module's metadata contains "
                                 "the 'configuration' entry, the module won't be "
-                                "loaded. Error: '%2%'", s, e.what());
+                                "loaded. Error: '{2}'", s, e.what());
                     modules_config_[module_name] = lth_jc::JsonContainer { "null" };
                 }
                 return true;
@@ -787,7 +793,7 @@ void RequestProcessor::loadModulesConfiguration()
             },
             "\\.conf$");
     } else {
-        LOG_DEBUG("Directory '%1%' specified by modules-config-dir doesn't "
+        LOG_DEBUG("Directory '{1}' specified by modules-config-dir doesn't "
                   "exist; no module configuration file will be loaded",
                   modules_config_dir_);
     }
@@ -802,69 +808,72 @@ void RequestProcessor::loadInternalModules()
 
 void RequestProcessor::loadExternalModulesFrom(fs::path dir_path)
 {
-    LOG_INFO("Loading external modules from %1%", dir_path.string());
+    if (!fs::is_directory(dir_path)) {
+        LOG_WARNING("Failed to locate the modules directory '{1}'; no external "
+                            "modules will be loaded", dir_path.string());
+        return;
+    }
 
-    if (fs::is_directory(dir_path)) {
-        fs::directory_iterator end;
+    LOG_INFO("Loading external modules from {1}", dir_path.string());
+    fs::directory_iterator end;
 
-        for (auto f = fs::directory_iterator(dir_path); f != end; ++f) {
-            if (!fs::is_directory(f->status())) {
-                auto f_p = fs::canonical(f->path());
-                auto extension = f_p.extension();
+    for (auto f = fs::directory_iterator(dir_path); f != end; ++f) {
+        if (!fs::is_directory(f->status())) {
+            auto f_p = fs::canonical(f->path());
+            auto extension = f_p.extension();
 
-                // valid module have no extension on *nix, .bat
-                // extensions on Windows
+            // valid module have no extension on *nix, .bat
+            // extensions on Windows
 #ifndef _WIN32
-                if (extension == "") {
+            if (extension == "") {
 #else
-                if (extension == ".bat") {
+            if (extension == ".bat") {
 #endif
-                    try {
-                        ExternalModule* e_m;
-                        auto config_itr = modules_config_.find(f_p.stem().string());
+                try {
+                    ExternalModule* e_m;
+                    auto config_itr = modules_config_.find(f_p.stem().string());
 
-                        if (config_itr != modules_config_.end()) {
-                            e_m = new ExternalModule(f_p.string(),
-                                                     config_itr->second,
-                                                     spool_dir_path_.string());
-                            e_m->validateConfiguration();
-                            LOG_DEBUG("The '%1%' module configuration has been "
-                                      "validated: %2%", e_m->module_name,
-                                      config_itr->second.toString());
-                        } else {
-                            e_m = new ExternalModule(f_p.string(),
-                                                     spool_dir_path_.string());
-                        }
-
-                        modules_[e_m->module_name] = std::shared_ptr<Module>(e_m);
-                    } catch (Module::LoadingError& e) {
-                        LOG_ERROR("Failed to load %1%; %2%", f_p, e.what());
-                    } catch (PCPClient::validation_error& e) {
-                        LOG_ERROR("Failed to configure %1%; %2%", f_p, e.what());
-                    } catch (std::exception& e) {
-                        LOG_ERROR("Unexpected error when loading %1%; %2%",
-                                  f_p, e.what());
-                    } catch (...) {
-                        LOG_ERROR("Unexpected error when loading %1%", f_p);
+                    if (config_itr != modules_config_.end()) {
+                        e_m = new ExternalModule(f_p.string(),
+                                                 config_itr->second,
+                                                 spool_dir_path_.string());
+                        e_m->validateConfiguration();
+                        LOG_DEBUG("The '{1}' module configuration has been "
+                                  "validated: {2}", e_m->module_name,
+                                  config_itr->second.toString());
+                    } else {
+                        e_m = new ExternalModule(f_p.string(),
+                                                 spool_dir_path_.string());
                     }
+
+                    modules_[e_m->module_name] = std::shared_ptr<Module>(e_m);
+                } catch (Module::LoadingError& e) {
+                    LOG_ERROR("Failed to load {1}; {2}", f_p, e.what());
+                } catch (PCPClient::validation_error& e) {
+                    LOG_ERROR("Failed to configure {1}; {2}", f_p, e.what());
+                } catch (std::exception& e) {
+                    LOG_ERROR("Unexpected error when loading {1}; {2}",
+                              f_p, e.what());
+                } catch (...) {
+                    LOG_ERROR("Unexpected error when loading {1}", f_p);
                 }
             }
         }
-    } else {
-        LOG_WARNING("Failed to locate the modules directory; no external "
-                    "modules will be loaded");
     }
 }
 
 void RequestProcessor::logLoadedModules() const
 {
+    // TODO(ale): deal with locale & plural (PCP-257)
+    std::string actions_label { lth_loc::translate("actions") };
+
     for (auto& module : modules_) {
-        std::string txt { "found no action" };
+        std::string txt { lth_loc::translate("found no action") };
         std::string actions_list { "" };
 
         for (auto& action : module.second->actions) {
             if (actions_list.empty()) {
-                txt = "action";
+                txt = actions_label;
                 actions_list += ": ";
             } else {
                 actions_list += ", ";
@@ -872,9 +881,7 @@ void RequestProcessor::logLoadedModules() const
             actions_list += action;
         }
 
-        auto txt_suffix = lth_util::plural(module.second->actions.size());
-        LOG_DEBUG("Loaded '%1%' module - %2%%3%%4%",
-                  module.first, txt, txt_suffix, actions_list);
+        LOG_DEBUG("Loaded '{1}' module - {2}{3}", module.first, txt, actions_list);
     }
 }
 
@@ -886,10 +893,10 @@ void RequestProcessor::spoolDirPurgeTask()
 {
     auto num_minutes = Timestamp::getMinutes(spool_dir_purge_ttl_);
     num_minutes *= 1.2;
-    LOG_INFO("Starting the task for purging the spool directory every %1% "
-             "minute%2%; thread id %3%",
-             num_minutes, lth_util::plural(num_minutes),
-             pcp_util::this_thread::get_id());
+    // TODO(ale): deal with locale & plural (PCP-257)
+    LOG_INFO("Starting the task for purging the spool directory every {1} "
+             "minutes; thread id {2}",
+             num_minutes, pcp_util::this_thread::get_id());
 
 
     while (true) {

--- a/lib/src/results_mutex.cc
+++ b/lib/src/results_mutex.cc
@@ -1,11 +1,13 @@
 #include <pxp-agent/results_mutex.hpp>
 
-#include <cpp-pcp-client/util/chrono.hpp>
+#include <leatherman/locale/locale.hpp>
 
 #define LEATHERMAN_LOGGING_NAMESPACE "puppetlabs.pxp_agent.results_mutex"
 #include <leatherman/logging/logging.hpp>
 
 namespace PXPAgent {
+
+namespace lth_loc  = leatherman::locale;
 
 // Private ctor
 
@@ -26,26 +28,26 @@ bool ResultsMutex::exists(std::string const& transaction_id) {
 }
 
 ResultsMutex::Mutex_Ptr ResultsMutex::get(std::string const& transaction_id) {
-    if (!exists(transaction_id)) {
-        throw Error { "does not exists" };
-    }
+    if (!exists(transaction_id))
+        throw Error { lth_loc::translate("does not exists") };
+
     return mutexes_[transaction_id];
 }
 
 void ResultsMutex::add(std::string const& transaction_id) {
-    LOG_TRACE("Adding transaction id %1%", transaction_id);
-    if (exists(transaction_id)) {
-        throw Error { "already exists" };
-    }
+    LOG_TRACE("Adding transaction id {1}", transaction_id);
+    if (exists(transaction_id))
+        throw Error { lth_loc::translate("already exists") };
+
     auto mtx = std::make_shared<Mutex>();
     mutexes_.emplace(transaction_id, mtx);
 }
 
 void ResultsMutex::remove(std::string const& transaction_id) {
-    LOG_TRACE("Removing transaction id %1%", transaction_id);
-    if (!exists(transaction_id)) {
-        throw Error { "does not exist" };
-    }
+    LOG_TRACE("Removing transaction id {1}", transaction_id);
+    if (!exists(transaction_id))
+        throw Error { lth_loc::translate("does not exist") };
+
     mutexes_.erase(transaction_id);
 }
 

--- a/lib/src/results_storage.cc
+++ b/lib/src/results_storage.cc
@@ -5,6 +5,8 @@
 #include <leatherman/file_util/file.hpp>
 #include <leatherman/file_util/directory.hpp>
 
+#include <leatherman/locale/locale.hpp>
+
 #define LEATHERMAN_LOGGING_NAMESPACE "puppetlabs.pxp_agent.results_storage"
 #include <leatherman/logging/logging.hpp>
 
@@ -16,8 +18,9 @@
 namespace PXPAgent {
 
 namespace fs = boost::filesystem;
-namespace lth_jc = leatherman::json_container;
+namespace lth_jc   = leatherman::json_container;
 namespace lth_file = leatherman::file_util;
+namespace lth_loc  = leatherman::locale;
 
 static const std::string METADATA { "metadata" };
 static const std::string STDOUT { "stdout" };
@@ -40,8 +43,8 @@ static void writeMetadata(const std::string& txt, const std::string& file_path) 
     try {
         lth_file::atomic_write_to_file(txt, file_path);
     } catch (const std::exception& e) {
-        std::string err_msg { "failed to write metadata: " };
-        throw ResultsStorage::Error { err_msg + e.what() };
+        throw ResultsStorage::Error {
+            lth_loc::format("failed to write metadata: {1}", e.what()) };
     }
 }
 
@@ -51,13 +54,14 @@ void ResultsStorage::initializeMetadataFile(const std::string& transaction_id,
     auto results_path = spool_dir_path_ / transaction_id;
 
     if (!fs::exists(results_path)) {
-        LOG_DEBUG("Creating results directory for the  transaction %1% in '%2%'",
+        LOG_DEBUG("Creating results directory for the  transaction {1} in '{2}'",
                   transaction_id, results_path.string());
         try {
             fs::create_directories(results_path);
         } catch (const fs::filesystem_error& e) {
             throw ResultsStorage::Error {
-                std::string("failed to create results directory: ") + e.what() };
+                lth_loc::format("failed to create results directory '{1}'",
+                                e.what()) };
         }
     }
 
@@ -69,8 +73,9 @@ void ResultsStorage::updateMetadataFile(const std::string& transaction_id,
                                         const lth_jc::JsonContainer& metadata)
 {
     if (!find(transaction_id))
-        throw Error { "no results directory for the transaction "
-                      + transaction_id };
+        throw Error {
+            lth_loc::format("no results directory for the transaction {1}",
+                            transaction_id) };
 
     auto metadata_file = (spool_dir_path_ / transaction_id / METADATA).string();
     writeMetadata(metadata.toString() + "\n", metadata_file);
@@ -83,29 +88,33 @@ ResultsStorage::getActionMetadata(const std::string& transaction_id)
     std::string metadata_txt {};
 
     if (!fs::exists(metadata_file))
-        throw Error { "metadata file of the transaction "
-                      + transaction_id + " does not exist"};
+        throw Error {
+            lth_loc::format("metadata file of the transaction {1} does not exist",
+                            transaction_id) };
 
     if (!lth_file::read(metadata_file, metadata_txt))
-        throw Error { "failed to read metadata file of the transaction "
-                      + transaction_id };
+        throw Error {
+            lth_loc::format("failed to read metadata file of the transaction {1}",
+                            transaction_id) };
 
     try {
         lth_jc::JsonContainer metadata { metadata_txt };
 
         if (!ActionResponse::isValidActionMetadata(metadata)) {
-            LOG_DEBUG("The file '%1%' contains invalid action metadata:\n%2%",
+            LOG_DEBUG("The file '{1}' contains invalid action metadata:\n{2}",
                       metadata_file, metadata.toString());
-            throw Error  { "invalid action metadata of the transaction "
-                           + transaction_id };
+            throw Error  {
+                lth_loc::format("invalid action metadata of the transaction {1}",
+                                transaction_id) };
         }
 
         return metadata;
     } catch (const lth_jc::data_parse_error& e) {
-        LOG_DEBUG("The metadata file '%1%' is not valid JSON: %2%",
+        LOG_DEBUG("The metadata file '{1}' is not valid JSON: {2}",
                   metadata_file, e.what());
-        throw Error { "invalid JSON in metadata file of the transaction "
-                      + transaction_id };
+        throw Error {
+            lth_loc::format("invalid JSON in metadata file of the transaction {1}",
+                            transaction_id) };
     }
 }
 
@@ -119,14 +128,16 @@ static int readIntegerFromFile(const std::string& file_path)
     std::string number_txt {};
 
     if (!fs::exists(file_path) || !lth_file::read(file_path, number_txt))
-        throw ResultsStorage::Error { "failed to read file " + file_path };
+        throw ResultsStorage::Error {
+            lth_loc::format("failed to read file '{1}'", file_path) };
 
     try {
         return std::stoi(number_txt);
     } catch (const std::invalid_argument& e) {
         throw ResultsStorage::Error {
-            "invalid value stored in file " + file_path
-            + (number_txt.empty() ? "" : ": " + number_txt) };
+            lth_loc::format("invalid value stored in file '{1}'{2}",
+                            file_path,
+                            (number_txt.empty() ? "" : ": " + number_txt)) };
     }
 }
 
@@ -158,21 +169,21 @@ ActionOutput ResultsStorage::getOutput_(const std::string& transaction_id,
 
     if (fs::exists(stderr_file)) {
         if (!lth_file::read(stderr_file, output.std_err)) {
-            LOG_ERROR("Failed to read error file '%1%'; this failure will be ignored",
+            LOG_ERROR("Failed to read error file '{1}'; this failure will be ignored",
                       stderr_file);
         } else {
-            LOG_TRACE("Successfully read error file '%1%'", stderr_file);
+            LOG_TRACE("Successfully read error file '{1}'", stderr_file);
         }
     }
 
     if (!fs::exists(stdout_file)) {
-        LOG_DEBUG("Output file '%1%' does not exist", stdout_file);
+        LOG_DEBUG("Output file '{1}' does not exist", stdout_file);
     } else if (!lth_file::read(stdout_file, output.std_out)) {
-        throw Error { "failed to read " + stdout_file };
+        throw Error { lth_loc::format("failed to read '{1}'", stdout_file) };
     } else if (output.std_out.empty()) {
-        LOG_TRACE("Output file '%1%' is empty", stdout_file);
+        LOG_TRACE("Output file '{1}' is empty", stdout_file);
     } else {
-        LOG_TRACE("Successfully read output file '%1%'", stdout_file);
+        LOG_TRACE("Successfully read output file '{1}'", stdout_file);
     }
 
     return output;
@@ -206,7 +217,7 @@ unsigned int ResultsStorage::purge(
     if (purge_callback == nullptr)
         purge_callback = &defaultPurgeCallback;
 
-    LOG_INFO("About to purge the results directories from %1%; TTL = %2%",
+    LOG_INFO("About to purge the results directories from '{1}'; TTL = {2}",
              spool_dir_path_.string(), ttl);
 
     lth_file::each_subdirectory(
@@ -214,7 +225,7 @@ unsigned int ResultsStorage::purge(
         [&](std::string const& s) -> bool {
             fs::path dir_path { s };
             auto transaction_id = dir_path.filename().string();
-            LOG_TRACE("Inspecting %1% for purging", s);
+            LOG_TRACE("Inspecting '{1}' for purging", s);
 
             if (!ongoing_transactions.empty()
                     && std::find(ongoing_transactions.begin(),
@@ -226,33 +237,33 @@ unsigned int ResultsStorage::purge(
                 auto md = getActionMetadata(transaction_id);
 
                 if (md.get<std::string>("status") == "running") {
-                    LOG_TRACE("Skipping %1% as the action status is \"running\"", s);
+                    LOG_TRACE("Skipping '{1}' as the action status is 'running'", s);
                 } else if (ts.isNewerThan(md.get<std::string>("start"))) {
-                    LOG_TRACE("Removing %1%", s);
+                    LOG_TRACE("Removing '{1}'", s);
 
                     try {
                         purge_callback(dir_path.string());
                         num_purged_dirs++;
                     } catch (const std::exception& e) {
-                        LOG_ERROR("Failed to remove %1%: %2%", s, e.what());
+                        LOG_ERROR("Failed to remove '{1}': {2}", s, e.what());
                     }
                 }
             } catch (const Error& e) {
-                LOG_WARNING("Failed to retrieve the metadata for the transaction %1% "
-                            "(the results directory will not be removed): %2%",
+                LOG_WARNING("Failed to retrieve the metadata for the transaction {1} "
+                            "(the results directory will not be removed): {2}",
                             transaction_id, e.what());
             } catch (const Timestamp::Error& e) {
-                LOG_WARNING("Failed to process the metadata for the transaction %1% "
-                            "(the results directory will not be removed): %2%",
+                LOG_WARNING("Failed to process the metadata for the transaction {1} "
+                            "(the results directory will not be removed): {2}",
                             transaction_id, e.what());
             }
 
             return true;
         });
 
-    LOG_INFO("Removed %1% director%2% from %3%",
-             num_purged_dirs, (num_purged_dirs == 1 ? "y" : "ies"),
-             spool_dir_path_.string());
+    // TODO(ale): deal with locale & plural (PCP-257)
+    LOG_INFO("Removed {1} directories from '{2}'",
+             num_purged_dirs, spool_dir_path_.string());
     return num_purged_dirs;
 }
 

--- a/lib/src/thread_container.cc
+++ b/lib/src/thread_container.cc
@@ -2,8 +2,7 @@
 
 #include <cpp-pcp-client/util/chrono.hpp>
 
-#include <algorithm>  // remove_if
-#include <iterator>   // distance
+#include <leatherman/locale/locale.hpp>
 
 #define LEATHERMAN_LOGGING_NAMESPACE "puppetlabs.pxp_agent.thread_container"
 #include <leatherman/logging/logging.hpp>
@@ -11,6 +10,7 @@
 namespace PXPAgent {
 
 namespace pcp_util = PCPClient::Util;
+namespace lth_loc  = leatherman::locale;
 
 // Check if the thread has completed; if so, and if it's joinable,
 // detach it. Return true if completed, false otherwise.
@@ -21,7 +21,7 @@ bool detachIfCompleted(std::shared_ptr<ManagedThread> thread_ptr) {
         if (thread_ptr->the_instance.joinable()) {
             // Detach the thread object; it will be then possible to
             // delete it without triggering std::terminate
-            LOG_TRACE("Detaching thread %1%", thread_ptr->the_instance.get_id());
+            LOG_TRACE("Detaching thread {1}", thread_ptr->the_instance.get_id());
             thread_ptr->the_instance.detach();
         }
 
@@ -74,7 +74,7 @@ ThreadContainer::~ThreadContainer() {
 
     if (!all_detached) {
         // NB: std::terminate will be invoked
-        LOG_WARNING("Not all threads stored by the '%1%' ThreadContainer have "
+        LOG_WARNING("Not all threads stored by the '{1}' ThreadContainer have "
                     "completed; pxp-agent will not terminate gracefully", name_);
     }
 }
@@ -82,13 +82,14 @@ ThreadContainer::~ThreadContainer() {
 void ThreadContainer::add(std::string thread_name,
                           pcp_util::thread task,
                           std::shared_ptr<std::atomic<bool>> is_done) {
-    LOG_TRACE("Adding thread %1%  (named '%2%') to the '%3%' "
-              "ThreadContainer; added %4% threads so far",
+    // TODO(ale): deal with locale & plural (PCP-257)
+    LOG_TRACE("Adding thread {1}  (named '{2}') to the '{3}' "
+              "ThreadContainer; added {4} threads so far",
               task.get_id(), thread_name,  name_, num_added_threads_);
     pcp_util::lock_guard<pcp_util::mutex> the_lock { mutex_ };
 
     if (findLocked(thread_name))
-        throw Error { "thread name is already stored" };
+        throw Error { lth_loc::translate("thread name is already stored") };
 
     threads_.insert(
         std::make_pair(
@@ -100,7 +101,8 @@ void ThreadContainer::add(std::string thread_name,
 
     // Start the monitoring thread, if necessary
     if (!is_monitoring_ && threads_.size() > threads_threshold) {
-        LOG_DEBUG("%1% threads stored in the '%2%' ThreadContainer; about "
+        // TODO(ale): deal with locale & plural (PCP-257)
+        LOG_DEBUG("{1} threads stored in the '{2}' ThreadContainer; about "
                   "to start a the monitoring thread", threads_.size(), name_);
 
         if (monitoring_thread_ptr_ != nullptr
@@ -157,8 +159,8 @@ bool ThreadContainer::findLocked(const std::string& thread_name) const {
 }
 
 void ThreadContainer::monitoringTask_() {
-    LOG_DEBUG("Starting monitoring task for the '%1%' ThreadContainer, "
-              "with id %2%", name_, pcp_util::this_thread::get_id());
+    LOG_DEBUG("Starting monitoring task for the '{1}' ThreadContainer, "
+              "with id {2}", name_, pcp_util::this_thread::get_id());
 
     while (true) {
         pcp_util::unique_lock<pcp_util::mutex> the_lock { mutex_ };
@@ -183,7 +185,7 @@ void ThreadContainer::monitoringTask_() {
 
         for (auto itr = threads_.begin(); itr != threads_.end();) {
             if (detachIfCompleted(itr->second)) {
-                LOG_DEBUG("Deleting thread %1% (named '%2%')",
+                LOG_DEBUG("Deleting thread {1} (named '{2}')",
                           itr->second->the_instance.get_id(), itr->first);
                 itr = threads_.erase(itr);
                 num_deletions++;
@@ -194,8 +196,8 @@ void ThreadContainer::monitoringTask_() {
 
         if (num_deletions > 0) {
             num_erased_threads_ += num_deletions;
-            LOG_DEBUG("Deleted %1% thread objects that have completed their "
-                      "execution; in total, deleted %2% threads so far",
+            LOG_DEBUG("Deleted {1} thread objects that have completed their "
+                      "execution; in total, deleted {2} threads so far",
                       num_deletions, num_erased_threads_);
         }
 

--- a/lib/src/util/posix/daemonize.cc
+++ b/lib/src/util/posix/daemonize.cc
@@ -25,7 +25,7 @@ static void sigHandler(int sig) {
     // NOTE(ale): if issued by the init process, between SIGTERM and
     // the successive SIGKILL there are only 5 s - must be fast
     auto pidfile = Configuration::Instance().get<std::string>("pidfile");
-    LOG_INFO("Caught signal %1% - removing PID file '%2%'",
+    LOG_INFO("Caught signal {1} - removing PID file '{2}'",
              std::to_string(sig), pidfile);
     PIDFile pidf { pidfile };
     pidf.cleanup();
@@ -38,7 +38,7 @@ std::unique_ptr<PIDFile> daemonize() {
     // Check if we're already a daemon
     if (getppid() == 1) {
         // Parent is init process (PID 1)
-        LOG_INFO("Already a daemon with PID=%1%", std::to_string(getpid()));
+        LOG_INFO("Already a daemon with PID={1}", std::to_string(getpid()));
         return nullptr;
     }
 
@@ -57,7 +57,7 @@ std::unique_ptr<PIDFile> daemonize() {
 
     if (pidf_ptr->isExecuting()) {
         auto pid = pidf_ptr->read();
-        LOG_ERROR("Already running with PID=%1%", pid);
+        LOG_ERROR("Already running with PID={1}", pid);
         removeLockAndExit();
     }
 
@@ -66,7 +66,7 @@ std::unique_ptr<PIDFile> daemonize() {
         LOG_DEBUG("Obtained a read lock for the PID file; no other pxp-agent "
                   "daemon should be executing");
     } catch (const PIDFile::Error& e) {
-        LOG_ERROR("Failed get a read lock for the PID file: %1%", e.what());
+        LOG_ERROR("Failed get a read lock for the PID file: {1}", e.what());
         removeLockAndExit();
     }
 
@@ -80,7 +80,7 @@ std::unique_ptr<PIDFile> daemonize() {
             removeLockAndExit();
         }
     } catch (const PIDFile::Error& e) {
-        LOG_ERROR("Failed to check if we can lock the PID file: %1%", e.what());
+        LOG_ERROR("Failed to check if we can lock the PID file: {1}", e.what());
         removeLockAndExit();
     }
 
@@ -90,12 +90,12 @@ std::unique_ptr<PIDFile> daemonize() {
 
     switch (first_child_pid) {
         case -1:
-            LOG_ERROR("Failed to perform the first fork; %1% (%2%)",
+            LOG_ERROR("Failed to perform the first fork; {1} ({2})",
                       strerror(errno), errno);
             removeLockAndExit();
         case 0:
             // CHILD - will fork and exit soon
-            LOG_DEBUG("First child spawned, with PID=%1%",
+            LOG_DEBUG("First child spawned, with PID={1}",
                       std::to_string(getpid()));
             break;
         default:
@@ -114,7 +114,7 @@ std::unique_ptr<PIDFile> daemonize() {
         pidf_ptr->lockRead();
         LOG_DEBUG("Obtained the read lock after first fork");
     } catch (const PIDFile::Error& e) {
-        LOG_ERROR("Failed get a read lock after first fork: %1%", e.what());
+        LOG_ERROR("Failed get a read lock after first fork: {1}", e.what());
         removeLockAndExit();
     }
 
@@ -123,7 +123,7 @@ std::unique_ptr<PIDFile> daemonize() {
 
     if (setsid() == -1) {
         LOG_ERROR("Failed to create new session for first child process; "
-                  "%1% (%2%)", strerror(errno), errno);
+                  "{1} ({2})", strerror(errno), errno);
         removeLockAndExit();
     }
 
@@ -158,7 +158,7 @@ std::unique_ptr<PIDFile> daemonize() {
 
     switch (second_child_pid) {
         case -1:
-            LOG_ERROR("Failed to perform the second fork; %1% (%2%)",
+            LOG_ERROR("Failed to perform the second fork; {1} ({2})",
                       strerror(errno), errno);
             removeLockAndExit();
         case 0:
@@ -171,7 +171,7 @@ std::unique_ptr<PIDFile> daemonize() {
 
             if (sigsuspend(&empty_mask) == -1 && errno != EINTR) {
                 LOG_ERROR("Unexpected error while waiting for pending signals "
-                          "after second fork; %1% (%2%)", strerror(errno), errno);
+                          "after second fork; {1} ({2})", strerror(errno), errno);
             }
 
             _exit(EXIT_SUCCESS);
@@ -183,7 +183,7 @@ std::unique_ptr<PIDFile> daemonize() {
         pidf_ptr->lockRead();
         LOG_DEBUG("Obtained the read lock after second fork");
     } catch (const PIDFile::Error& e) {
-        LOG_ERROR("Failed get a read lock after second fork: %1%", e.what());
+        LOG_ERROR("Failed get a read lock after second fork: {1}", e.what());
         kill(getppid(), SIGUSR1);
         removeLockAndExit();
     }
@@ -192,12 +192,12 @@ std::unique_ptr<PIDFile> daemonize() {
 
     if (sigprocmask(SIG_SETMASK, &orig_mask, NULL) == -1) {
         LOG_ERROR("Failed to reset signal mask after second fork; "
-                  "%1% (%2%)", strerror(errno), errno);
+                  "{1} ({2})", strerror(errno), errno);
         removeLockAndExit();
     }
 
     auto agent_pid = getpid();
-    LOG_DEBUG("Second child spawned, with PID=%1%", agent_pid);
+    LOG_DEBUG("Second child spawned, with PID={1}", agent_pid);
 
     // Convert the read lock to a write lock and write PID to file
 
@@ -207,7 +207,7 @@ std::unique_ptr<PIDFile> daemonize() {
         pidf_ptr->lockWrite(true);  // blocking call
         LOG_DEBUG("Successfully converted read lock to write lock");
     } catch (const PIDFile::Error& e) {
-        LOG_ERROR("Failed to convert to write lock after second fork: %1%",
+        LOG_ERROR("Failed to convert to write lock after second fork: {1}",
                   e.what());
         removeLockAndExit();
     }
@@ -217,11 +217,11 @@ std::unique_ptr<PIDFile> daemonize() {
     // Change work directory
 
     if (chdir(DEFAULT_DAEMON_WORKING_DIR.data())) {
-        LOG_ERROR("Failed to change work directory to '%1%'; %2% (%3%)",
+        LOG_ERROR("Failed to change work directory to '{1}'; {2} ({3})",
                   DEFAULT_DAEMON_WORKING_DIR, strerror(errno), errno);
         removeLockAndExit();
     } else {
-        LOG_DEBUG("Changed working directory to '%1%'", DEFAULT_DAEMON_WORKING_DIR);
+        LOG_DEBUG("Changed working directory to '{1}'", DEFAULT_DAEMON_WORKING_DIR);
     }
 
     // Change signal dispositions
@@ -229,7 +229,7 @@ std::unique_ptr<PIDFile> daemonize() {
 
     for (auto s : std::vector<int> { SIGINT, SIGTERM, SIGQUIT }) {
         if (signal(s, sigHandler) == SIG_ERR) {
-            LOG_ERROR("Failed to set signal handler for sig %1%", s);
+            LOG_ERROR("Failed to set signal handler for sig {1}", s);
             removeLockAndExit();
         }
     }
@@ -244,21 +244,21 @@ std::unique_ptr<PIDFile> daemonize() {
 
     auto tmpin = freopen("/dev/null", "r", stdin);
     if (tmpin == nullptr) {
-        LOG_WARNING("Failed to redirect stdin to /dev/null; %1% (%2%)",
+        LOG_WARNING("Failed to redirect stdin to /dev/null; {1} ({2})",
                     strerror(errno), errno);
     }
     auto tmpout = freopen("/dev/null", "w", stdout);
     if (tmpout == nullptr) {
-        LOG_WARNING("Failed to redirect stdout to /dev/null; %1% (%2%)",
+        LOG_WARNING("Failed to redirect stdout to /dev/null; {1} ({2})",
                     strerror(errno), errno);
     }
     auto tmperr = freopen("/dev/null", "w", stderr);
     if (tmperr == nullptr) {
-        LOG_WARNING("Failed to redirect stderr to /dev/null; %1% (%2%)",
+        LOG_WARNING("Failed to redirect stderr to /dev/null; {1} ({2})",
                     strerror(errno), errno);
     }
 
-    LOG_INFO("Daemonization completed; pxp-agent PID=%1%, PID lock file in '%2%'",
+    LOG_INFO("Daemonization completed; pxp-agent PID={1}, PID lock file in '{2}'",
              agent_pid, pidfile);
 
     // Set PIDFile dtor to clean itself up and return pointer for RAII

--- a/lib/src/util/windows/daemonize.cc
+++ b/lib/src/util/windows/daemonize.cc
@@ -3,6 +3,7 @@
 
 #define LEATHERMAN_LOGGING_NAMESPACE "puppetlabs.pxp_agent.util.daemonize"
 #include <leatherman/logging/logging.hpp>
+
 #include <leatherman/windows/system_error.hpp>
 
 #include <cstdlib>
@@ -21,7 +22,7 @@ BOOL WINAPI ctrl_handler(DWORD sig)
         case CTRL_CLOSE_EVENT:
         case CTRL_SHUTDOWN_EVENT:
         {
-            LOG_INFO("Caught signal %1% - shutting down", std::to_string(sig));
+            LOG_INFO("Caught signal {1} - shutting down", std::to_string(sig));
             daemon_cleanup();
             exit(EXIT_SUCCESS);
         }
@@ -37,7 +38,7 @@ void daemonize() {
     assert(program_lock == INVALID_HANDLE_VALUE);
     program_lock = CreateMutexA(NULL, TRUE, program_lock_name);
     if (NULL == program_lock) {
-        LOG_ERROR("Unable to acquire process lock: %1%", lth_win::system_error());
+        LOG_ERROR("Unable to acquire process lock: {1}", lth_win::system_error());
         exit(EXIT_FAILURE);
     } else if (ERROR_ALREADY_EXISTS == GetLastError()) {
         LOG_ERROR("Already running daemonized");
@@ -47,12 +48,12 @@ void daemonize() {
     if (SetConsoleCtrlHandler(static_cast<PHANDLER_ROUTINE>(ctrl_handler), TRUE)) {
         LOG_DEBUG("Console control handler installed");
     } else {
-        LOG_ERROR("Could not set control handler: %1%", lth_win::system_error());
+        LOG_ERROR("Could not set control handler: {1}", lth_win::system_error());
         daemon_cleanup();
         exit(EXIT_FAILURE);
     }
 
-    LOG_INFO("Daemonization completed; pxp-agent PID=%1%, process lock '%2%'",
+    LOG_INFO("Daemonization completed; pxp-agent PID={1}, process lock '{2}'",
              GetCurrentProcessId(), program_lock_name);
 }
 
@@ -61,7 +62,7 @@ void daemon_cleanup() {
     // destruction would preclude using logging because Boost.Log also uses global static
     // destruction.
     if (program_lock != INVALID_HANDLE_VALUE && program_lock != NULL) {
-        LOG_DEBUG("Removing process lock '%1%'", program_lock_name);
+        LOG_DEBUG("Removing process lock '{1}'", program_lock_name);
         ReleaseMutex(program_lock);
         CloseHandle(program_lock);
         program_lock = INVALID_HANDLE_VALUE;

--- a/lib/src/util/windows/process.cc
+++ b/lib/src/util/windows/process.cc
@@ -18,7 +18,7 @@ bool processExists(int pid) {
         return true;
     } else {
         LOG_TRACE("OpenProcess failure while trying to determine the state "
-                  "of PID %1%: %2%", pid, lth_win::system_error());
+                  "of PID {1}: {2}", pid, lth_win::system_error());
     }
     return false;
 }

--- a/locales/pxp-agent.pot
+++ b/locales/pxp-agent.pot
@@ -18,70 +18,75 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #. error
-#: exe/main.cc:57
+#: exe/main.cc:59
 msgid "Failed to daemonize: {1}"
 msgstr ""
 
 #. error
-#: exe/main.cc:60
+#: exe/main.cc:62
 msgid "Failed to daemonize"
 msgstr ""
 
 #. error
-#: exe/main.cc:71
+#: exe/main.cc:73
 msgid "PCP configuration error: {1}"
 msgstr ""
 
 #. error
-#: exe/main.cc:74
+#: exe/main.cc:76
 msgid "WebSocket configuration error: {1}"
 msgstr ""
 
 #. error
-#: exe/main.cc:77
+#: exe/main.cc:79
 msgid "Fatal error: {1}"
 msgstr ""
 
 #. error
-#: exe/main.cc:80
+#: exe/main.cc:82
 #: lib/src/module.cc:92
 msgid "Unexpected error: {1}"
 msgstr ""
 
 #. error
-#: exe/main.cc:83
+#: exe/main.cc:85
 msgid "Unexpected error"
 msgstr ""
 
-#: exe/main.cc:129
-msgid "Cannot start pxp-agent"
+#: exe/main.cc:139
+msgid ""
+"{1}\n"
+"Cannot start pxp-agent"
 msgstr ""
 
-#: exe/main.cc:150
+#: exe/main.cc:163
+msgid "Invalid parse result (%1%)"
+msgstr ""
+
+#: exe/main.cc:168
 msgid ""
-"An unexpected code was returned when trying to parse command line arguments "
-"- {1}\n"
+"Failed to parse command line ({1})\n"
 "Cannot start pxp-agent"
 msgstr ""
 
 #. debug
-#: exe/main.cc:162
+#: exe/main.cc:186
 msgid "pxp-agent logging has been initialized"
 msgstr ""
 
-#: exe/main.cc:165
+#: exe/main.cc:188
 msgid ""
 "Failed to configure logging: {1}\n"
 "Cannot start pxp-agent"
 msgstr ""
 
 #. info
-#: exe/main.cc:175
+#: exe/main.cc:202
 msgid "pxp-agent configuration has been validated"
 msgstr ""
 
 #. error
-#: exe/main.cc:177
+#: exe/main.cc:204
 msgid "Fatal configuration error: {1}; cannot start pxp-agent"
 msgstr ""
 
@@ -158,191 +163,191 @@ msgid "invalid log level: '{1}'"
 msgstr ""
 
 #. debug
-#: lib/src/configuration.cc:255
+#: lib/src/configuration.cc:254
 msgid "Logging configured"
 msgstr ""
 
 #. debug
-#: lib/src/configuration.cc:295
+#: lib/src/configuration.cc:294
 msgid "Failed to close logfile stream; already closed?"
 msgstr ""
 
 #. error
-#: lib/src/configuration.cc:300
+#: lib/src/configuration.cc:299
 msgid "Failed to open logfile stream"
 msgstr ""
 
-#: lib/src/configuration.cc:326
+#: lib/src/configuration.cc:325
 msgid "Config file, default: {1}"
 msgstr ""
 
-#: lib/src/configuration.cc:335
+#: lib/src/configuration.cc:334
 msgid "WebSocket URI of the PCP broker"
 msgstr ""
 
-#: lib/src/configuration.cc:344
+#: lib/src/configuration.cc:343
 msgid ""
 "Timeout (in seconds) for establishing a WebSocket connection, default: 5 s"
 msgstr ""
 
-#: lib/src/configuration.cc:354
+#: lib/src/configuration.cc:353
 msgid "SSL CA certificate"
 msgstr ""
 
-#: lib/src/configuration.cc:363
+#: lib/src/configuration.cc:362
 msgid "pxp-agent SSL certificate"
 msgstr ""
 
-#: lib/src/configuration.cc:372
+#: lib/src/configuration.cc:371
 msgid "pxp-agent private SSL key"
 msgstr ""
 
-#: lib/src/configuration.cc:381
+#: lib/src/configuration.cc:380
 msgid "Log file, default: {1}"
 msgstr ""
 
-#: lib/src/configuration.cc:390
+#: lib/src/configuration.cc:389
 msgid ""
 "Valid options are 'none', 'trace', 'debug', 'info','warning', 'error' and "
 "'fatal'. Defaults to 'info'"
 msgstr ""
 
-#: lib/src/configuration.cc:401
+#: lib/src/configuration.cc:400
 msgid "Modules directory, default (relative to the pxp-agent.exe path): {1}"
 msgstr ""
 
-#: lib/src/configuration.cc:414
+#: lib/src/configuration.cc:413
 msgid "Module config files directory, default: {1}"
 msgstr ""
 
-#: lib/src/configuration.cc:424
+#: lib/src/configuration.cc:423
 msgid "Spool action results directory, default: {1}"
 msgstr ""
 
-#: lib/src/configuration.cc:434
+#: lib/src/configuration.cc:433
 msgid "TTL for action results before being deleted, default: '{1}' (days)"
 msgstr ""
 
-#: lib/src/configuration.cc:445
+#: lib/src/configuration.cc:444
 msgid "Don't daemonize, default: false"
 msgstr ""
 
-#: lib/src/configuration.cc:458
+#: lib/src/configuration.cc:457
 msgid "PID file path, default: {1}"
 msgstr ""
 
-#: lib/src/configuration.cc:530
+#: lib/src/configuration.cc:529
 msgid "cannot parse config file; invalid JSON"
 msgstr ""
 
-#: lib/src/configuration.cc:544
+#: lib/src/configuration.cc:543
 msgid "field '{1}' must be of type {2}"
 msgstr ""
 
-#: lib/src/configuration.cc:553
+#: lib/src/configuration.cc:552
 msgid "field '{1}' is not a valid configuration variable"
 msgstr ""
 
-#: lib/src/configuration.cc:585
+#: lib/src/configuration.cc:584
 msgid "{1} value must be defined"
 msgstr ""
 
-#: lib/src/configuration.cc:590
+#: lib/src/configuration.cc:589
 msgid "{1} file '{2}' not found"
 msgstr ""
 
-#: lib/src/configuration.cc:594
+#: lib/src/configuration.cc:593
 msgid "{1} file '{2}' not readable"
 msgstr ""
 
-#: lib/src/configuration.cc:605
+#: lib/src/configuration.cc:604
 msgid "broker-ws-uri value must be defined"
 msgstr ""
 
-#: lib/src/configuration.cc:608
+#: lib/src/configuration.cc:607
 msgid "broker-ws-uri value must start with wss://"
 msgstr ""
 
 #. info
-#: lib/src/configuration.cc:637
+#: lib/src/configuration.cc:636
 msgid "Creating the {1} '{2}'"
 msgstr ""
 
 #. debug
-#: lib/src/configuration.cc:640
+#: lib/src/configuration.cc:639
 msgid "Failed to create the {1} '{2}': {3}"
 msgstr ""
 
-#: lib/src/configuration.cc:643
+#: lib/src/configuration.cc:642
 msgid "failed to create the {1} '{2}'"
 msgstr ""
 
-#: lib/src/configuration.cc:648
+#: lib/src/configuration.cc:647
 msgid "the {1} '{2}' does not exist"
 msgstr ""
 
-#: lib/src/configuration.cc:653
+#: lib/src/configuration.cc:652
 msgid "the {1} '{2}' is not a directory"
 msgstr ""
 
-#: lib/src/configuration.cc:679
+#: lib/src/configuration.cc:678
 msgid "spool-dir must be defined"
 msgstr ""
 
 #. debug
-#: lib/src/configuration.cc:696
+#: lib/src/configuration.cc:695
 msgid ""
 "Failed to create the test dir in spool path '{1}' duringconfiguration "
 "validation: {2}"
 msgstr ""
 
-#: lib/src/configuration.cc:703
+#: lib/src/configuration.cc:702
 msgid "the spool-dir '{1}' is not writable"
 msgstr ""
 
-#: lib/src/configuration.cc:714
+#: lib/src/configuration.cc:713
 msgid "the PID file '{1}' is not a regular file"
 msgstr ""
 
 #. debug
-#: lib/src/configuration.cc:724
+#: lib/src/configuration.cc:723
 msgid "Creating the PID file directory '{1}'"
 msgstr ""
 
 #. debug
-#: lib/src/configuration.cc:727
+#: lib/src/configuration.cc:726
 msgid "Failed to create '{1}' directory: {2}"
 msgstr ""
 
-#: lib/src/configuration.cc:729
+#: lib/src/configuration.cc:728
 msgid "failed to create the PID file directory"
 msgstr ""
 
-#: lib/src/configuration.cc:736
+#: lib/src/configuration.cc:735
 msgid "'{1}' is not a directory"
 msgstr ""
 
-#: lib/src/configuration.cc:739
+#: lib/src/configuration.cc:738
 msgid "the PID directory '{1}' does not exist; cannot create the PID file"
 msgstr ""
 
-#: lib/src/configuration.cc:751
+#: lib/src/configuration.cc:750
 msgid "invalid spool-dir-purge-ttl: {1}"
 msgstr ""
 
-#: lib/src/configuration.cc:760
+#: lib/src/configuration.cc:759
 msgid "no default value for {1}"
 msgstr ""
 
-#: lib/src/configuration.cc:766
+#: lib/src/configuration.cc:765
 msgid "invalid value for {1}"
 msgstr ""
 
-#: lib/src/configuration.cc:771
+#: lib/src/configuration.cc:770
 msgid "unknown flag name: {1}"
 msgstr ""
 
-#: lib/src/configuration.cc:779
+#: lib/src/configuration.cc:777
 msgid "cannot set configuration value until configuration is validated"
 msgstr ""
 

--- a/locales/pxp-agent.pot
+++ b/locales/pxp-agent.pot
@@ -1,0 +1,1385 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Puppet Labs <docs@puppetlabs.com>
+# This file is distributed under the same license as the pxp-agent package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: pxp-agent \n"
+"Report-Msgid-Bugs-To: docs@puppetlabs.com\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. error
+#: exe/main.cc:57
+msgid "Failed to daemonize: {1}"
+msgstr ""
+
+#. error
+#: exe/main.cc:60
+msgid "Failed to daemonize"
+msgstr ""
+
+#. error
+#: exe/main.cc:71
+msgid "PCP configuration error: {1}"
+msgstr ""
+
+#. error
+#: exe/main.cc:74
+msgid "WebSocket configuration error: {1}"
+msgstr ""
+
+#. error
+#: exe/main.cc:77
+msgid "Fatal error: {1}"
+msgstr ""
+
+#. error
+#: exe/main.cc:80
+#: lib/src/module.cc:92
+msgid "Unexpected error: {1}"
+msgstr ""
+
+#. error
+#: exe/main.cc:83
+msgid "Unexpected error"
+msgstr ""
+
+#: exe/main.cc:129
+msgid "Cannot start pxp-agent"
+msgstr ""
+
+#: exe/main.cc:150
+msgid ""
+"An unexpected code was returned when trying to parse command line arguments "
+"- {1}\n"
+"Cannot start pxp-agent"
+msgstr ""
+
+#. debug
+#: exe/main.cc:162
+msgid "pxp-agent logging has been initialized"
+msgstr ""
+
+#: exe/main.cc:165
+msgid ""
+"Failed to configure logging: {1}\n"
+"Cannot start pxp-agent"
+msgstr ""
+
+#. info
+#: exe/main.cc:175
+msgid "pxp-agent configuration has been validated"
+msgstr ""
+
+#. error
+#: exe/main.cc:177
+msgid "Fatal configuration error: {1}; cannot start pxp-agent"
+msgstr ""
+
+#: lib/src/action_request.cc:71
+#: lib/src/action_response.cc:149
+msgid "{1} '{2} {3}' request (transaction {4})"
+msgstr ""
+
+#. debug
+#: lib/src/action_request.cc:84
+msgid ""
+"Validating {1} request {2} by {3]:\n"
+"{4}"
+msgstr ""
+
+#: lib/src/action_request.cc:99
+msgid "no data"
+msgstr ""
+
+#: lib/src/action_request.cc:101
+msgid "invalid data"
+msgstr ""
+
+#: lib/src/action_request.cc:105
+msgid "data is not in JSON format"
+msgstr ""
+
+#: lib/src/action_response.cc:115
+msgid "invalid action metadata"
+msgstr ""
+
+#. warning
+#: lib/src/agent.cc:57
+msgid ""
+"Error during the PCP Session Association ({1}); will retry to connect in {2} "
+"s"
+msgstr ""
+
+#. debug
+#: lib/src/agent.cc:71
+msgid "PCP connection established; about to start monitoring it"
+msgstr ""
+
+#: lib/src/configuration.cc:53
+msgid "failure getting Windows AppData directory: {1}"
+msgstr ""
+
+#: lib/src/configuration.cc:68
+msgid "failed to retrive pxp-agent binary path"
+msgstr ""
+
+#: lib/src/configuration.cc:80
+msgid "failed to determine the modules directory path: {1}"
+msgstr ""
+
+#: lib/src/configuration.cc:110
+msgid "Usage: pxp-agent [options]"
+msgstr ""
+
+#: lib/src/configuration.cc:155
+msgid "An error occurred while parsing cli options"
+msgstr ""
+
+#: lib/src/configuration.cc:177
+msgid "cannot write to the specified logfile; '{1}' is not a directory"
+msgstr ""
+
+#: lib/src/configuration.cc:182
+msgid "cannot write to '{1}'; its parent directory does not exist"
+msgstr ""
+
+#: lib/src/configuration.cc:234
+msgid "invalid log level: '{1}'"
+msgstr ""
+
+#. debug
+#: lib/src/configuration.cc:255
+msgid "Logging configured"
+msgstr ""
+
+#. debug
+#: lib/src/configuration.cc:295
+msgid "Failed to close logfile stream; already closed?"
+msgstr ""
+
+#. error
+#: lib/src/configuration.cc:300
+msgid "Failed to open logfile stream"
+msgstr ""
+
+#: lib/src/configuration.cc:326
+msgid "Config file, default: {1}"
+msgstr ""
+
+#: lib/src/configuration.cc:335
+msgid "WebSocket URI of the PCP broker"
+msgstr ""
+
+#: lib/src/configuration.cc:344
+msgid ""
+"Timeout (in seconds) for establishing a WebSocket connection, default: 5 s"
+msgstr ""
+
+#: lib/src/configuration.cc:354
+msgid "SSL CA certificate"
+msgstr ""
+
+#: lib/src/configuration.cc:363
+msgid "pxp-agent SSL certificate"
+msgstr ""
+
+#: lib/src/configuration.cc:372
+msgid "pxp-agent private SSL key"
+msgstr ""
+
+#: lib/src/configuration.cc:381
+msgid "Log file, default: {1}"
+msgstr ""
+
+#: lib/src/configuration.cc:390
+msgid ""
+"Valid options are 'none', 'trace', 'debug', 'info','warning', 'error' and "
+"'fatal'. Defaults to 'info'"
+msgstr ""
+
+#: lib/src/configuration.cc:401
+msgid "Modules directory, default (relative to the pxp-agent.exe path): {1}"
+msgstr ""
+
+#: lib/src/configuration.cc:414
+msgid "Module config files directory, default: {1}"
+msgstr ""
+
+#: lib/src/configuration.cc:424
+msgid "Spool action results directory, default: {1}"
+msgstr ""
+
+#: lib/src/configuration.cc:434
+msgid "TTL for action results before being deleted, default: '{1}' (days)"
+msgstr ""
+
+#: lib/src/configuration.cc:445
+msgid "Don't daemonize, default: false"
+msgstr ""
+
+#: lib/src/configuration.cc:458
+msgid "PID file path, default: {1}"
+msgstr ""
+
+#: lib/src/configuration.cc:530
+msgid "cannot parse config file; invalid JSON"
+msgstr ""
+
+#: lib/src/configuration.cc:544
+msgid "field '{1}' must be of type {2}"
+msgstr ""
+
+#: lib/src/configuration.cc:553
+msgid "field '{1}' is not a valid configuration variable"
+msgstr ""
+
+#: lib/src/configuration.cc:585
+msgid "{1} value must be defined"
+msgstr ""
+
+#: lib/src/configuration.cc:590
+msgid "{1} file '{2}' not found"
+msgstr ""
+
+#: lib/src/configuration.cc:594
+msgid "{1} file '{2}' not readable"
+msgstr ""
+
+#: lib/src/configuration.cc:605
+msgid "broker-ws-uri value must be defined"
+msgstr ""
+
+#: lib/src/configuration.cc:608
+msgid "broker-ws-uri value must start with wss://"
+msgstr ""
+
+#. info
+#: lib/src/configuration.cc:637
+msgid "Creating the {1} '{2}'"
+msgstr ""
+
+#. debug
+#: lib/src/configuration.cc:640
+msgid "Failed to create the {1} '{2}': {3}"
+msgstr ""
+
+#: lib/src/configuration.cc:643
+msgid "failed to create the {1} '{2}'"
+msgstr ""
+
+#: lib/src/configuration.cc:648
+msgid "the {1} '{2}' does not exist"
+msgstr ""
+
+#: lib/src/configuration.cc:653
+msgid "the {1} '{2}' is not a directory"
+msgstr ""
+
+#: lib/src/configuration.cc:679
+msgid "spool-dir must be defined"
+msgstr ""
+
+#. debug
+#: lib/src/configuration.cc:696
+msgid ""
+"Failed to create the test dir in spool path '{1}' duringconfiguration "
+"validation: {2}"
+msgstr ""
+
+#: lib/src/configuration.cc:703
+msgid "the spool-dir '{1}' is not writable"
+msgstr ""
+
+#: lib/src/configuration.cc:714
+msgid "the PID file '{1}' is not a regular file"
+msgstr ""
+
+#. debug
+#: lib/src/configuration.cc:724
+msgid "Creating the PID file directory '{1}'"
+msgstr ""
+
+#. debug
+#: lib/src/configuration.cc:727
+msgid "Failed to create '{1}' directory: {2}"
+msgstr ""
+
+#: lib/src/configuration.cc:729
+msgid "failed to create the PID file directory"
+msgstr ""
+
+#: lib/src/configuration.cc:736
+msgid "'{1}' is not a directory"
+msgstr ""
+
+#: lib/src/configuration.cc:739
+msgid "the PID directory '{1}' does not exist; cannot create the PID file"
+msgstr ""
+
+#: lib/src/configuration.cc:751
+msgid "invalid spool-dir-purge-ttl: {1}"
+msgstr ""
+
+#: lib/src/configuration.cc:760
+msgid "no default value for {1}"
+msgstr ""
+
+#: lib/src/configuration.cc:766
+msgid "invalid value for {1}"
+msgstr ""
+
+#: lib/src/configuration.cc:771
+msgid "unknown flag name: {1}"
+msgstr ""
+
+#: lib/src/configuration.cc:779
+msgid "cannot set configuration value until configuration is validated"
+msgstr ""
+
+#. info
+#: lib/src/configuration/posix/configuration.cc:16
+msgid "Caught SIGUSR2 signal - reopening log file"
+msgstr ""
+
+#. error
+#: lib/src/configuration/posix/configuration.cc:20
+msgid "Failed to reopen logfile: {1}"
+msgstr ""
+
+#: lib/src/configuration/posix/configuration.cc:29
+msgid "failed to set the SIGUSR2 handler"
+msgstr ""
+
+#. debug
+#: lib/src/configuration/posix/configuration.cc:31
+msgid "Successfully registered the SIGUSR2 handler to reopen the logfile"
+msgstr ""
+
+#. debug
+#: lib/src/external_module.cc:96
+msgid "Found no configuration schema for module '{1}'"
+msgstr ""
+
+#. error
+#: lib/src/external_module.cc:101
+#: lib/src/external_module.cc:121
+msgid "Failed to retrieve metadata of module {1}: {2}"
+msgstr ""
+
+#: lib/src/external_module.cc:104
+#: lib/src/external_module.cc:124
+msgid "invalid metadata of module {1}"
+msgstr ""
+
+#. debug
+#: lib/src/external_module.cc:133
+msgid ""
+"The '{1}' configuration will not be validated; no JSON schema is available"
+msgstr ""
+
+#. debug
+#: lib/src/external_module.cc:172
+msgid ""
+"Obtained invalid JSON on stdout for the {1}; (validation error: {2}); "
+"stdout:\n"
+"{3}"
+msgstr ""
+
+#: lib/src/external_module.cc:176
+msgid ""
+"The task executed for the {1} returned invalid JSON on stdout - stderr:{2}"
+msgstr ""
+
+#: lib/src/external_module.cc:180
+msgid " (empty)"
+msgstr ""
+
+#. error
+#: lib/src/external_module.cc:206
+msgid "Failed to load the external module metadata from {1}: {2}"
+msgstr ""
+
+#: lib/src/external_module.cc:209
+msgid "failed to load external module metadata"
+msgstr ""
+
+#. debug
+#: lib/src/external_module.cc:216
+msgid "External module {1}: metadata is valid JSON"
+msgstr ""
+
+#: lib/src/external_module.cc:219
+msgid "metadata is not in a valid JSON format: {1}"
+msgstr ""
+
+#. debug
+#: lib/src/external_module.cc:224
+msgid "External module {1}: metadata validation OK"
+msgstr ""
+
+#: lib/src/external_module.cc:227
+msgid "metadata validation failure: {1}"
+msgstr ""
+
+#. debug
+#: lib/src/external_module.cc:237
+msgid "Registering module configuration schema for '{1}'"
+msgstr ""
+
+#. error
+#: lib/src/external_module.cc:240
+msgid "Failed to parse the configuration schema of module '{1}': {2}"
+msgstr ""
+
+#: lib/src/external_module.cc:243
+msgid "invalid configuration schema of module {1}"
+msgstr ""
+
+#. debug
+#: lib/src/external_module.cc:260
+msgid "Validating action '{1} {2}'"
+msgstr ""
+
+#. debug
+#: lib/src/external_module.cc:270
+msgid "Action '{1} {2}' has been validated"
+msgstr ""
+
+#. error
+#: lib/src/external_module.cc:275
+msgid "Failed to parse metadata schemas of action '{1} {2}': {3}"
+msgstr ""
+
+#: lib/src/external_module.cc:278
+msgid "invalid schemas of '{1} {2}'"
+msgstr ""
+
+#. error
+#: lib/src/external_module.cc:280
+msgid "Failed to retrieve metadata schemas of action '{1} {2}': {3}"
+msgstr ""
+
+#: lib/src/external_module.cc:283
+msgid "invalid metadata of '{1} {2}'"
+msgstr ""
+
+#. info
+#: lib/src/external_module.cc:313
+msgid "Executing the {1}"
+msgstr ""
+
+#. info
+#: lib/src/external_module.cc:341
+msgid "Starting a task for the {1}; stdout and stderr will be stored in {2}"
+msgstr ""
+
+#. info
+#: lib/src/external_module.cc:362
+msgid "The task for the {1} has completed"
+msgstr ""
+
+#: lib/src/external_module.cc:368
+#: lib/src/module.cc:61
+msgid "(empty)"
+msgstr ""
+
+#. warning
+#: lib/src/external_module.cc:369
+msgid ""
+"The task process failed to write output on file for the {1}; stdout: {2}; "
+"stderr: {3}"
+msgstr ""
+
+#: lib/src/external_module.cc:375
+msgid "failed to write output on file"
+msgstr ""
+
+#: lib/src/module.cc:45
+msgid "The task executed for the {1} returned invalid results."
+msgstr ""
+
+#: lib/src/module.cc:51
+msgid "The task executed for the {1} returned "
+msgstr ""
+
+#: lib/src/module.cc:55
+msgid "no results on stdout - stderr: "
+msgstr ""
+
+#: lib/src/module.cc:57
+msgid "invalid results on stdout: {1} - stderr: "
+msgstr ""
+
+#: lib/src/module.cc:90
+msgid "Error: {1}"
+msgstr ""
+
+#: lib/src/module.cc:94
+msgid "Unexpected excption."
+msgstr ""
+
+#: lib/src/module.cc:98
+msgid "Failed to execute the task for the {1}. {2}"
+msgstr ""
+
+#. error
+#: lib/src/modules/ping.cc:36
+msgid "Found no debug entry in the request message"
+msgstr ""
+
+#: lib/src/modules/ping.cc:37
+msgid "no debug entry"
+msgstr ""
+
+#. error
+#: lib/src/modules/ping.cc:47
+msgid "Failed to parse debug entry: {1}"
+msgstr ""
+
+#. debug
+#: lib/src/modules/ping.cc:48
+msgid "Debug entry: {1}"
+msgstr ""
+
+#: lib/src/modules/ping.cc:50
+msgid "debug entry is not valid JSON"
+msgstr ""
+
+#. warning
+#: lib/src/pxp_connector.cc:23
+msgid "Message {1} contained {2} bad debug chunks"
+msgstr ""
+
+#. info
+#: lib/src/pxp_connector.cc:56
+msgid "Replied to request {1} with a PCP error message"
+msgstr ""
+
+#. error
+#: lib/src/pxp_connector.cc:59
+msgid "Failed to send PCP error message for request {1}: {2}"
+msgstr ""
+
+#. info
+#: lib/src/pxp_connector.cc:76
+msgid "Sent provisional response for the {1} by {2}"
+msgstr ""
+
+#. error
+#: lib/src/pxp_connector.cc:79
+msgid ""
+"Failed to send provisional response for the {1} by {2} (no further attempts "
+"will be made): {3}"
+msgstr ""
+
+#. info
+#: lib/src/pxp_connector.cc:98
+#: lib/src/pxp_connector.cc:117
+msgid "Replied to {1} by {2}, request ID {3}, with a PXP error message"
+msgstr ""
+
+#. error
+#: lib/src/pxp_connector.cc:101
+#: lib/src/pxp_connector.cc:122
+msgid ""
+"Failed to send a PXP error message for the {1} by {2} (no further sending "
+"attempts will be made): {3}"
+msgstr ""
+
+#. info
+#: lib/src/pxp_connector.cc:160
+#: lib/src/pxp_connector.cc:189
+msgid "Sent response for the {1} by {2}"
+msgstr ""
+
+#. error
+#: lib/src/pxp_connector.cc:164
+msgid "Failed to reply to {1} by {2}, (no further attempts will be made): {3}"
+msgstr ""
+
+#. error
+#: lib/src/pxp_connector.cc:192
+msgid "Failed to reply to the {1} by {2}: {3}"
+msgstr ""
+
+#. debug
+#: lib/src/request_processor.cc:87
+msgid "Mutex for transaction ID {1} is already cached"
+msgstr ""
+
+#. error
+#: lib/src/request_processor.cc:96
+msgid "Failed to obtain the mutex pointer for transaction {1}: {2}"
+msgstr ""
+
+#. error
+#: lib/src/request_processor.cc:111
+msgid "Failed to remove the mutex pointer for transaction {1}: {2}"
+msgstr ""
+
+#. info
+#: lib/src/request_processor.cc:139
+#: lib/src/request_processor.cc:348
+msgid "The {1}, request ID {2} by {3}, has successfully completed"
+msgstr ""
+
+#. error
+#: lib/src/request_processor.cc:157
+msgid "Failed to write metadata of the {1}: {2}"
+msgstr ""
+
+#. warning
+#: lib/src/request_processor.cc:189
+msgid ""
+"The modules directory was not provided; no external module will be loaded"
+msgstr ""
+
+#. info
+#: lib/src/request_processor.cc:225
+msgid "Processing {1}, request ID {2}, by {3}"
+msgstr ""
+
+#. error
+#: lib/src/request_processor.cc:233
+msgid ""
+"Invalid {1}, request ID {2} by {3}. Will reply with an RPC Error message. "
+"Error: {4}"
+msgstr ""
+
+#. debug
+#: lib/src/request_processor.cc:240
+msgid "The {1} has been successfully validated"
+msgstr ""
+
+#. debug
+#: lib/src/request_processor.cc:251
+msgid "The {1}, request ID {2} by {3}, has been successfully processed"
+msgstr ""
+
+#. error
+#: lib/src/request_processor.cc:255
+msgid ""
+"Failed to process {1}, request ID {2} by {3}. Will reply with an RPC Error "
+"message. Error: {4}"
+msgstr ""
+
+#. error
+#: lib/src/request_processor.cc:266
+msgid ""
+"Invalid request with ID {1} by {2}. Will reply with a PCP error. Error: {3}"
+msgstr ""
+
+#: lib/src/request_processor.cc:287
+msgid "no configuration loaded for the module '{1}'"
+msgstr ""
+
+#: lib/src/request_processor.cc:307
+msgid "unknown action '{1}' for module '{2}'"
+msgstr ""
+
+#: lib/src/request_processor.cc:310
+msgid "unknown module: {1}"
+msgstr ""
+
+#: lib/src/request_processor.cc:321
+msgid "the module '{1}' supports only blocking PXP requests"
+msgstr ""
+
+#. debug
+#: lib/src/request_processor.cc:327
+msgid "Validating input parameters of the {1}, request ID {2} by {3}"
+msgstr ""
+
+#. debug
+#: lib/src/request_processor.cc:336
+msgid "Invalid input parameters of the {1}, request ID {2} by {3}: {4}"
+msgstr ""
+
+#: lib/src/request_processor.cc:339
+msgid "invalid input for {1}"
+msgstr ""
+
+#. debug
+#: lib/src/request_processor.cc:363
+msgid ""
+"Preparing the task for the {1}, request ID {2} by {3} (using the transaction "
+"ID as identifier)"
+msgstr ""
+
+#: lib/src/request_processor.cc:374
+msgid "already exists an ongoing task with transaction id {1}"
+msgstr ""
+
+#: lib/src/request_processor.cc:383
+msgid "Failed to initialize the metadata file: {1}"
+msgstr ""
+
+#. error
+#: lib/src/request_processor.cc:406
+msgid "Failed to spawn the action job for transaction {1}; error: {2}"
+msgstr ""
+
+#. debug
+#: lib/src/request_processor.cc:461
+msgid "Found no results for the {1}"
+msgstr ""
+
+#: lib/src/request_processor.cc:464
+#: lib/src/request_processor.cc:691
+msgid "found no results directory"
+msgstr ""
+
+#. debug
+#: lib/src/request_processor.cc:481
+msgid "The PID file for the transaction {1} task does not exist"
+msgstr ""
+
+#. debug
+#: lib/src/request_processor.cc:485
+msgid "The PID of the action process for the transaction {1} is {2}"
+msgstr ""
+
+#. error
+#: lib/src/request_processor.cc:507
+msgid "Failed to get the PID for transaction {1}: {2}"
+msgstr ""
+
+#. debug
+#: lib/src/request_processor.cc:514
+msgid "Retrieving metadata and output for the transaction {1}"
+msgstr ""
+
+#: lib/src/request_processor.cc:543
+msgid "unknow action stored in metadata file: '{1} {2}'"
+msgstr ""
+
+#. error
+#: lib/src/request_processor.cc:546
+msgid "Cannot access the stored metadata for the transaction {1}: {2}"
+msgstr ""
+
+#. error
+#: lib/src/request_processor.cc:550
+msgid ""
+"Unexpected failure while retrieving metadata for the transaction {1}: {2}"
+msgstr ""
+
+#: lib/src/request_processor.cc:555
+msgid "unexpected failure while retrieving metadata{1}"
+msgstr ""
+
+#. error
+#: lib/src/request_processor.cc:594
+msgid "Failed to get the output of the trasaction {1}: {2}"
+msgstr ""
+
+#: lib/src/request_processor.cc:598
+msgid "failed to retrieve the output: {1}"
+msgstr ""
+
+#. warning
+#: lib/src/request_processor.cc:626
+msgid ""
+"The action process of the transaction {1} is not running; updating its "
+"status to 'undetermined' on its metadata file"
+msgstr ""
+
+#: lib/src/request_processor.cc:630
+msgid "task process is not running, but no output is available"
+msgstr ""
+
+#. error
+#: lib/src/request_processor.cc:644
+msgid "Failed to update the metadata file of the transaction {1}: {2}"
+msgstr ""
+
+#. warning
+#: lib/src/request_processor.cc:652
+msgid ""
+"We cannot determine the status of the transaction {1} from the action "
+"process' PID"
+msgstr ""
+
+#: lib/src/request_processor.cc:654
+msgid "the PID and output of this task are not available"
+msgstr ""
+
+#. debug
+#: lib/src/request_processor.cc:672
+msgid ""
+"The output for the transaction {1} is now available, but the action process "
+"was still executing when this handler started; wait for {2} ms before "
+"retrieving the output from file"
+msgstr ""
+
+#. error
+#: lib/src/request_processor.cc:685
+msgid ""
+"Failed to get the output of the transaction {1} (it status will be updated "
+"to 'undetermined' on its metadata file): {2}"
+msgstr ""
+
+#. error
+#: lib/src/request_processor.cc:704
+msgid "Failed to update metadata for the {1}: {2}"
+msgstr ""
+
+#. info
+#: lib/src/request_processor.cc:730
+msgid "Setting the status of the transaction {1} to '{2}' on its metadata file"
+msgstr ""
+
+#. error
+#: lib/src/request_processor.cc:741
+msgid "Failed to update metadata of the transaction {1}: {2}"
+msgstr ""
+
+#. info
+#: lib/src/request_processor.cc:765
+msgid "Loading external modules configuration from {1}"
+msgstr ""
+
+#. debug
+#: lib/src/request_processor.cc:781
+msgid "Loaded module configuration for module '{1}' from {2}"
+msgstr ""
+
+#. warning
+#: lib/src/request_processor.cc:784
+msgid ""
+"Cannot load module config file '{1}'; invalid JSON format. If the module's "
+"metadata contains the 'configuration' entry, the module won't be loaded. "
+"Error: '{2}'"
+msgstr ""
+
+#. debug
+#: lib/src/request_processor.cc:796
+msgid ""
+"Directory '{1}' specified by modules-config-dir doesn't exist; no module "
+"configuration file will be loaded"
+msgstr ""
+
+#. warning
+#: lib/src/request_processor.cc:812
+msgid ""
+"Failed to locate the modules directory '{1}'; no external modules will be "
+"loaded"
+msgstr ""
+
+#. info
+#: lib/src/request_processor.cc:817
+msgid "Loading external modules from {1}"
+msgstr ""
+
+#. debug
+#: lib/src/request_processor.cc:841
+msgid "The '{1}' module configuration has been validated: {2}"
+msgstr ""
+
+#. error
+#: lib/src/request_processor.cc:851
+msgid "Failed to load {1}; {2}"
+msgstr ""
+
+#. error
+#: lib/src/request_processor.cc:853
+msgid "Failed to configure {1}; {2}"
+msgstr ""
+
+#. error
+#: lib/src/request_processor.cc:855
+msgid "Unexpected error when loading {1}; {2}"
+msgstr ""
+
+#. error
+#: lib/src/request_processor.cc:858
+msgid "Unexpected error when loading {1}"
+msgstr ""
+
+#: lib/src/request_processor.cc:868
+msgid "actions"
+msgstr ""
+
+#: lib/src/request_processor.cc:871
+msgid "found no action"
+msgstr ""
+
+#. debug
+#: lib/src/request_processor.cc:884
+msgid "Loaded '{1}' module - {2}{3}"
+msgstr ""
+
+#. info
+#: lib/src/request_processor.cc:897
+msgid ""
+"Starting the task for purging the spool directory every {1} minutes; thread "
+"id {2}"
+msgstr ""
+
+#: lib/src/results_mutex.cc:32
+msgid "does not exists"
+msgstr ""
+
+#: lib/src/results_mutex.cc:40
+msgid "already exists"
+msgstr ""
+
+#: lib/src/results_mutex.cc:49
+msgid "does not exist"
+msgstr ""
+
+#: lib/src/results_storage.cc:47
+msgid "failed to write metadata: {1}"
+msgstr ""
+
+#. debug
+#: lib/src/results_storage.cc:57
+msgid "Creating results directory for the  transaction {1} in '{2}'"
+msgstr ""
+
+#: lib/src/results_storage.cc:63
+msgid "failed to create results directory '{1}'"
+msgstr ""
+
+#: lib/src/results_storage.cc:77
+msgid "no results directory for the transaction {1}"
+msgstr ""
+
+#: lib/src/results_storage.cc:92
+msgid "metadata file of the transaction {1} does not exist"
+msgstr ""
+
+#: lib/src/results_storage.cc:97
+msgid "failed to read metadata file of the transaction {1}"
+msgstr ""
+
+#. debug
+#: lib/src/results_storage.cc:104
+msgid ""
+"The file '{1}' contains invalid action metadata:\n"
+"{2}"
+msgstr ""
+
+#: lib/src/results_storage.cc:107
+msgid "invalid action metadata of the transaction {1}"
+msgstr ""
+
+#. debug
+#: lib/src/results_storage.cc:113
+msgid "The metadata file '{1}' is not valid JSON: {2}"
+msgstr ""
+
+#: lib/src/results_storage.cc:116
+msgid "invalid JSON in metadata file of the transaction {1}"
+msgstr ""
+
+#: lib/src/results_storage.cc:132
+msgid "failed to read file '{1}'"
+msgstr ""
+
+#: lib/src/results_storage.cc:138
+msgid "invalid value stored in file '{1}'{2}"
+msgstr ""
+
+#. error
+#: lib/src/results_storage.cc:172
+msgid "Failed to read error file '{1}'; this failure will be ignored"
+msgstr ""
+
+#. debug
+#: lib/src/results_storage.cc:180
+msgid "Output file '{1}' does not exist"
+msgstr ""
+
+#: lib/src/results_storage.cc:182
+msgid "failed to read '{1}'"
+msgstr ""
+
+#. info
+#: lib/src/results_storage.cc:220
+msgid "About to purge the results directories from '{1}'; TTL = {2}"
+msgstr ""
+
+#. error
+#: lib/src/results_storage.cc:248
+msgid "Failed to remove '{1}': {2}"
+msgstr ""
+
+#. warning
+#: lib/src/results_storage.cc:252
+msgid ""
+"Failed to retrieve the metadata for the transaction {1} (the results "
+"directory will not be removed): {2}"
+msgstr ""
+
+#. warning
+#: lib/src/results_storage.cc:256
+msgid ""
+"Failed to process the metadata for the transaction {1} (the results "
+"directory will not be removed): {2}"
+msgstr ""
+
+#. info
+#: lib/src/results_storage.cc:265
+msgid "Removed {1} directories from '{2}'"
+msgstr ""
+
+#. warning
+#: lib/src/thread_container.cc:77
+msgid ""
+"Not all threads stored by the '{1}' ThreadContainer have completed; pxp-"
+"agent will not terminate gracefully"
+msgstr ""
+
+#: lib/src/thread_container.cc:92
+msgid "thread name is already stored"
+msgstr ""
+
+#. debug
+#: lib/src/thread_container.cc:105
+msgid ""
+"{1} threads stored in the '{2}' ThreadContainer; about to start a the "
+"monitoring thread"
+msgstr ""
+
+#. debug
+#: lib/src/thread_container.cc:110
+msgid "Joining the old (idle) monitoring thread instance"
+msgstr ""
+
+#. debug
+#: lib/src/thread_container.cc:162
+msgid "Starting monitoring task for the '{1}' ThreadContainer, with id {2}"
+msgstr ""
+
+#. debug
+#: lib/src/thread_container.cc:188
+msgid "Deleting thread {1} (named '{2}')"
+msgstr ""
+
+#. debug
+#: lib/src/thread_container.cc:199
+msgid ""
+"Deleted {1} thread objects that have completed their execution; in total, "
+"deleted {2} threads so far"
+msgstr ""
+
+#. debug
+#: lib/src/thread_container.cc:206
+msgid "Stopping the monitoring task"
+msgstr ""
+
+#: lib/src/time.cc:26
+msgid "invalid duration string: {1}"
+msgstr ""
+
+#: lib/src/time.cc:35
+#: lib/src/time.cc:59
+#: lib/src/time.cc:85
+msgid "invalid duration string: {1}{2}"
+msgstr ""
+
+#: lib/src/time.cc:95
+msgid "empty time string"
+msgstr ""
+
+#: lib/src/time.cc:98
+msgid "invalid time string: {1}"
+msgstr ""
+
+#: lib/src/time.cc:121
+msgid "failed to create a timepoint for {1}{2}"
+msgstr ""
+
+#. info
+#: lib/src/util/posix/daemonize.cc:28
+msgid "Caught signal {1} - removing PID file '{2}'"
+msgstr ""
+
+#. info
+#: lib/src/util/posix/daemonize.cc:41
+msgid "Already a daemon with PID={1}"
+msgstr ""
+
+#. error
+#: lib/src/util/posix/daemonize.cc:60
+msgid "Already running with PID={1}"
+msgstr ""
+
+#. debug
+#: lib/src/util/posix/daemonize.cc:66
+msgid ""
+"Obtained a read lock for the PID file; no other pxp-agent daemon should be "
+"executing"
+msgstr ""
+
+#. error
+#: lib/src/util/posix/daemonize.cc:69
+msgid "Failed get a read lock for the PID file: {1}"
+msgstr ""
+
+#. debug
+#: lib/src/util/posix/daemonize.cc:75
+msgid ""
+"It is possible to get a write lock for the PID file; no other pxp-agent "
+"daemonization should be in progress"
+msgstr ""
+
+#. error
+#: lib/src/util/posix/daemonize.cc:78
+msgid ""
+"Cannot acquire the write lock for the PID file; please ensure that there is "
+"no other pxp-agent instance executing"
+msgstr ""
+
+#. error
+#: lib/src/util/posix/daemonize.cc:83
+msgid "Failed to check if we can lock the PID file: {1}"
+msgstr ""
+
+#. error
+#: lib/src/util/posix/daemonize.cc:93
+msgid "Failed to perform the first fork; {1} ({2})"
+msgstr ""
+
+#. debug
+#: lib/src/util/posix/daemonize.cc:98
+msgid "First child spawned, with PID={1}"
+msgstr ""
+
+#. debug
+#: lib/src/util/posix/daemonize.cc:115
+msgid "Obtained the read lock after first fork"
+msgstr ""
+
+#. error
+#: lib/src/util/posix/daemonize.cc:117
+msgid "Failed get a read lock after first fork: {1}"
+msgstr ""
+
+#. error
+#: lib/src/util/posix/daemonize.cc:125
+msgid "Failed to create new session for first child process; {1} ({2})"
+msgstr ""
+
+#. error
+#: lib/src/util/posix/daemonize.cc:141
+msgid "Failed to set the signal mask after first fork"
+msgstr ""
+
+#. error
+#: lib/src/util/posix/daemonize.cc:150
+msgid "Failed to set SIGUSR1 disposition after first fork"
+msgstr ""
+
+#. error
+#: lib/src/util/posix/daemonize.cc:161
+msgid "Failed to perform the second fork; {1} ({2})"
+msgstr ""
+
+#. error
+#: lib/src/util/posix/daemonize.cc:173
+msgid ""
+"Unexpected error while waiting for pending signals after second fork; {1} "
+"({2})"
+msgstr ""
+
+#. debug
+#: lib/src/util/posix/daemonize.cc:184
+msgid "Obtained the read lock after second fork"
+msgstr ""
+
+#. error
+#: lib/src/util/posix/daemonize.cc:186
+msgid "Failed get a read lock after second fork: {1}"
+msgstr ""
+
+#. error
+#: lib/src/util/posix/daemonize.cc:194
+msgid "Failed to reset signal mask after second fork; {1} ({2})"
+msgstr ""
+
+#. debug
+#: lib/src/util/posix/daemonize.cc:200
+msgid "Second child spawned, with PID={1}"
+msgstr ""
+
+#. debug
+#: lib/src/util/posix/daemonize.cc:204
+msgid "Converting the read lock to write lock after second fork"
+msgstr ""
+
+#. debug
+#: lib/src/util/posix/daemonize.cc:208
+msgid "Successfully converted read lock to write lock"
+msgstr ""
+
+#. error
+#: lib/src/util/posix/daemonize.cc:210
+msgid "Failed to convert to write lock after second fork: {1}"
+msgstr ""
+
+#. error
+#: lib/src/util/posix/daemonize.cc:220
+msgid "Failed to change work directory to '{1}'; {2} ({3})"
+msgstr ""
+
+#. debug
+#: lib/src/util/posix/daemonize.cc:224
+msgid "Changed working directory to '{1}'"
+msgstr ""
+
+#. error
+#: lib/src/util/posix/daemonize.cc:232
+msgid "Failed to set signal handler for sig {1}"
+msgstr ""
+
+#. warning
+#: lib/src/util/posix/daemonize.cc:247
+msgid "Failed to redirect stdin to /dev/null; {1} ({2})"
+msgstr ""
+
+#. warning
+#: lib/src/util/posix/daemonize.cc:252
+msgid "Failed to redirect stdout to /dev/null; {1} ({2})"
+msgstr ""
+
+#. warning
+#: lib/src/util/posix/daemonize.cc:257
+msgid "Failed to redirect stderr to /dev/null; {1} ({2})"
+msgstr ""
+
+#. info
+#: lib/src/util/posix/daemonize.cc:261
+msgid "Daemonization completed; pxp-agent PID={1}, PID lock file in '{2}'"
+msgstr ""
+
+#: lib/src/util/posix/pid_file.cc:38
+msgid "failed to open PID file '{1}'; {2} ({3})"
+msgstr ""
+
+#. error
+#: lib/src/util/posix/pid_file.cc:47
+msgid "Failed to clean up PID file '{1}': {2}"
+msgstr ""
+
+#. debug
+#: lib/src/util/posix/pid_file.cc:59
+msgid "Couldn't retrieve PID from file '{1}': {2}"
+msgstr ""
+
+#: lib/src/util/posix/pid_file.cc:95
+msgid "failed to write '{1}': {2}"
+msgstr ""
+
+#: lib/src/util/posix/pid_file.cc:101
+msgid "PID file does not exist"
+msgstr ""
+
+#: lib/src/util/posix/pid_file.cc:106
+msgid "PID file is not a regular file"
+msgstr ""
+
+#: lib/src/util/posix/pid_file.cc:110
+msgid "cannot read PID file"
+msgstr ""
+
+#: lib/src/util/posix/pid_file.cc:116
+msgid "PID file is empty"
+msgstr ""
+
+#: lib/src/util/posix/pid_file.cc:124
+msgid "invalid value stored in PID file"
+msgstr ""
+
+#. debug
+#: lib/src/util/posix/pid_file.cc:129
+msgid "Unlocking PID file {1} and closing its open file descriptor"
+msgstr ""
+
+#. error
+#: lib/src/util/posix/pid_file.cc:137
+msgid "Failed to remove PID file '{1}'"
+msgstr ""
+
+#. debug
+#: lib/src/util/posix/pid_file.cc:139
+msgid "Removed PID file '{1}'"
+msgstr ""
+
+#. debug
+#: lib/src/util/posix/pid_file.cc:142
+msgid "Cannot access PID file '{1}'"
+msgstr ""
+
+#. debug
+#: lib/src/util/posix/pid_file.cc:145
+msgid "PID file '{1}' does not exist"
+msgstr ""
+
+#: lib/src/util/posix/pid_file.cc:172
+msgid "incompatible with an existent lock"
+msgstr ""
+
+#: lib/src/util/posix/pid_file.cc:174
+msgid "deadlock"
+msgstr ""
+
+#: lib/src/util/posix/pid_file.cc:178
+#: lib/src/util/posix/pid_file.cc:193
+msgid "unexpected error with errno={1}"
+msgstr ""
+
+#: lib/src/util/posix/pid_file.cc:189
+msgid "caught an interrupt signal"
+msgstr ""
+
+#: lib/src/util/posix/pid_file.cc:201
+#: lib/src/util/posix/pid_file.cc:215
+msgid "errno={1}"
+msgstr ""
+
+#. info
+#: lib/src/util/windows/daemonize.cc:25
+msgid "Caught signal {1} - shutting down"
+msgstr ""
+
+#. error
+#: lib/src/util/windows/daemonize.cc:41
+msgid "Unable to acquire process lock: {1}"
+msgstr ""
+
+#. error
+#: lib/src/util/windows/daemonize.cc:44
+msgid "Already running daemonized"
+msgstr ""
+
+#. debug
+#: lib/src/util/windows/daemonize.cc:49
+msgid "Console control handler installed"
+msgstr ""
+
+#. error
+#: lib/src/util/windows/daemonize.cc:51
+msgid "Could not set control handler: {1}"
+msgstr ""
+
+#. info
+#: lib/src/util/windows/daemonize.cc:56
+msgid "Daemonization completed; pxp-agent PID={1}, process lock '{2}'"
+msgstr ""
+
+#. debug
+#: lib/src/util/windows/daemonize.cc:65
+msgid "Removing process lock '{1}'"
+msgstr ""


### PR DESCRIPTION
Enable the creation of the .pot file that includes the strings that
we want to translate. Don't enable localization now; we'll do that on
PCP-257.

Use leatherman::locale::format() and translate() for the strings that we
want to translate.

Use "{}" instead of "%%" for string interpolation.

Don't use leatherman::util::plural(); we'll deal with plurals once we
enable localization on PCP-257.