### PR TITLE
(maint) Fix gettext in Travis CI

### DIFF
--- a/.travis_target.sh
+++ b/.travis_target.sh
@@ -11,6 +11,12 @@ fi
 # Set compiler to GCC 4.8 here, as Travis overrides the global variables.
 export CC=gcc-4.8 CXX=g++-4.8
 
+get_gettext() {
+  wget https://s3.amazonaws.com/kylo-pl-bucket/gettext-0.19.6_install.tar.bz2
+  tar xjvf gettext-0.19.6_install.tar.bz2 --strip 1 -C $USERDIR
+  rm -f ../locales/cpp-pcp-client.pot
+}
+
 if [ ${TRAVIS_TARGET} == CPPCHECK ]; then
   # grab a pre-built cppcheck from s3
   wget https://s3.amazonaws.com/kylo-pl-bucket/pcre-8.36_install.tar.bz2
@@ -20,6 +26,9 @@ if [ ${TRAVIS_TARGET} == CPPCHECK ]; then
 elif [ ${TRAVIS_TARGET} == DEBUG ]; then
   # Install coveralls.io update utility
   pip install --user cpp-coveralls
+  get_gettext
+else
+  get_gettext
 fi
 
 git clone https://github.com/puppetlabs/cpp-pcp-client


### PR DESCRIPTION
Our use of gettext requires version 0.19. Ensure it's installed and used
every time.