### PR TITLE
(maint) Pin pcp-broker version to 0.6.1

### DIFF
--- a/acceptance/setup/common/050_Setup_Broker.rb
+++ b/acceptance/setup/common/050_Setup_Broker.rb
@@ -13,8 +13,9 @@ step 'Install build dependencies on master' do
 end
 
 step 'Clone pcp-broker to master' do
+  # Temporarily pin to pcp-broker 0.6.1 to avoid failures introduced by PCP-245.
   clone_git_repo_on(master, GIT_CLONE_FOLDER,
-    extract_repo_info_from(build_git_url('pcp-broker', nil, nil, 'https')))
+    extract_repo_info_from(build_git_url('pcp-broker', nil, nil, 'https')).merge({:rev => '0.6.1'}))
 end
 
 step 'Download lein bootstrap' do


### PR DESCRIPTION
Known issues in 0.7.0 seem to be causing testing to be unstable. Pin
pxp-agent#stable testing to version 0.6.1 until resolved.

/cc @james-stocks @er0ck 

It'd be nice to have a better way to pin stable builds. Also, why are we using git rather than ezbake helpers?