### PR TITLE
(maint) Fix path for pxp-agent using new Windows MSI layout

### DIFF
--- a/acceptance/tests/pxp_agent_version.rb
+++ b/acceptance/tests/pxp_agent_version.rb
@@ -8,7 +8,9 @@ agents.each do |agent|
     # Vendored Ruby needs to be on path for Windows/cygwin.
     # Only do this for cygwin because other OSes (Cisco Nexus) do not handle setting env values inline.
     if windows?(agent) then
-      version_command = "PATH=\"#{agent['privatebindir']}:$PATH\"" + " " + version_command
+      puppet_bindir = '/cygdrive/c/Program Files (x86)/Puppet Labs/Puppet/puppet/bin:'+
+        '/cygdrive/c/Program Files/Puppet Labs/Puppet/puppet/bin'
+      version_command = "PATH=\"#{agent['privatebindir']}:#{puppet_bindir}:$PATH\"" + " " + version_command
     end
     on(agent, version_command) do |result|
       assert(/[0-9\.]*/ =~ result.stdout, "Version number should be numbers and periods but was \"#{result.stdout.to_s}\"")


### PR DESCRIPTION
The Windows MSI layout changed to sharing binaries for C++ applications.
That means pxp-agent.exe now relies on files in puppet/bin. Update the
test to include that in PATH.

For now hard-code in the test. It's not trivial to amend the
privatebindir in config/aio/options.rb, since the setting is
platform-dependent. This might eventually live in Beaker, but since it's
only needed for this test that may not be worth it.