### PR TITLE
(PCP-515) Acceptance - update ticket reference for skipped test on Arista

### DIFF
--- a/acceptance/tests/restart_host_run_puppet.rb
+++ b/acceptance/tests/restart_host_run_puppet.rb
@@ -14,7 +14,7 @@ test_name 'C94777 - Ensure pxp-agent functions after agent host restart' do
 
   applicable_agents = applicable_agents.select { |agent| agent['platform'] != "eos-4-i386"}
   unless applicable_agents.length > 0 then
-    skip_test('PCP-515 - Arista devices will reload their system image on reboot')
+    skip_test('RE-7673 - Arista hosts cannot be restarted')
   end  
 
   step 'Ensure each agent host has pxp-agent service running and enabled' do


### PR DESCRIPTION
We currently skip the host restart test on Arista VMs due to their reboot behaviour.
Fixing this will require some RE work - this commit simply updates the ticket reference in the test from PCP-515 to RE-7673

[skip ci]