### PR TITLE
(PCP-478) Acceptance pre-suite should skip timesync for Ubuntu

### DIFF
--- a/acceptance/setup/common/005_SyncTime.rb
+++ b/acceptance/setup/common/005_SyncTime.rb
@@ -4,6 +4,7 @@ extend Beaker::HostPrebuiltSteps
 # Note: QENG-3641 would allow beaker to take care of this for us
 test_name 'Ensure hosts have synchronized clocks'
 
-# QENG-3786 - OSX is already running ntpd and manually running ntpdate will return 1
-applicable_hosts = hosts.select{|host| host['platform'] !~ /osx/}
+# BKR-797 - If host is already running ntpd, manually running ntpdate will return 1
+# Affects OSX and Ubuntu on vmpooler
+applicable_hosts = hosts.select{|host| host['platform'] !~ /osx|ubuntu/}
 timesync(applicable_hosts, {:logger => logger})


### PR DESCRIPTION
Our vmpooler images for Ubuntu 14.04 now have the ntp service running.
This causes the pre-suite step 005_SyncTime.rb to fail, as beaker's timesync method fails if ntp is running as a service.
This commit skips timesync for Ubuntu hosts. It intentionally skips any Ubuntu host as I found that 15.10 and 16.04 also had ntp running.

[skip ci]