### PR TITLE
(PCP-453) Only kill pxp-agent if it's running

### DIFF
--- a/ext/systemd/pxp-agent.logrotate
+++ b/ext/systemd/pxp-agent.logrotate
@@ -6,6 +6,6 @@
     notifempty
     sharedscripts
     postrotate
-        systemctl kill --signal=USR2 --kill-who=main pxp-agent.service
+        if [ systemctl status pxp-agent.service > /dev/null 2>&1 ]; then systemctl kill --signal=USR2 --kill-who=main pxp-agent.service; fi
     endscript
 }


### PR DESCRIPTION
If logrotate ran and pxp-agent wasn't running it would fail to kill it. Now it
will only try to kill it if it's running.