### PR TITLE
(PCP-428) define missing variable in restart_host_run_puppet test

### DIFF
--- a/acceptance/tests/restart_host_run_puppet.rb
+++ b/acceptance/tests/restart_host_run_puppet.rb
@@ -23,8 +23,9 @@ test_name 'C94777 - Ensure pxp-agent functions after agent host restart' do
     applicable_agents.each do |agent|
       agent.reboot
       # BKR-812
+      timeout = 10
       begin
-        Timeout.timeout(10) do
+        Timeout.timeout(timeout) do
           until agent.up?
             sleep 1
           end


### PR DESCRIPTION
Last commit against this test, to fix some flakiness let a missing
variable definition squeak through, in the exception handling for
timeout.  This commit remedies this.