### PR TITLE
(PCP-430) previous fix for other tests broke the failover test

### DIFF
--- a/acceptance/lib/pxp-agent/config_helper.rb
+++ b/acceptance/lib/pxp-agent/config_helper.rb
@@ -67,7 +67,7 @@ end
 # @param broker_host the host name or beaker host object for the pcp-broker host
 # @return the broker-ws-uri config string
 def broker_ws_uri(broker_host)
-  if broker_host.is_a?(Hash) && broker_host[:pcp_broker_instance]
+  if broker_host.is_a?(Unix::Host) && broker_host[:pcp_broker_instance]
     "wss://#{broker_host}:#{PCP_BROKER_PORTS[broker_host[:pcp_broker_instance]]}/pcp/"
   else
     "wss://#{broker_host}:#{PCP_BROKER_PORTS[0]}/pcp/"


### PR DESCRIPTION
Broker_hosts can come through as hashes, ips, hostnames, or beaker
hosts.  We need to ensure we trigger failover uri's when using a beaker
host.

[skip ci]