### PR TITLE
(PCP-452) Add option to configure Association timeout

### DIFF
--- a/lib/inc/pxp-agent/configuration.hpp
+++ b/lib/inc/pxp-agent/configuration.hpp
@@ -136,7 +136,8 @@ class Configuration
         std::string client_type;
         long ws_connection_timeout_ms;
         uint32_t association_timeout_s;
-        uint32_t pcp_message_timeout_s;
+        uint32_t association_request_ttl_s;
+        uint32_t pcp_message_ttl_s;
         uint32_t allowed_keepalive_timeouts;
     };
 

--- a/lib/inc/pxp-agent/pxp_connector.hpp
+++ b/lib/inc/pxp-agent/pxp_connector.hpp
@@ -52,7 +52,7 @@ class PXPConnector : public PCPClient::Connector {
     TEST_VIRTUAL_SPECIFIER void sendNonBlockingResponse(const ActionResponse& response);
 
   private:
-    uint32_t pcp_message_timeout_s;
+    uint32_t pcp_message_ttl_s;
 
     void sendBlockingResponse_(const ActionResponse::ResponseType& response_type,
                                const ActionResponse& response,

--- a/lib/src/configuration.cc
+++ b/lib/src/configuration.cc
@@ -284,7 +284,8 @@ const Configuration::Agent& Configuration::getAgentConfiguration() const
         AGENT_CLIENT_TYPE,
         HW::GetFlag<int>("connection-timeout") * 1000,
         static_cast<uint32_t >(HW::GetFlag<int>("association-timeout")),
-        static_cast<uint32_t >(HW::GetFlag<int>("pcp-message-timeout")),
+        static_cast<uint32_t >(HW::GetFlag<int>("association-request-ttl")),
+        static_cast<uint32_t >(HW::GetFlag<int>("pcp-message-ttl")),
         static_cast<uint32_t >(HW::GetFlag<int>("allowed-keepalive-timeouts")) };
     return agent_configuration_;
 }
@@ -359,7 +360,8 @@ void Configuration::defineDefaultValues()
                     Types::Int,
                     5) } });
 
-    // Hidden option: number of ping/pong timeouts to allow before disconnecting, default: 2
+    // Hidden option: number of ping/pong timeouts to allow before
+    // disconnecting, default: 2
     defaults_.insert(
         Option { "allowed-keepalive-timeouts",
                  Base_ptr { new Entry<int>(
@@ -369,7 +371,7 @@ void Configuration::defineDefaultValues()
                     Types::Int,
                     2) } });
 
-    // Hidden option: TTL of the PCP Association request, default: 10 s
+    // Hidden option: PCP Association timeout, default: 15 s
     defaults_.insert(
         Option { "association-timeout",
                  Base_ptr { new Entry<int>(
@@ -377,13 +379,23 @@ void Configuration::defineDefaultValues()
                     "",
                     "<hidden>",
                     Types::Int,
-                    10) } });
+                    15) } });
+
+    // Hidden option: TTL of the PCP Association request, default: 10 s
+    defaults_.insert(
+            Option { "association-request-ttl",
+                     Base_ptr { new Entry<int>(
+                             "association-request-ttl",
+                             "",
+                             "<hidden>",
+                             Types::Int,
+                             10) } });
 
     // Hidden option: TTL of the PCP messages, default: 5 s
     defaults_.insert(
-        Option { "pcp-message-timeout",
+        Option { "pcp-message-ttl",
                  Base_ptr { new Entry<int>(
-                    "pcp-message-timeout",
+                    "pcp-message-ttl",
                     "",
                     "<hidden>",
                     Types::Int,
@@ -818,9 +830,13 @@ void Configuration::validateAndNormalizeOtherSettings()
         throw Configuration::Error {
             lth_loc::translate("association-timeout must be positive") };
 
-    if (HW::GetFlag<int>("pcp-message-timeout") < 0)
+    if (HW::GetFlag<int>("association-request-ttl") < 0)
         throw Configuration::Error {
-            lth_loc::translate("pcp-message-timeout must be positive") };
+                lth_loc::translate("association-request-ttl must be positive") };
+
+    if (HW::GetFlag<int>("pcp-message-ttl") < 0)
+        throw Configuration::Error {
+            lth_loc::translate("association-request-ttl must be positive") };
 }
 
 const Options::iterator Configuration::getDefaultIndex(const std::string& flagname)

--- a/lib/tests/common/mock_connector.hpp
+++ b/lib/tests/common/mock_connector.hpp
@@ -34,12 +34,13 @@ static Configuration::Agent AGENT_CONFIGURATION { MODULES,
                                                   KEY,
                                                   SPOOL,
                                                   "0d",  // don't purge!
-                                                  "",  // modules config dir
+                                                  "",    // modules config dir
                                                   "test_agent",
-                                                  5000,
-                                                  5,
-                                                  5,
-                                                  2 };
+                                                  5000,  // connection timeout
+                                                  10,    // association timeout
+                                                  5,     // association ttl
+                                                  5,     // general PCP ttl
+                                                  2 };   // keepalive timeouts
 
 static const std::string VALID_ENVELOPE_TXT {
     " { \"id\" : \"123456\","

--- a/lib/tests/unit/agent_test.cc
+++ b/lib/tests/unit/agent_test.cc
@@ -29,7 +29,7 @@ TEST_CASE("Agent::Agent", "[agent]") {
                                                "0d",  // don't purge!
                                                "",  // modules config dir
                                                "test_agent",
-                                               5000, 5, 5, 2 };
+                                               5000, 10, 5, 5, 2 };
 
     SECTION("does not throw if it fails to find the external modules directory") {
         agent_configuration.modules_dir = MODULES + "/fake_dir";

--- a/locales/pxp-agent.pot
+++ b/locales/pxp-agent.pot
@@ -168,206 +168,207 @@ msgid "Logging configured"
 msgstr ""
 
 #. debug
-#: lib/src/configuration.cc:298
+#: lib/src/configuration.cc:299
 msgid "Failed to close logfile stream; already closed?"
 msgstr ""
 
 #. error
-#: lib/src/configuration.cc:303
+#: lib/src/configuration.cc:304
 msgid "Failed to open logfile stream"
 msgstr ""
 
-#: lib/src/configuration.cc:329
+#: lib/src/configuration.cc:330
 msgid "Config file, default: {1}"
 msgstr ""
 
-#: lib/src/configuration.cc:338
+#: lib/src/configuration.cc:339
 msgid "WebSocket URI of the PCP broker"
 msgstr ""
 
-#: lib/src/configuration.cc:347
+#: lib/src/configuration.cc:348
 msgid ""
 "WebSocket URI of the failover PCP broker used when the default is unavailable"
 msgstr ""
 
-#: lib/src/configuration.cc:357
+#: lib/src/configuration.cc:358
 msgid "Timeout (in seconds) for starting the WebSocket handshake, default: 5 s"
 msgstr ""
 
-#: lib/src/configuration.cc:397
+#: lib/src/configuration.cc:409
 msgid "SSL CA certificate"
 msgstr ""
 
-#: lib/src/configuration.cc:406
+#: lib/src/configuration.cc:418
 msgid "pxp-agent SSL certificate"
 msgstr ""
 
-#: lib/src/configuration.cc:415
+#: lib/src/configuration.cc:427
 msgid "pxp-agent private SSL key"
 msgstr ""
 
-#: lib/src/configuration.cc:424
+#: lib/src/configuration.cc:436
 msgid "Log file, default: {1}"
 msgstr ""
 
-#: lib/src/configuration.cc:433
+#: lib/src/configuration.cc:445
 msgid ""
 "Valid options are 'none', 'trace', 'debug', 'info','warning', 'error' and "
 "'fatal'. Defaults to 'info'"
 msgstr ""
 
-#: lib/src/configuration.cc:444
+#: lib/src/configuration.cc:456
 msgid "Modules directory, default (relative to the pxp-agent.exe path): {1}"
 msgstr ""
 
-#: lib/src/configuration.cc:457
+#: lib/src/configuration.cc:469
 msgid "Module config files directory, default: {1}"
 msgstr ""
 
-#: lib/src/configuration.cc:467
+#: lib/src/configuration.cc:479
 msgid "Spool action results directory, default: {1}"
 msgstr ""
 
-#: lib/src/configuration.cc:477
+#: lib/src/configuration.cc:489
 msgid "TTL for action results before being deleted, default: '{1}' (days)"
 msgstr ""
 
-#: lib/src/configuration.cc:488
+#: lib/src/configuration.cc:500
 msgid "Don't daemonize, default: false"
 msgstr ""
 
-#: lib/src/configuration.cc:501
+#: lib/src/configuration.cc:513
 msgid "PID file path, default: {1}"
 msgstr ""
 
-#: lib/src/configuration.cc:578
+#: lib/src/configuration.cc:590
 msgid "cannot parse config file; invalid JSON"
 msgstr ""
 
-#: lib/src/configuration.cc:592
+#: lib/src/configuration.cc:604
 msgid "field '{1}' must be of type {2}"
 msgstr ""
 
-#: lib/src/configuration.cc:601
+#: lib/src/configuration.cc:613
 msgid "field '{1}' is not a valid configuration variable"
 msgstr ""
 
-#: lib/src/configuration.cc:638
+#: lib/src/configuration.cc:650
 msgid "{1} value must be defined"
 msgstr ""
 
-#: lib/src/configuration.cc:643
+#: lib/src/configuration.cc:655
 msgid "{1} file '{2}' not found"
 msgstr ""
 
-#: lib/src/configuration.cc:647
+#: lib/src/configuration.cc:659
 msgid "{1} file '{2}' not readable"
 msgstr ""
 
-#: lib/src/configuration.cc:658
+#: lib/src/configuration.cc:670
 msgid "broker-ws-uri value must be defined"
 msgstr ""
 
-#: lib/src/configuration.cc:661
+#: lib/src/configuration.cc:673
 msgid "broker-ws-uri value must start with wss://"
 msgstr ""
 
-#: lib/src/configuration.cc:667
+#: lib/src/configuration.cc:679
 msgid "failover-ws-uri requires broker-ws-uri is defined"
 msgstr ""
 
-#: lib/src/configuration.cc:670
+#: lib/src/configuration.cc:682
 msgid "failover-ws-uri value must start with wss://"
 msgstr ""
 
 #. info
-#: lib/src/configuration.cc:700
+#: lib/src/configuration.cc:712
 msgid "Creating the {1} '{2}'"
 msgstr ""
 
 #. debug
-#: lib/src/configuration.cc:703
+#: lib/src/configuration.cc:715
 msgid "Failed to create the {1} '{2}': {3}"
 msgstr ""
 
-#: lib/src/configuration.cc:706
+#: lib/src/configuration.cc:718
 msgid "failed to create the {1} '{2}'"
 msgstr ""
 
-#: lib/src/configuration.cc:711
+#: lib/src/configuration.cc:723
 msgid "the {1} '{2}' does not exist"
 msgstr ""
 
-#: lib/src/configuration.cc:716
+#: lib/src/configuration.cc:728
 msgid "the {1} '{2}' is not a directory"
 msgstr ""
 
-#: lib/src/configuration.cc:742
+#: lib/src/configuration.cc:754
 msgid "spool-dir must be defined"
 msgstr ""
 
 #. debug
-#: lib/src/configuration.cc:759
+#: lib/src/configuration.cc:771
 msgid ""
 "Failed to create the test dir in spool path '{1}' duringconfiguration "
 "validation: {2}"
 msgstr ""
 
-#: lib/src/configuration.cc:766
+#: lib/src/configuration.cc:778
 msgid "the spool-dir '{1}' is not writable"
 msgstr ""
 
-#: lib/src/configuration.cc:777
+#: lib/src/configuration.cc:789
 msgid "the PID file '{1}' is not a regular file"
 msgstr ""
 
 #. debug
-#: lib/src/configuration.cc:787
+#: lib/src/configuration.cc:799
 msgid "Creating the PID file directory '{1}'"
 msgstr ""
 
 #. debug
-#: lib/src/configuration.cc:790
+#: lib/src/configuration.cc:802
 msgid "Failed to create '{1}' directory: {2}"
 msgstr ""
 
-#: lib/src/configuration.cc:792
+#: lib/src/configuration.cc:804
 msgid "failed to create the PID file directory"
 msgstr ""
 
-#: lib/src/configuration.cc:799
+#: lib/src/configuration.cc:811
 msgid "'{1}' is not a directory"
 msgstr ""
 
-#: lib/src/configuration.cc:802
+#: lib/src/configuration.cc:814
 msgid "the PID directory '{1}' does not exist; cannot create the PID file"
 msgstr ""
 
-#: lib/src/configuration.cc:814
+#: lib/src/configuration.cc:826
 msgid "invalid spool-dir-purge-ttl: {1}"
 msgstr ""
 
-#: lib/src/configuration.cc:819
+#: lib/src/configuration.cc:831
 msgid "association-timeout must be positive"
 msgstr ""
 
-#: lib/src/configuration.cc:823
-msgid "pcp-message-timeout must be positive"
+#: lib/src/configuration.cc:835
+#: lib/src/configuration.cc:839
+msgid "association-request-ttl must be positive"
 msgstr ""
 
-#: lib/src/configuration.cc:831
+#: lib/src/configuration.cc:847
 msgid "no default value for {1}"
 msgstr ""
 
-#: lib/src/configuration.cc:837
+#: lib/src/configuration.cc:853
 msgid "invalid value for {1}"
 msgstr ""
 
-#: lib/src/configuration.cc:842
+#: lib/src/configuration.cc:858
 msgid "unknown flag name: {1}"
 msgstr ""
 
-#: lib/src/configuration.cc:849
+#: lib/src/configuration.cc:865
 msgid "cannot set configuration value until configuration is validated"
 msgstr ""
 
@@ -591,54 +592,54 @@ msgid "Message {1} contained {2} bad debug chunks"
 msgstr ""
 
 #. info
-#: lib/src/pxp_connector.cc:71
+#: lib/src/pxp_connector.cc:72
 msgid "Replied to request {1} with a PCP error message"
 msgstr ""
 
 #. error
-#: lib/src/pxp_connector.cc:74
+#: lib/src/pxp_connector.cc:75
 msgid "Failed to send PCP error message for request {1}: {2}"
 msgstr ""
 
 #. info
-#: lib/src/pxp_connector.cc:91
+#: lib/src/pxp_connector.cc:92
 msgid "Sent provisional response for the {1} by {2}"
 msgstr ""
 
 #. error
-#: lib/src/pxp_connector.cc:94
+#: lib/src/pxp_connector.cc:95
 msgid ""
 "Failed to send provisional response for the {1} by {2} (no further attempts "
 "will be made): {3}"
 msgstr ""
 
 #. info
-#: lib/src/pxp_connector.cc:113
-#: lib/src/pxp_connector.cc:132
+#: lib/src/pxp_connector.cc:114
+#: lib/src/pxp_connector.cc:133
 msgid "Replied to {1} by {2}, request ID {3}, with a PXP error message"
 msgstr ""
 
 #. error
-#: lib/src/pxp_connector.cc:116
-#: lib/src/pxp_connector.cc:137
+#: lib/src/pxp_connector.cc:117
+#: lib/src/pxp_connector.cc:138
 msgid ""
 "Failed to send a PXP error message for the {1} by {2} (no further sending "
 "attempts will be made): {3}"
 msgstr ""
 
 #. info
-#: lib/src/pxp_connector.cc:175
-#: lib/src/pxp_connector.cc:204
+#: lib/src/pxp_connector.cc:176
+#: lib/src/pxp_connector.cc:205
 msgid "Sent response for the {1} by {2}"
 msgstr ""
 
 #. error
-#: lib/src/pxp_connector.cc:179
+#: lib/src/pxp_connector.cc:180
 msgid "Failed to reply to {1} by {2}, (no further attempts will be made): {3}"
 msgstr ""
 
 #. error
-#: lib/src/pxp_connector.cc:207
+#: lib/src/pxp_connector.cc:208
 msgid "Failed to reply to the {1} by {2}: {3}"
 msgstr ""
 


### PR DESCRIPTION
The `association-timeout` option is now used to set the timeout for the
overall Association process (default to 15 s).

The old `association-timeout` (ttl for the Association request) can now
be specified by the `association-request-ttl` option (default to 10 s).

Renaming the `pcp-message-timeout` option to 'pcp-messag-ttl', for
consistency with the other ttl option.