### PR TITLE
(PCP-349) support running puppet as non-root

### DIFF
--- a/modules/pxp-module-puppet
+++ b/modules/pxp-module-puppet
@@ -28,7 +28,9 @@ DEFAULT_EXITCODE = -1
 
 env_fix_up = nil
 
-def get_env_fix_up
+# use this way of defining the `get_env_fix_up` method so that it can "see"
+# the `env_fix_up` variable
+self.class.send(:define_method, :get_env_fix_up) do
   # Prepare an environment fix-up to make up for its cleansing performed
   # by the Puppet::Util::Execution.execute function.
   # Without this fix-up it's impossible to run puppet under a non-root
@@ -45,8 +47,11 @@ def get_env_fix_up
       {"USER"    => pwentry.name,
        "LOGNAME" => pwentry.name,
        "HOME"    => pwentry.dir}
-    rescue
+    rescue => e
       # oh well ..., let's give it a try without the environment fix-up
+      myname = File.basename($0)
+      $stderr.puts "#{myname}: Could not fix environment for effective UID #{Process.euid}: #{e.message}"
+      $stderr.puts "#{myname}: Expect puppet run problems"
       {}
     end
   end

--- a/modules/pxp-module-puppet
+++ b/modules/pxp-module-puppet
@@ -26,14 +26,30 @@ end
 
 DEFAULT_EXITCODE = -1
 
-# This method exists to facilitate testing
-def last_child_exit_status
-  return $?
-end
+env_fix_up = nil
 
-# This method exists to facilitate testing
-def is_win?
-  return !!File::ALT_SEPARATOR
+def get_env_fix_up
+  # Prepare an environment fix-up to make up for its cleansing performed
+  # by the Puppet::Util::Execution.execute function.
+  # Without this fix-up it's impossible to run puppet under a non-root
+  # user because it cannot find the user's HOME directory.
+  env_fix_up ||= if Puppet.features.microsoft_windows? || Process.euid == 0
+    # no environment fix-up is needed on windows or for root
+    {}
+  else
+    begin
+      require 'etc'
+
+      pwentry = Etc.getpwuid(Process.euid)
+
+      {"USER"    => pwentry.name,
+       "LOGNAME" => pwentry.name,
+       "HOME"    => pwentry.dir}
+    rescue
+      # oh well ..., let's give it a try without the environment fix-up
+      {}
+    end
+  end
 end
 
 def last_run_result(exitcode)
@@ -48,7 +64,8 @@ end
 
 def check_config_print(cli_arg, config)
   command_array = [config["puppet_bin"], "agent", "--configprint", cli_arg]
-  process_output = Puppet::Util::Execution.execute(command_array)
+  process_output = Puppet::Util::Execution.execute(command_array,
+                                                   {:custom_environment => get_env_fix_up()})
   return process_output.to_s.chomp
 end
 
@@ -66,6 +83,8 @@ def make_environment_hash(action_input)
     key, value = entry.split('=')
     env_hash[key] = value
   end
+
+  env_hash.merge!(get_env_fix_up());
 
   return env_hash
 end
@@ -231,7 +250,7 @@ def get_configuration(args)
   config = args["configuration"] || {}
 
   if config["puppet_bin"].nil? || config["puppet_bin"].empty?
-    if !is_win?
+    if !Puppet.features.microsoft_windows?
       config["puppet_bin"] = "/opt/puppetlabs/bin/puppet"
     else
       module_path = File.expand_path(File.dirname(__FILE__))

--- a/modules/spec/unit/modules/puppet_spec.rb
+++ b/modules/spec/unit/modules/puppet_spec.rb
@@ -27,7 +27,8 @@ describe "pxp-module-puppet" do
   describe "check_config_print" do
     it "returns the result of configprint" do
       cli_vec = ["puppet", "agent", "--configprint", "value"]
-      expect(Puppet::Util::Execution).to receive(:execute).with(cli_vec).and_return("value\n")
+      expect(self).to receive(:get_env_fix_up).and_return({"FIXVAR" => "fixvalue"})
+      expect(Puppet::Util::Execution).to receive(:execute).with(cli_vec, {:custom_environment => {"FIXVAR" => "fixvalue"}}).and_return("value\n")
       expect(check_config_print("value", default_configuration)).to be == "value"
     end
   end
@@ -66,8 +67,9 @@ describe "pxp-module-puppet" do
     it "should correctly add the env entries" do
       input = default_input
       input["env"] = ["FOO=bar", "BAR=foo"]
+      expect(self).to receive(:get_env_fix_up).and_return({"FIXVAR" => "fixvalue"})
       expect(make_environment_hash(input)).to be ==
-        {"FOO" => "bar", "BAR" => "foo"}
+        {"FOO" => "bar", "BAR" => "foo", "FIXVAR" => "fixvalue"}
     end
   end
 


### PR DESCRIPTION
This commit makes it possible to run puppet under a non root user.
Previously this was not possible because puppet failed to expand the user home directory. This was due to the environment cleaning performed by the `Puppet::Util::Execution.execute` function used for the puppet run execution which included unsetting of the `HOME` environment variable.
This patch solves that by fixing the environment (re-adding the necessary environment variables to it) after the cleaning. The values of the re-added variables are obtained by reading the pwentry corresponding to the current effective user id.