### PR TITLE
(PCP-453) Only kill pxp-agent if it's running

### DIFF
--- a/ext/systemd/pxp-agent.logrotate
+++ b/ext/systemd/pxp-agent.logrotate
@@ -6,6 +6,6 @@
     notifempty
     sharedscripts
     postrotate
-        systemctl kill --signal=USR2 --kill-who=main pxp-agent.service
+        if [ systemctl status pxp-agent.service > /dev/null 2>&1 ]; then systemctl kill --signal=USR2 --kill-who=main pxp-agent.service; fi
     endscript
 }


### PR DESCRIPTION
Previously, the Debian package puppet-agent installs a logrotate definition /etc/logrotate.d/pxp-agent too but doesn't setup this pxp-agent. Added logic so now it should. 