### PR TITLE
(maint) Cleanup HorseWhisperer enum use

### DIFF
--- a/lib/inc/pxp-agent/configuration.hpp
+++ b/lib/inc/pxp-agent/configuration.hpp
@@ -25,7 +25,7 @@ extern const std::string DEFAULT_SPOOL_DIR;     // used by unit tests
 // Types
 //
 
-enum Types { Integer, String, Bool, Double };
+using Types = HorseWhisperer::FlagType;
 
 struct EntryBase
 {

--- a/lib/src/configuration.cc
+++ b/lib/src/configuration.cc
@@ -342,7 +342,7 @@ void Configuration::defineDefaultValues()
                     "",
                     lth_loc::translate("Timeout (in seconds) for establishing "
                                        "a WebSocket connection, default: 5 s"),
-                    Types::Integer,
+                    Types::Int,
                     5) } });
 
     defaults_.insert(
@@ -472,7 +472,7 @@ void Configuration::setDefaultValues()
         }
 
         switch (opt_idx->ptr->type) {
-            case Integer:
+            case Types::Int:
                 {
                     Entry<int>* entry_ptr = (Entry<int>*) opt_idx->ptr.get();
                     HW::DefineGlobalFlag<int>(flag_names, entry_ptr->help,
@@ -482,7 +482,7 @@ void Configuration::setDefaultValues()
                                               });
                 }
                 break;
-            case Bool:
+            case Types::Bool:
                 {
                     Entry<bool>* entry_ptr = (Entry<bool>*) opt_idx->ptr.get();
                     HW::DefineGlobalFlag<bool>(flag_names, entry_ptr->help,
@@ -492,7 +492,7 @@ void Configuration::setDefaultValues()
                                                });
                 }
                 break;
-            case Double:
+            case Types::Double:
                 {
                     Entry<double>* entry_ptr = (Entry<double>*) opt_idx->ptr.get();
                     HW::DefineGlobalFlag<double>(flag_names, entry_ptr->help,
@@ -502,7 +502,7 @@ void Configuration::setDefaultValues()
                                                  });
                 }
                 break;
-            default:
+            case Types::String:
                 {
                     Entry<std::string>* entry_ptr = (Entry<std::string>*) opt_idx->ptr.get();
                     HW::DefineGlobalFlag<std::string>(flag_names, entry_ptr->help,
@@ -511,6 +511,11 @@ void Configuration::setDefaultValues()
                                                           entry_ptr->configured = true;
                                                       });
                 }
+                break;
+            default:
+                // Present because FlagType is not an enum class, and I don't trust
+                // compilers to warn/error about missing cases.
+                assert(false);
         }
     }
 }
@@ -556,21 +561,26 @@ void Configuration::parseConfigFile()
             continue;
 
         switch (opt_idx->ptr->type) {
-            case Integer:
+            case Types::Int:
                 check_key_type(key, "Integer", lth_jc::DataType::Int);
                 HW::SetFlag<int>(key, config_json.get<int>(key));
                 break;
-            case Bool:
+            case Types::Bool:
                 check_key_type(key, "Bool", lth_jc::DataType::Bool);
                 HW::SetFlag<bool>(key, config_json.get<bool>(key));
                 break;
-            case Double:
+            case Types::Double:
                 check_key_type(key, "Double", lth_jc::DataType::Double);
                 HW::SetFlag<double>(key, config_json.get<double>(key));
                 break;
-            default:
+            case Types::String:
                 check_key_type(key, "String", lth_jc::DataType::String);
                 HW::SetFlag<std::string>(key, config_json.get<std::string>(key));
+                break;
+            default:
+                // Present because FlagType is not an enum class, and I don't trust
+                // compilers to warn/error about missing cases.
+                assert(false);
         }
     }
 }

--- a/locales/pxp-agent.pot
+++ b/locales/pxp-agent.pot
@@ -236,118 +236,118 @@ msgstr ""
 msgid "PID file path, default: {1}"
 msgstr ""
 
-#: lib/src/configuration.cc:529
+#: lib/src/configuration.cc:532
 msgid "cannot parse config file; invalid JSON"
 msgstr ""
 
-#: lib/src/configuration.cc:543
+#: lib/src/configuration.cc:546
 msgid "field '{1}' must be of type {2}"
 msgstr ""
 
-#: lib/src/configuration.cc:552
+#: lib/src/configuration.cc:555
 msgid "field '{1}' is not a valid configuration variable"
 msgstr ""
 
-#: lib/src/configuration.cc:584
+#: lib/src/configuration.cc:592
 msgid "{1} value must be defined"
 msgstr ""
 
-#: lib/src/configuration.cc:589
+#: lib/src/configuration.cc:597
 msgid "{1} file '{2}' not found"
 msgstr ""
 
-#: lib/src/configuration.cc:593
+#: lib/src/configuration.cc:601
 msgid "{1} file '{2}' not readable"
 msgstr ""
 
-#: lib/src/configuration.cc:604
+#: lib/src/configuration.cc:612
 msgid "broker-ws-uri value must be defined"
 msgstr ""
 
-#: lib/src/configuration.cc:607
+#: lib/src/configuration.cc:615
 msgid "broker-ws-uri value must start with wss://"
 msgstr ""
 
 #. info
-#: lib/src/configuration.cc:636
+#: lib/src/configuration.cc:644
 msgid "Creating the {1} '{2}'"
 msgstr ""
 
 #. debug
-#: lib/src/configuration.cc:639
+#: lib/src/configuration.cc:647
 msgid "Failed to create the {1} '{2}': {3}"
 msgstr ""
 
-#: lib/src/configuration.cc:642
+#: lib/src/configuration.cc:650
 msgid "failed to create the {1} '{2}'"
 msgstr ""
 
-#: lib/src/configuration.cc:647
+#: lib/src/configuration.cc:655
 msgid "the {1} '{2}' does not exist"
 msgstr ""
 
-#: lib/src/configuration.cc:652
+#: lib/src/configuration.cc:660
 msgid "the {1} '{2}' is not a directory"
 msgstr ""
 
-#: lib/src/configuration.cc:678
+#: lib/src/configuration.cc:686
 msgid "spool-dir must be defined"
 msgstr ""
 
 #. debug
-#: lib/src/configuration.cc:695
+#: lib/src/configuration.cc:703
 msgid ""
 "Failed to create the test dir in spool path '{1}' duringconfiguration "
 "validation: {2}"
 msgstr ""
 
-#: lib/src/configuration.cc:702
+#: lib/src/configuration.cc:710
 msgid "the spool-dir '{1}' is not writable"
 msgstr ""
 
-#: lib/src/configuration.cc:713
+#: lib/src/configuration.cc:721
 msgid "the PID file '{1}' is not a regular file"
 msgstr ""
 
 #. debug
-#: lib/src/configuration.cc:723
+#: lib/src/configuration.cc:731
 msgid "Creating the PID file directory '{1}'"
 msgstr ""
 
 #. debug
-#: lib/src/configuration.cc:726
+#: lib/src/configuration.cc:734
 msgid "Failed to create '{1}' directory: {2}"
 msgstr ""
 
-#: lib/src/configuration.cc:728
+#: lib/src/configuration.cc:736
 msgid "failed to create the PID file directory"
 msgstr ""
 
-#: lib/src/configuration.cc:735
+#: lib/src/configuration.cc:743
 msgid "'{1}' is not a directory"
 msgstr ""
 
-#: lib/src/configuration.cc:738
+#: lib/src/configuration.cc:746
 msgid "the PID directory '{1}' does not exist; cannot create the PID file"
 msgstr ""
 
-#: lib/src/configuration.cc:750
+#: lib/src/configuration.cc:758
 msgid "invalid spool-dir-purge-ttl: {1}"
 msgstr ""
 
-#: lib/src/configuration.cc:759
+#: lib/src/configuration.cc:767
 msgid "no default value for {1}"
 msgstr ""
 
-#: lib/src/configuration.cc:765
+#: lib/src/configuration.cc:773
 msgid "invalid value for {1}"
 msgstr ""
 
-#: lib/src/configuration.cc:770
+#: lib/src/configuration.cc:778
 msgid "unknown flag name: {1}"
 msgstr ""
 
-#: lib/src/configuration.cc:777
+#: lib/src/configuration.cc:785
 msgid "cannot set configuration value until configuration is validated"
 msgstr ""
 
@@ -530,7 +530,7 @@ msgid "Error: {1}"
 msgstr ""
 
 #: lib/src/module.cc:94
-msgid "Unexpected excption."
+msgid "Unexpected exception."
 msgstr ""
 
 #: lib/src/module.cc:98


### PR DESCRIPTION
Uses alias to original type in HorseWhisperer for FlagType so they're
guaranteed to be in-sync. Also uses explicit assert to ensure we always
hit valid switch statements; a new option type will hit `assert(false)`.