### PR TITLE
(PCP-479) Update pxp-agent to install batch wrapper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,13 @@ install(FILES modules/pxp-module-puppet
         DESTINATION ${MODULES_INSTALL_PATH}
         PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
 
+if (WIN32)
+# Add the module install batch file on windows platforms
+install(FILES modules/pxp-module-puppet.bat
+        DESTINATION ${MODULES_INSTALL_PATH}
+        PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+endif()
+
 # Add the test suite
 enable_testing()
 

--- a/modules/pxp-module-puppet.bat
+++ b/modules/pxp-module-puppet.bat
@@ -3,4 +3,4 @@ SETLOCAL
 
 call "%~dp0..\..\bin\environment.bat" %0 %*
 
-ruby -S -- "%~dp0%SCRIPT_NAME%" %*
+ruby -S -- "%~dp0\pxp-module-puppet" %*


### PR DESCRIPTION
The pxp-module-puppet batch wrapper needs to be installed on windows platforms
to correctly load the module.