### PR TITLE
(PCP-405) Make broker-ws-uris a config file only option

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ single JSON object. Example:
 
 ```
 {
-    "broker-ws-uri" : "wss://pcp_broker_cn:8142/pcp/",
+    "broker-ws-uris" : ["wss://pcp_broker_cn:8142/pcp/", "wss://pcp_alt_broker_cn:8142/pcp/"],
     "ssl-key" : "/etc/puppetlabs/puppet/ssl/private_keys/myhost.net.pem",
     "ssl-ca-cert" : "/etc/puppetlabs/puppet/ssl/certs/ca.pem",
     "ssl-cert" : "/etc/puppetlabs/puppet/ssl/certs/myhost.net.pem"
@@ -281,6 +281,15 @@ Specify which config file to use.
 The WebSocket URI of the PXP broker you wish to connect the agent to, in the
 `wss://<broker identity>:8142/pcp/` format; example:
 *wss://pcp_broker_cn:8142/pcp/*
+
+**broker-ws-uris (alternative to broker-ws-uri)**
+
+A config file only alternative to broker-ws-uri, that takes an array
+specifying multiple brokers the agent can connect to. When multiple brokers
+are specified, it will use them in a failover capacity, where if it's unable
+to connect to one it will try the next in the list, and repeat until a
+successful connection is made. In the event of a disconnect, the agent will
+retry that connection before trying a new broker.
 
 **connection-timeout (optional flag)**
 

--- a/lib/inc/pxp-agent/configuration.hpp
+++ b/lib/inc/pxp-agent/configuration.hpp
@@ -193,6 +193,14 @@ class Configuration
         return entry_ptr->value;
     }
 
+    /// Return the list of configured brokers.
+    /// If called after validate(), this will be overridden by
+    /// broker-ws-uri if it was set.
+    std::vector<std::string> get_broker_ws_uris()
+    {
+        return broker_ws_uris_;
+    }
+
     /// Set the specified value for a given configuration flag.
     /// Throw an Configuration::Error in case the Configuration was
     /// not initialized so far.
@@ -204,7 +212,7 @@ class Configuration
         checkValidForSetting();
 
         try {
-            HorseWhisperer::SetFlag<T>(flagname, value);
+            HorseWhisperer::SetFlag<T>(flagname, std::move(value));
         } catch (HorseWhisperer::flag_validation_error) {
             throw Configuration::Error { getInvalidFlagError(flagname) };
         } catch (HorseWhisperer::undefined_flag_error) {
@@ -236,6 +244,9 @@ class Configuration
 
     // Cache for agent configuration parameters
     mutable Agent agent_configuration_;
+
+    // List of brokers
+    std::vector<std::string> broker_ws_uris_;
 
     // Path to the logfile
     std::string logfile_;

--- a/lib/tests/resources/config/bad-uri.cfg
+++ b/lib/tests/resources/config/bad-uri.cfg
@@ -1,0 +1,3 @@
+{
+    "broker-ws-uris" : ["//test_pcp_broker"]
+}

--- a/lib/tests/resources/config/duplicate.cfg
+++ b/lib/tests/resources/config/duplicate.cfg
@@ -1,0 +1,4 @@
+{
+    "broker-ws-uri" : "wss://test_pcp_broker",
+    "broker-ws-uris" : ["wss://test_pcp_broker", "wss://alt_pcp_broker"]
+}

--- a/lib/tests/resources/config/multi-broker.cfg
+++ b/lib/tests/resources/config/multi-broker.cfg
@@ -1,0 +1,3 @@
+{
+    "broker-ws-uris" : ["wss://test_pcp_broker", "wss://alt_pcp_broker"]
+}

--- a/locales/pxp-agent.pot
+++ b/locales/pxp-agent.pot
@@ -186,11 +186,6 @@ msgid "WebSocket URI of the PCP broker"
 msgstr ""
 
 #: lib/src/configuration.cc
-msgid ""
-"List of WebSocket URIs of PCP brokers (cannot be used with broker-ws-uri)"
-msgstr ""
-
-#: lib/src/configuration.cc
 msgid "Timeout (in seconds) for starting the WebSocket handshake, default: 5 s"
 msgstr ""
 
@@ -253,6 +248,11 @@ msgid "field '{1}' is not a valid configuration variable"
 msgstr ""
 
 #: lib/src/configuration.cc
+msgid ""
+"broker-ws-uri and broker-ws-uris cannot both be defined in the config file"
+msgstr ""
+
+#: lib/src/configuration.cc
 msgid "{1} value must be defined"
 msgstr ""
 
@@ -269,11 +269,7 @@ msgid "{1} value \"{2}\" must start with wss://"
 msgstr ""
 
 #: lib/src/configuration.cc
-msgid "broker-ws-uris must be defined"
-msgstr ""
-
-#: lib/src/configuration.cc
-msgid "broker-ws-uri and broker-ws-uris cannot both be defined"
+msgid "broker-ws-uri or broker-ws-uris must be defined"
 msgstr ""
 
 #. info


### PR DESCRIPTION
Changes broker-ws-uris to only be settable via a config file. Also
clarifies how it and broker-ws-uri interract, and adds documentation in
the README.