### PR TITLE
(PUP-428) fix restart_host test on windows agents

### DIFF
--- a/acceptance/tests/restart_host_run_puppet.rb
+++ b/acceptance/tests/restart_host_run_puppet.rb
@@ -23,7 +23,7 @@ test_name 'C94777 - Ensure pxp-agent functions after agent host restart' do
     applicable_agents.each do |agent|
       agent.reboot
       # BKR-812
-      timeout = 10
+      timeout = 30
       begin
         Timeout.timeout(timeout) do
           until agent.up?
@@ -36,10 +36,10 @@ test_name 'C94777 - Ensure pxp-agent functions after agent host restart' do
 
       step "wait until pxp-agent is back up and associated on #{agent}" do
         opts = {
-          :max_retries => 10,
+          :max_retries => 30,
           :retry_interval => 1,
         }
-        retry_on(agent, 'puppet resource service pxp-agent | grep running', opts)
+        retry_on(agent, puppet('resource service pxp-agent | grep running'), opts)
         assert(is_associated?(master, "pcp://#{agent}/agent"),
                "Agent #{agent} should be associated with pcp-broker following host reboot")
       end


### PR DESCRIPTION
The previous commit works around some flaky host and pxp-agent restart
issues by using retry_on(), but did not take into account puppet command
pathing issues in windows.  this commit fixes this.