### PR TITLE
(PCP-381) Fix usage of env values in acceptance Rakefile

### DIFF
--- a/acceptance/Rakefile
+++ b/acceptance/Rakefile
@@ -92,7 +92,22 @@ EOS
   tests = ENV['TESTS'] || ENV['TEST']
   tests_opt = "--tests=#{tests}" if tests
 
-  config_opt = "--hosts=#{config}" if config
+  target = ENV['TEST_TARGET']
+  master_host = ENV['MASTER_TEST_TARGET'] || 'redhat7-64m'
+  if !target.start_with?(master_host)
+    target = "#{master_host}-#{target}"
+  end
+  if config and File.exists?(config)
+    config_opt = "--hosts=#{config}"
+  elsif target
+    cli = BeakerHostGenerator::CLI.new([target, '--disable-default-role', '--osinfo-version', '1'])
+    ENV['BEAKER_HOSTS'] = "tmp/#{target}-#{SecureRandom.uuid}.yaml"
+    FileUtils.mkdir_p('tmp')
+    File.open(config, 'w') do |fh|
+      fh.print(cli.execute)
+    end
+    config_opt = "--hosts=#{config}"
+  end
 
   overriding_options = ENV['OPTIONS']
 
@@ -233,38 +248,22 @@ def sha
   ENV['SHA']
 end
 
-# Return the host config file for beaker to use
-# If TEST_TARGET is set, pass it to beaker-hostgenerator to generate a file
-# else, assume CONFIG is set to the path of an existing host config file
 def config
-  if (ENV['TEST_TARGET'])
-    if !ENV['TEST_TARGET'].start_with?('redhat7-64m')
-      ENV['TEST_TARGET'] = "redhat7-64m-#{ENV['TEST_TARGET']}"
-      puts "Adding Redhat 7 master to ENV['TEST_TARGET']. Value is now '#{ENV['TEST_TARGET']}'"
-    end
-    cli = BeakerHostGenerator::CLI.new([ENV['TEST_TARGET'], '--disable-default-role', '--osinfo-version', '1'])
-    ENV['CONFIG'] = "tmp/#{ENV['TEST_TARGET']}-#{SecureRandom.uuid}.yaml"
-    FileUtils.mkdir_p('tmp')
-    File.open(ENV['CONFIG'], 'w') do |fh|
-      fh.print(cli.execute)
-    end
-  end
-  ENV['CONFIG']
+  ENV['BEAKER_HOSTS']
 end
 
 namespace :ci do
 
   task :check_env do
     raise(USAGE) unless sha
-    raise(USAGE) unless config
   end
 
   namespace :test do
 
     USAGE = <<-EOS
 SUITE_COMMIT or SHA environment variable must be set to the SHA of the puppet-agent package to test.
-TEST_TARGET environment variable must be set to a valid beaker-hostgenerator string e.g. redhat7-64m-ubuntu1404-64a
-  Also must set CONFIG=config/nodes/foo.yaml or include it in an options.rb for Beaker.
+Also must set BEAKER_HOSTS=config/nodes/foo.yaml or include it in an options.rb for Beaker,
+or specify TEST_TARGET in a form beaker-hostgenerator accepts, e.g. ubuntu1504-64a.
 You may set TESTS=path/to/test,and/more/tests.
 You may set additional Beaker OPTIONS='--more --options'
 If testing from git checkouts, you may optionally set the github fork to checkout from using FORK='other-puppet-fork'.


### PR DESCRIPTION
ci:test:aio was failing in the puppet-agent pipelines when a static hosts file (e.g. aix-71-power.yaml) was needed.
This commit updates Rakefile to work with ENV values passed from CI in the same way as all other puppet-agent components.

[skip ci]