### PR TITLE
(PCP-493) Ensure stderr is returned in module response

### DIFF
--- a/lib/src/module.cc
+++ b/lib/src/module.cc
@@ -47,7 +47,7 @@ void Module::validateOutputAndUpdateMetadata(ActionResponse& response)
         } else {
             // Log about the output
             const auto& out = response.output.std_out;
-            const auto& err = response.output.std_out;
+            const auto& err = response.output.std_err;
             err_msg = lth_loc::format("The task executed for the {1} returned ",
                                       response.prettyRequestLabel());
 


### PR DESCRIPTION
Without this change stderr was inadvertently left out of the module
response. Ensure it's included.