### PR TITLE
(maint) Add libpxp-agent dependency on horsewhisperer

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -68,6 +68,7 @@ if (CMAKE_SYSTEM_NAME MATCHES "Linux" OR CMAKE_SYSTEM_NAME MATCHES "SunOS" OR CM
 endif()
 
 add_library(libpxp-agent STATIC ${LIBRARY_COMMON_SOURCES} ${LIBRARY_STANDARD_SOURCES})
+add_dependencies(libpxp-agent horsewhisperer)
 target_link_libraries(libpxp-agent ${LIBS})
 set_target_properties(libpxp-agent PROPERTIES PREFIX "" IMPORT_PREFIX "")
 


### PR DESCRIPTION
This avoids compilation failure during parallel builds (as in `make -j`)
when horsewhisperer is unpacked after starting to compile source for
libpxp-agent.