### PR TITLE
(PCP-431) pxp agent acceptance should support a failover pcp broker

### DIFF
--- a/acceptance/Rakefile
+++ b/acceptance/Rakefile
@@ -16,7 +16,6 @@ module HarnessOptions
 
   DEFAULTS = {
     :type => 'aio',
-    :helper => ['lib/helper.rb'],
     :tests  => ['tests'],
     :ssh => {
       :keys => ["~/.ssh/id_rsa-acceptance"],

--- a/acceptance/config/aio/options.rb
+++ b/acceptance/config/aio/options.rb
@@ -1,5 +1,7 @@
 {
   :type => 'aio',
+  :log_level => 'verbose',
+  :helper => 'lib/helper.rb',
   :is_puppetserver => true,
   :puppetservice => 'puppetserver',
   :'puppetserver-confdir' => '/etc/puppetlabs/puppetserver/conf.d',

--- a/acceptance/setup/common/050_Setup_Broker.rb
+++ b/acceptance/setup/common/050_Setup_Broker.rb
@@ -2,19 +2,42 @@ require 'puppet/acceptance/install_utils'
 extend Puppet::Acceptance::InstallUtils
 require 'pxp-agent/test_helper'
 
-step 'Install build dependencies on master' do
-  MASTER_PACKAGES = {
+step 'Install build dependencies for broker' do
+  BROKER_DEP_PACKAGES = {
     :redhat => [
       'git',
       'java-1.8.0-openjdk-devel',
     ],
   }
-  install_packages_on(master, MASTER_PACKAGES, :check_if_exists => true)
+  install_packages_on(master, BROKER_DEP_PACKAGES, :check_if_exists => true)
 end
 
-step 'Clone pcp-broker to master' do
+NUM_BROKERS = 2
+have_broker_replica = NUM_BROKERS > 1
+
+step 'Clone pcp-broker to broker_hosts' do
   clone_git_repo_on(master, GIT_CLONE_FOLDER,
     extract_repo_info_from(build_git_url('pcp-broker', nil, nil, 'https')))
+
+  step 'Replace PCP test certs with the Puppet certs of this SUT' do
+    on(master, puppet('config print ssldir')) do |result|
+      puppet_ssldir = result.stdout.chomp
+      broker_ssldir = "#{GIT_CLONE_FOLDER}/pcp-broker/test-resources/ssl"
+      on master, "\\cp #{puppet_ssldir}/certs/#{master}.pem #{broker_ssldir}/certs/broker.example.com.pem"
+      on master, "\\cp #{puppet_ssldir}/private_keys/#{master}.pem #{broker_ssldir}/private_keys/broker.example.com.pem"
+      on master, "\\cp #{puppet_ssldir}/ca/ca_crt.pem #{broker_ssldir}/ca/ca_crt.pem"
+      on master, "\\cp #{puppet_ssldir}/ca/ca_crl.pem #{broker_ssldir}/ca/ca_crl.pem"
+    end
+  end
+
+  on(master, "\\ln -s #{GIT_CLONE_FOLDER}/pcp-broker #{GIT_CLONE_FOLDER}/pcp-broker0")
+  if have_broker_replica
+    step 'create replica pcp-broker dir' do
+      for i in 1..NUM_BROKERS-1
+        on(master, "\\cp -a #{GIT_CLONE_FOLDER}/pcp-broker #{GIT_CLONE_FOLDER}/pcp-broker#{i}")
+      end
+    end
+  end
 end
 
 step 'Download lein bootstrap' do
@@ -29,20 +52,16 @@ end
 step 'Run lein deps to download dependencies' do
   # 'lein tk' will download dependencies automatically, but downloading them will take
   # some time and will eat into the polling period we allow for the broker to start
-  on master, "cd #{GIT_CLONE_FOLDER}/pcp-broker; export LEIN_ROOT=ok; lein deps"
-end
-
-step 'Replace PCP test certs with the Puppet certs of this SUT' do
-  on(master, puppet('config print ssldir')) do |result|
-    puppet_ssldir = result.stdout.chomp
-    broker_ssldir = "#{GIT_CLONE_FOLDER}/pcp-broker/test-resources/ssl"
-    on master, "\\cp #{puppet_ssldir}/certs/#{master}.pem #{broker_ssldir}/certs/broker.example.com.pem"
-    on master, "\\cp #{puppet_ssldir}/private_keys/#{master}.pem #{broker_ssldir}/private_keys/broker.example.com.pem"
-    on master, "\\cp #{puppet_ssldir}/ca/ca_crt.pem #{broker_ssldir}/ca/ca_crt.pem"
-    on master, "\\cp #{puppet_ssldir}/ca/ca_crl.pem #{broker_ssldir}/ca/ca_crl.pem"
+  for i in 0..NUM_BROKERS-1
+    on master, "cd #{GIT_CLONE_FOLDER}/pcp-broker#{i}; export LEIN_ROOT=ok; lein deps"
   end
 end
 
-step "Run pcp-broker in trapperkeeper in background and wait for it to report status 'running'" do
-  run_pcp_broker(master)
+step "Run pcp-broker on master in trapperkeeper in background and wait for it to report status 'running'" do
+  for i in 0..NUM_BROKERS-1
+    broker_instance = i
+    configure_pcp_broker(master,broker_instance)
+  end
+  broker_instance = 0 # 0 indexed
+  run_pcp_broker(master, broker_instance)
 end


### PR DESCRIPTION
also: 
(maint) acceptance: move helper config option out of Rakefile
* make default log_level verbose for beaker