### PR TITLE
(PCP-515) Acceptance - skip restart_host_run_puppet.rb on Arista

### DIFF
--- a/acceptance/tests/restart_host_run_puppet.rb
+++ b/acceptance/tests/restart_host_run_puppet.rb
@@ -12,6 +12,11 @@ test_name 'C94777 - Ensure pxp-agent functions after agent host restart' do
     skip_test('PCP-508 - CiscoNX hosts cannot be restarted')
   end
 
+  applicable_agents = applicable_agents.select { |agent| agent['platform'] != "eos-4-i386"}
+  unless applicable_agents.length > 0 then
+    skip_test('PCP-515 - Arista devices will reload their system image on reboot')
+  end  
+
   step 'Ensure each agent host has pxp-agent service running and enabled' do
     applicable_agents.each do |agent|
       on agent, puppet('resource service pxp-agent ensure=stopped')


### PR DESCRIPTION
restart_host_run_puppet.rb will fail (and ruin any subsequent tests) on Arista due to the device applying a system image on reboot.
This commit adds a skip_test clause for Arista.

[skip ci]