### PR TITLE
(PCP-542) Allow parsing last_run_report with Puppet objects

### DIFF
--- a/modules/pxp-module-puppet
+++ b/modules/pxp-module-puppet
@@ -102,6 +102,20 @@ def make_error_result(exitcode, error_type, error_message)
   return result
 end
 
+def parse_report(filename)
+  # Read the report and drop Ruby objects first. We can't parse the Ruby objects
+  # (because we don't have Puppet loaded) and don't need that data.
+  # Psych::Nodes::Node#each iterates over each node in the parsed document tree.
+  # YAML.parse_file returns a Psych::Nodes::Document, and #root returns the
+  # root-level Node.
+  data = YAML.parse_file(filename)
+  data.root.each do |o|
+    o.tag = nil if o.respond_to?(:tag=)
+  end
+
+  data.to_ruby
+end
+
 def get_result_from_report(last_run_report, exitcode, config, start_time)
   if !File.exist?(last_run_report)
     return make_error_result(exitcode, Errors::NoLastRunReport,
@@ -116,7 +130,7 @@ def get_result_from_report(last_run_report, exitcode, config, start_time)
   last_run_report_yaml = {}
 
   begin
-    last_run_report_yaml = YAML.load_file(last_run_report)
+    last_run_report_yaml = parse_report(last_run_report)
   rescue => e
     return make_error_result(exitcode, Errors::InvalidLastRunReport,
                              "#{last_run_report} could not be loaded: #{e}")
@@ -129,11 +143,11 @@ def get_result_from_report(last_run_report, exitcode, config, start_time)
                                    "Puppet agent exited with a non 0 exitcode")
   end
 
-  run_result["kind"] = last_run_report_yaml.kind
-  run_result["time"] = last_run_report_yaml.time
-  run_result["transaction_uuid"] = last_run_report_yaml.transaction_uuid
-  run_result["environment"] = last_run_report_yaml.environment
-  run_result["status"] = last_run_report_yaml.status
+  run_result["kind"] = last_run_report_yaml['kind']
+  run_result["time"] = last_run_report_yaml['time']
+  run_result["transaction_uuid"] = last_run_report_yaml['transaction_uuid']
+  run_result["environment"] = last_run_report_yaml['environment']
+  run_result["status"] = last_run_report_yaml['status']
 
   return run_result
 end

--- a/modules/spec/fixtures/last_run_report.yaml
+++ b/modules/spec/fixtures/last_run_report.yaml
@@ -1,0 +1,6227 @@
+--- !ruby/object:Puppet::Transaction::Report
+metrics:
+  resources: !ruby/object:Puppet::Util::Metric
+    name: resources
+    label: Resources
+    values:
+    - - total
+      - Total
+      - 183
+    - - skipped
+      - Skipped
+      - 0
+    - - failed
+      - Failed
+      - 0
+    - - failed_to_restart
+      - Failed to restart
+      - 0
+    - - restarted
+      - Restarted
+      - 0
+    - - changed
+      - Changed
+      - 1
+    - - out_of_sync
+      - Out of sync
+      - 1
+    - - scheduled
+      - Scheduled
+      - 0
+  time: !ruby/object:Puppet::Util::Metric
+    name: time
+    label: Time
+    values:
+    - - filebucket
+      - Filebucket
+      - 0.0
+    - - package
+      - Package
+      - 0.0
+    - - file
+      - File
+      - 0.34399100000000005
+    - - exec
+      - Exec
+      - 13.250796999999997
+    - - acl
+      - Acl
+      - 0.0
+    - - pe_anchor
+      - Pe anchor
+      - 0.0
+    - - service
+      - Service
+      - 0.0
+    - - scheduled_task
+      - Scheduled task
+      - 0.0
+    - - schedule
+      - Schedule
+      - 0.0
+    - - config_retrieval
+      - Config retrieval
+      - 2.562491
+    - - total
+      - Total
+      - 16.157279
+  changes: !ruby/object:Puppet::Util::Metric
+    name: changes
+    label: Changes
+    values:
+    - - total
+      - Total
+      - 1
+  events: !ruby/object:Puppet::Util::Metric
+    name: events
+    label: Events
+    values:
+    - - total
+      - Total
+      - 1
+    - - failure
+      - Failure
+      - 0
+    - - success
+      - Success
+      - 1
+logs:
+- !ruby/object:Puppet::Util::Log
+  level: :info
+  tags: !ruby/object:Puppet::Util::TagSet
+    hash:
+      info: true
+  message: Using configured environment 'production'
+  source: Puppet
+  time: 2016-02-24 23:07:22.179068000 +00:00
+- !ruby/object:Puppet::Util::Log
+  level: :info
+  tags: !ruby/object:Puppet::Util::TagSet
+    hash:
+      info: true
+  message: Retrieving pluginfacts
+  source: Puppet
+  time: 2016-02-24 23:07:22.193772000 +00:00
+- !ruby/object:Puppet::Util::Log
+  level: :info
+  tags: !ruby/object:Puppet::Util::TagSet
+    hash:
+      info: true
+  message: Retrieving plugin
+  source: Puppet
+  time: 2016-02-24 23:07:22.271909000 +00:00
+- !ruby/object:Puppet::Util::Log
+  level: :info
+  tags: !ruby/object:Puppet::Util::TagSet
+    hash:
+      info: true
+  message: Loading facts
+  source: Puppet
+  time: 2016-02-24 23:07:25.209398000 +00:00
+- !ruby/object:Puppet::Util::Log
+  level: :info
+  tags: !ruby/object:Puppet::Util::TagSet
+    hash:
+      info: true
+  message: Caching catalog for win2012r2-agent
+  source: Puppet
+  time: 2016-02-24 23:07:29.568767000 +00:00
+- !ruby/object:Puppet::Util::Log
+  level: :info
+  tags: !ruby/object:Puppet::Util::TagSet
+    hash:
+      info: true
+  message: Applying configuration version '1456354776'
+  source: Puppet
+  time: 2016-02-24 23:07:30.178200000 +00:00
+- !ruby/object:Puppet::Util::Log
+  level: :notice
+  tags: !ruby/object:Puppet::Util::TagSet
+    hash:
+      notice: true
+      acl: true
+      class: true
+      windemo::mvcapp: true
+      windemo: true
+      mvcapp: true
+  message: "permissions changed [\n] to [\n { identity => 'IIS APPPOOL\\mvc', rights
+    => [\"full\"] }, \n { identity => 'BUILTIN\\IIS_IUSRS', rights => [\"full\"] }\n]"
+  source: "/Stage[main]/Windemo::Mvcapp/Acl[C:\\inetpub\\wwwroot\\razorC/App_Data]/permissions"
+  time: 2016-02-24 23:07:39.570586000 +00:00
+  file: "/etc/puppetlabs/code/environments/production/modules/windemo/manifests/mvcapp.pp"
+  line: 66
+- !ruby/object:Puppet::Util::Log
+  level: :notice
+  tags: !ruby/object:Puppet::Util::TagSet
+    hash:
+      notice: true
+  message: Applied catalog in 14.28 seconds
+  source: Puppet
+  time: 2016-02-24 23:07:44.334869000 +00:00
+resource_statuses:
+  Filebucket[main]: !ruby/object:Puppet::Resource::Status
+    resource: Filebucket[main]
+    file: "/etc/puppetlabs/code/environments/production/manifests/site.pp"
+    line: 4
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        filebucket: true
+        main: true
+        class: true
+    time: 2016-02-24 23:07:30.256349000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: Filebucket
+    title: main
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Main
+    - Filebucket[main]
+  Package[Microsoft SQL Server Compact 4.0 SP1 x64 ENU]: !ruby/object:Puppet::Resource::Status
+    resource: Package[Microsoft SQL Server Compact 4.0 SP1 x64 ENU]
+    file: "/etc/puppetlabs/code/environments/production/modules/windemo/manifests/sqlce.pp"
+    line: 5
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        package: true
+        class: true
+        windemo::sqlce: true
+        windemo: true
+        sqlce: true
+    time: 2016-02-24 23:07:30.256349000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: Package
+    title: Microsoft SQL Server Compact 4.0 SP1 x64 ENU
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Windemo::Sqlce
+    - Package[Microsoft SQL Server Compact 4.0 SP1 x64 ENU]
+  File[C:\Windows\Temp\razorC_v1.1.1.zip]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\Windows\Temp\razorC_v1.1.1.zip]
+    file: "/etc/puppetlabs/code/environments/production/modules/windemo/manifests/mvcapp.pp"
+    line: 12
+    evaluation_time: 0.124994
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        windemo::mvcapp: true
+        windemo: true
+        mvcapp: true
+    time: 2016-02-24 23:07:30.271924000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\Windows\Temp\razorC_v1.1.1.zip
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Windemo::Mvcapp
+    - File[C:\Windows\Temp\razorC_v1.1.1.zip]
+  Exec[extract_zip]: !ruby/object:Puppet::Resource::Status
+    resource: Exec[extract_zip]
+    file: "/etc/puppetlabs/code/environments/production/modules/windemo/manifests/mvcapp.pp"
+    line: 18
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        exec: true
+        extract_zip: true
+        class: true
+        windemo::mvcapp: true
+        windemo: true
+        mvcapp: true
+    time: 2016-02-24 23:07:30.396918000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: Exec
+    title: extract_zip
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Windemo::Mvcapp
+    - Exec[extract_zip]
+  Exec[add-feature-NET45]: !ruby/object:Puppet::Resource::Status
+    resource: Exec[add-feature-NET45]
+    file: "/etc/puppetlabs/code/environments/production/modules/windowsfeature/manifests/init.pp"
+    line: 106
+    evaluation_time: 1.015637
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        exec: true
+        add-feature-net45: true
+        windowsfeature: true
+        net45: true
+        class: true
+        windemo::dotnet_enable: true
+        windemo: true
+        dotnet_enable: true
+    time: 2016-02-24 23:07:30.396918000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: Exec
+    title: add-feature-NET45
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Windemo::Dotnet_enable
+    - Windowsfeature[NET45]
+    - Exec[add-feature-NET45]
+  Exec[add-feature-IIS_NET45]: !ruby/object:Puppet::Resource::Status
+    resource: Exec[add-feature-IIS_NET45]
+    file: "/etc/puppetlabs/code/environments/production/modules/windowsfeature/manifests/init.pp"
+    line: 106
+    evaluation_time: 1.0169
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        exec: true
+        add-feature-iis_net45: true
+        windowsfeature: true
+        iis_net45: true
+        class: true
+        windemo::iis_enable: true
+        windemo: true
+        iis_enable: true
+    time: 2016-02-24 23:07:31.412555000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: Exec
+    title: add-feature-IIS_NET45
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Windemo::Iis_enable
+    - Windowsfeature[IIS_NET45]
+    - Exec[add-feature-IIS_NET45]
+  Exec[DeleteSite-Default Web Site]: !ruby/object:Puppet::Resource::Status
+    resource: Exec[DeleteSite-Default Web Site]
+    file: "/etc/puppetlabs/code/environments/production/modules/iis/manifests/manage_site.pp"
+    line: 58
+    evaluation_time: 1.014336
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        exec: true
+        iis::manage_site: true
+        iis: true
+        manage_site: true
+        class: true
+        windemo::iis_enable: true
+        windemo: true
+        iis_enable: true
+    time: 2016-02-24 23:07:32.429455000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: Exec
+    title: DeleteSite-Default Web Site
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Windemo::Iis_enable
+    - Iis::Manage_site[Default Web Site]
+    - Exec[DeleteSite-Default Web Site]
+  Exec[Create-mvc]: !ruby/object:Puppet::Resource::Status
+    resource: Exec[Create-mvc]
+    file: "/etc/puppetlabs/code/environments/production/modules/iis/manifests/manage_app_pool.pp"
+    line: 145
+    evaluation_time: 1.016723
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        exec: true
+        create-mvc: true
+        iis::manage_app_pool: true
+        iis: true
+        manage_app_pool: true
+        mvc: true
+        class: true
+        windemo::mvcapp: true
+        windemo: true
+        mvcapp: true
+    time: 2016-02-24 23:07:33.443791000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: Exec
+    title: Create-mvc
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Windemo::Mvcapp
+    - Iis::Manage_app_pool[mvc]
+    - Exec[Create-mvc]
+  Exec[StartMode-mvc]: !ruby/object:Puppet::Resource::Status
+    resource: Exec[StartMode-mvc]
+    file: "/etc/puppetlabs/code/environments/production/modules/iis/manifests/manage_app_pool.pp"
+    line: 152
+    evaluation_time: 1.03019
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        exec: true
+        startmode-mvc: true
+        iis::manage_app_pool: true
+        iis: true
+        manage_app_pool: true
+        mvc: true
+        class: true
+        windemo::mvcapp: true
+        windemo: true
+        mvcapp: true
+    time: 2016-02-24 23:07:34.460514000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: Exec
+    title: StartMode-mvc
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Windemo::Mvcapp
+    - Iis::Manage_app_pool[mvc]
+    - Exec[StartMode-mvc]
+  Exec[RapidFailProtection-mvc]: !ruby/object:Puppet::Resource::Status
+    resource: Exec[RapidFailProtection-mvc]
+    file: "/etc/puppetlabs/code/environments/production/modules/iis/manifests/manage_app_pool.pp"
+    line: 160
+    evaluation_time: 1.016772
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        exec: true
+        rapidfailprotection-mvc: true
+        iis::manage_app_pool: true
+        iis: true
+        manage_app_pool: true
+        mvc: true
+        class: true
+        windemo::mvcapp: true
+        windemo: true
+        mvcapp: true
+    time: 2016-02-24 23:07:35.490704000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: Exec
+    title: RapidFailProtection-mvc
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Windemo::Mvcapp
+    - Iis::Manage_app_pool[mvc]
+    - Exec[RapidFailProtection-mvc]
+  Exec[Framework-mvc]: !ruby/object:Puppet::Resource::Status
+    resource: Exec[Framework-mvc]
+    file: "/etc/puppetlabs/code/environments/production/modules/iis/manifests/manage_app_pool.pp"
+    line: 168
+    evaluation_time: 1.01508
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        exec: true
+        framework-mvc: true
+        iis::manage_app_pool: true
+        iis: true
+        manage_app_pool: true
+        mvc: true
+        class: true
+        windemo::mvcapp: true
+        windemo: true
+        mvcapp: true
+    time: 2016-02-24 23:07:36.507476000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: Exec
+    title: Framework-mvc
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Windemo::Mvcapp
+    - Iis::Manage_app_pool[mvc]
+    - Exec[Framework-mvc]
+  Exec[32bit-mvc]: !ruby/object:Puppet::Resource::Status
+    resource: Exec[32bit-mvc]
+    file: "/etc/puppetlabs/code/environments/production/modules/iis/manifests/manage_app_pool.pp"
+    line: 176
+    evaluation_time: 1.015929
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        exec: true
+        32bit-mvc: true
+        iis::manage_app_pool: true
+        iis: true
+        manage_app_pool: true
+        mvc: true
+        class: true
+        windemo::mvcapp: true
+        windemo: true
+        mvcapp: true
+    time: 2016-02-24 23:07:37.522556000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: Exec
+    title: 32bit-mvc
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Windemo::Mvcapp
+    - Iis::Manage_app_pool[mvc]
+    - Exec[32bit-mvc]
+  Exec[ManagedPipelineMode-mvc]: !ruby/object:Puppet::Resource::Status
+    resource: Exec[ManagedPipelineMode-mvc]
+    file: "/etc/puppetlabs/code/environments/production/modules/iis/manifests/manage_app_pool.pp"
+    line: 190
+    evaluation_time: 1.032101
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        exec: true
+        managedpipelinemode-mvc: true
+        iis::manage_app_pool: true
+        iis: true
+        manage_app_pool: true
+        mvc: true
+        class: true
+        windemo::mvcapp: true
+        windemo: true
+        mvcapp: true
+    time: 2016-02-24 23:07:38.538485000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: Exec
+    title: ManagedPipelineMode-mvc
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Windemo::Mvcapp
+    - Iis::Manage_app_pool[mvc]
+    - Exec[ManagedPipelineMode-mvc]
+  Acl[C:\inetpub\wwwroot\razorC]: !ruby/object:Puppet::Resource::Status
+    resource: Acl[C:\inetpub\wwwroot\razorC]
+    file: "/etc/puppetlabs/code/environments/production/modules/windemo/manifests/mvcapp.pp"
+    line: 41
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        acl: true
+        class: true
+        windemo::mvcapp: true
+        windemo: true
+        mvcapp: true
+    time: 2016-02-24 23:07:39.570586000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: Acl
+    title: C:\inetpub\wwwroot\razorC
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Windemo::Mvcapp
+    - Acl[C:\inetpub\wwwroot\razorC]
+  Acl[C:\inetpub\wwwroot\razorC/App_Data]: !ruby/object:Puppet::Resource::Status
+    resource: Acl[C:\inetpub\wwwroot\razorC/App_Data]
+    file: "/etc/puppetlabs/code/environments/production/modules/windemo/manifests/mvcapp.pp"
+    line: 66
+    evaluation_time: 0.0
+    change_count: 1
+    out_of_sync_count: 1
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        acl: true
+        class: true
+        windemo::mvcapp: true
+        windemo: true
+        mvcapp: true
+    time: 2016-02-24 23:07:39.570586000 +00:00
+    events:
+    - !ruby/object:Puppet::Transaction::Event
+      audited: false
+      property: permissions
+      previous_value:
+      - !ruby/hash:Puppet::Type::Acl::Ace {}
+      - !ruby/hash:Puppet::Type::Acl::Ace {}
+      - !ruby/hash:Puppet::Type::Acl::Ace {}
+      - !ruby/hash:Puppet::Type::Acl::Ace {}
+      desired_value:
+      - !ruby/hash:Puppet::Type::Acl::Ace {}
+      - !ruby/hash:Puppet::Type::Acl::Ace {}
+      historical_value: 
+      message: "permissions changed [\n] to [\n { identity => 'IIS APPPOOL\\mvc',
+        rights => [\"full\"] }, \n { identity => 'BUILTIN\\IIS_IUSRS', rights => [\"full\"]
+        }\n]"
+      name: :permissions_changed
+      status: success
+      time: 2016-02-24 23:07:39.570586000 +00:00
+    out_of_sync: true
+    changed: true
+    resource_type: Acl
+    title: C:\inetpub\wwwroot\razorC/App_Data
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Windemo::Mvcapp
+    - Acl[C:\inetpub\wwwroot\razorC/App_Data]
+  Exec[UpdateSite-PhysicalPath-razorC]: !ruby/object:Puppet::Resource::Status
+    resource: Exec[UpdateSite-PhysicalPath-razorC]
+    file: "/etc/puppetlabs/code/environments/production/modules/iis/manifests/manage_site.pp"
+    line: 41
+    evaluation_time: 1.015327
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        exec: true
+        updatesite-physicalpath-razorc: true
+        iis::manage_site: true
+        iis: true
+        manage_site: true
+        razorc: true
+        class: true
+        windemo::mvcapp: true
+        windemo: true
+        mvcapp: true
+    time: 2016-02-24 23:07:39.584709000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: Exec
+    title: UpdateSite-PhysicalPath-razorC
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Windemo::Mvcapp
+    - Iis::Manage_site[razorC]
+    - Exec[UpdateSite-PhysicalPath-razorC]
+  Exec[UpdateSite-ApplicationPool-razorC]: !ruby/object:Puppet::Resource::Status
+    resource: Exec[UpdateSite-ApplicationPool-razorC]
+    file: "/etc/puppetlabs/code/environments/production/modules/iis/manifests/manage_site.pp"
+    line: 50
+    evaluation_time: 1.015709
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        exec: true
+        updatesite-applicationpool-razorc: true
+        iis::manage_site: true
+        iis: true
+        manage_site: true
+        razorc: true
+        class: true
+        windemo::mvcapp: true
+        windemo: true
+        mvcapp: true
+    time: 2016-02-24 23:07:40.600036000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: Exec
+    title: UpdateSite-ApplicationPool-razorC
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Windemo::Mvcapp
+    - Iis::Manage_site[razorC]
+    - Exec[UpdateSite-ApplicationPool-razorC]
+  Pe_anchor[puppet_enterprise:barrier:ca]: !ruby/object:Puppet::Resource::Status
+    resource: Pe_anchor[puppet_enterprise:barrier:ca]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/init.pp"
+    line: 156
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        pe_anchor: true
+        puppet_enterprise:barrier:ca: true
+        class: true
+        puppet_enterprise: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.615745000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: Pe_anchor
+    title: puppet_enterprise:barrier:ca
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise
+    - Pe_anchor[puppet_enterprise:barrier:ca]
+  File[C:\ProgramData/PuppetLabs/pxp-agent/etc/pxp-agent.conf]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/pxp-agent/etc/pxp-agent.conf]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/pxp_agent.pp"
+    line: 24
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::pxp_agent: true
+        puppet_enterprise: true
+        pxp_agent: true
+        puppet_enterprise::profile::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.615745000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/pxp-agent/etc/pxp-agent.conf
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Pxp_agent
+    - File[C:\ProgramData/PuppetLabs/pxp-agent/etc/pxp-agent.conf]
+  Service[pxp-agent]: !ruby/object:Puppet::Resource::Status
+    resource: Service[pxp-agent]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/pxp_agent/service.pp"
+    line: 2
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        service: true
+        pxp-agent: true
+        class: true
+        puppet_enterprise::pxp_agent::service: true
+        puppet_enterprise: true
+        pxp_agent: true
+        puppet_enterprise::pxp_agent: true
+        puppet_enterprise::profile::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.615745000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: Service
+    title: pxp-agent
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Pxp_agent::Service
+    - Service[pxp-agent]
+  File[C:\ProgramData/PuppetLabs/mcollective/plugins]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/plugins]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/server/plugins.pp"
+    line: 15
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.615745000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/plugins
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:\ProgramData/PuppetLabs/mcollective/plugins]
+  File[C:\ProgramData/PuppetLabs/mcollective/plugins/mcollective]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/plugins/mcollective]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/server/plugins.pp"
+    line: 21
+    evaluation_time: 0.015614
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.850120000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/plugins/mcollective
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:\ProgramData/PuppetLabs/mcollective/plugins/mcollective]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/agent]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/agent]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.865734000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/agent
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/agent]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/agent/package.ddl]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/agent/package.ddl]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.865734000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/agent/package.ddl
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/agent/package.ddl]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/agent/package.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/agent/package.rb]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.865734000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/agent/package.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/agent/package.rb]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/agent/puppet.ddl]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/agent/puppet.ddl]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.865734000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/agent/puppet.ddl
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/agent/puppet.ddl]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/agent/puppet.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/agent/puppet.rb]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.865734000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/agent/puppet.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/agent/puppet.rb]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/agent/puppetral.ddl]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/agent/puppetral.ddl]
+    file: 
+    line: 
+    evaluation_time: 0.015574
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.865734000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/agent/puppetral.ddl
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/agent/puppetral.ddl]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/agent/puppetral.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/agent/puppetral.rb]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.881308000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/agent/puppetral.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/agent/puppetral.rb]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/agent/service.ddl]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/agent/service.ddl]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.881308000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/agent/service.ddl
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/agent/service.ddl]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/agent/service.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/agent/service.rb]
+    file: 
+    line: 
+    evaluation_time: 0.015687
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.881308000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/agent/service.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/agent/service.rb]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/aggregate]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/aggregate]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.896995000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/aggregate
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/aggregate]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/aggregate/boolean_summary.ddl]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/aggregate/boolean_summary.ddl]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.896995000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/aggregate/boolean_summary.ddl
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/aggregate/boolean_summary.ddl]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/aggregate/boolean_summary.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/aggregate/boolean_summary.rb]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.896995000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/aggregate/boolean_summary.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/aggregate/boolean_summary.rb]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/application]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/application]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.896995000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/application
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/application]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/application/package.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/application/package.rb]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.896995000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/application/package.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/application/package.rb]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/application/puppet.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/application/puppet.rb]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.896995000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/application/puppet.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/application/puppet.rb]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/application/service.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/application/service.rb]
+    file: 
+    line: 
+    evaluation_time: 0.01559
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.896995000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/application/service.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/application/service.rb]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/data]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/data]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.912585000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/data
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/data]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/data/puppet_data.ddl]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/data/puppet_data.ddl]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.912585000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/data/puppet_data.ddl
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/data/puppet_data.ddl]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/data/puppet_data.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/data/puppet_data.rb]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.912585000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/data/puppet_data.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/data/puppet_data.rb]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/data/resource_data.ddl]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/data/resource_data.ddl]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.912585000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/data/resource_data.ddl
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/data/resource_data.ddl]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/data/resource_data.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/data/resource_data.rb]
+    file: 
+    line: 
+    evaluation_time: 0.015565
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.912585000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/data/resource_data.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/data/resource_data.rb]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/data/service_data.ddl]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/data/service_data.ddl]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.928150000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/data/service_data.ddl
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/data/service_data.ddl]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/data/service_data.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/data/service_data.rb]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.928150000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/data/service_data.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/data/service_data.rb]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/mco_plugin_versions]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/mco_plugin_versions]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.928150000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/mco_plugin_versions
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/mco_plugin_versions]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/registration]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/registration]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.928150000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/registration
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/registration]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/registration/meta.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/registration/meta.rb]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.928150000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/registration/meta.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/registration/meta.rb]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/security]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/security]
+    file: 
+    line: 
+    evaluation_time: 0.015626
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.928150000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/security
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/security]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/security/sshkey.ddl]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/security/sshkey.ddl]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.943776000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/security/sshkey.ddl
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/security/sshkey.ddl]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/security/sshkey.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/security/sshkey.rb]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.943776000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/security/sshkey.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/security/sshkey.rb]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.943776000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/actionpolicy.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/actionpolicy.rb]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.943776000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/actionpolicy.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/actionpolicy.rb]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/package]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/package]
+    file: 
+    line: 
+    evaluation_time: 0.015632
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.943776000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/package
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/package]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/package/base.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/package/base.rb]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.959408000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/package/base.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/package/base.rb]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/package/packagehelpers.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/package/packagehelpers.rb]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.959408000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/package/packagehelpers.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/package/packagehelpers.rb]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/package/puppetpackage.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/package/puppetpackage.rb]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.959408000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/package/puppetpackage.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/package/puppetpackage.rb]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/package/yumHelper.py]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/package/yumHelper.py]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.959408000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/package/yumHelper.py
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/package/yumHelper.py]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/package/yumpackage.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/package/yumpackage.rb]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.959408000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/package/yumpackage.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/package/yumpackage.rb]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/puppet_agent_mgr]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/puppet_agent_mgr]
+    file: 
+    line: 
+    evaluation_time: 0.016504
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.959408000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/puppet_agent_mgr
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/puppet_agent_mgr]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/puppet_agent_mgr.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/puppet_agent_mgr.rb]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.975912000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/puppet_agent_mgr.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/puppet_agent_mgr.rb]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/puppet_agent_mgr/mgr_v2.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/puppet_agent_mgr/mgr_v2.rb]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.975912000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/puppet_agent_mgr/mgr_v2.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/puppet_agent_mgr/mgr_v2.rb]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/puppet_agent_mgr/mgr_v3.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/puppet_agent_mgr/mgr_v3.rb]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.975912000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/puppet_agent_mgr/mgr_v3.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/puppet_agent_mgr/mgr_v3.rb]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/puppet_agent_mgr/mgr_windows.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/puppet_agent_mgr/mgr_windows.rb]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.975912000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/puppet_agent_mgr/mgr_windows.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/puppet_agent_mgr/mgr_windows.rb]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/puppet_server_address_validation.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/puppet_server_address_validation.rb]
+    file: 
+    line: 
+    evaluation_time: 0.014736
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.975912000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/puppet_server_address_validation.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/puppet_server_address_validation.rb]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/puppetrunner.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/puppetrunner.rb]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.990648000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/puppetrunner.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/puppetrunner.rb]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/service]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/service]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.990648000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/service
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/service]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/service/base.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/service/base.rb]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.990648000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/service/base.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/service/base.rb]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/service/puppetservice.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/service/puppetservice.rb]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.990648000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/service/puppetservice.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/util/service/puppetservice.rb]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/validator]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/validator]
+    file: 
+    line: 
+    evaluation_time: 0.015628
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:41.990648000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/validator
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/validator]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/validator/puppet_resource_validator.ddl]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/validator/puppet_resource_validator.ddl]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.006276000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/validator/puppet_resource_validator.ddl
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/validator/puppet_resource_validator.ddl]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/validator/puppet_resource_validator.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/validator/puppet_resource_validator.rb]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.006276000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/validator/puppet_resource_validator.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/validator/puppet_resource_validator.rb]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/validator/puppet_server_address_validator.ddl]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/validator/puppet_server_address_validator.ddl]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.006276000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/validator/puppet_server_address_validator.ddl
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/validator/puppet_server_address_validator.ddl]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/validator/puppet_server_address_validator.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/validator/puppet_server_address_validator.rb]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.006276000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/validator/puppet_server_address_validator.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/validator/puppet_server_address_validator.rb]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/validator/puppet_tags_validator.ddl]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/validator/puppet_tags_validator.ddl]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.006276000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/validator/puppet_tags_validator.ddl
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/validator/puppet_tags_validator.ddl]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/validator/puppet_tags_validator.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/validator/puppet_tags_validator.rb]
+    file: 
+    line: 
+    evaluation_time: 0.01572
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.006276000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/validator/puppet_tags_validator.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/validator/puppet_tags_validator.rb]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/validator/puppet_variable_validator.ddl]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/validator/puppet_variable_validator.ddl]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.021996000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/validator/puppet_variable_validator.ddl
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/validator/puppet_variable_validator.ddl]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/validator/puppet_variable_validator.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/validator/puppet_variable_validator.rb]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.021996000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/validator/puppet_variable_validator.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/validator/puppet_variable_validator.rb]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/validator/service_name.ddl]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/validator/service_name.ddl]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.021996000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/validator/service_name.ddl
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/validator/service_name.ddl]
+  File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/validator/service_name.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/validator/service_name.rb]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::plugins: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        plugins: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.021996000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/validator/service_name.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Plugins
+    - File[C:/ProgramData/PuppetLabs/mcollective/plugins/mcollective/validator/service_name.rb]
+  File[C:\ProgramData/PuppetLabs/mcollective/var/log]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/var/log]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/server/logs.pp"
+    line: 13
+    evaluation_time: 0.015565
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::logs: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        logs: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.021996000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/var/log
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Logs
+    - File[C:\ProgramData/PuppetLabs/mcollective/var/log]
+  File[C:\ProgramData/PuppetLabs/mcollective/var/log/mcollective.log]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/var/log/mcollective.log]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/server/logs.pp"
+    line: 17
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::logs: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        logs: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.037561000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/var/log/mcollective.log
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Logs
+    - File[C:\ProgramData/PuppetLabs/mcollective/var/log/mcollective.log]
+  File[C:\ProgramData/PuppetLabs/mcollective/var/log/mcollective-audit.log]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/var/log/mcollective-audit.log]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/server/logs.pp"
+    line: 17
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::logs: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        logs: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.037561000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/var/log/mcollective-audit.log
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Logs
+    - File[C:\ProgramData/PuppetLabs/mcollective/var/log/mcollective-audit.log]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/ssl]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/ssl]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/server/certs.pp"
+    line: 34
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::certs: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        certs: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.037561000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/ssl
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Certs
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/ssl]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/ssl/clients]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/ssl/clients]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/server/certs.pp"
+    line: 34
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::certs: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        certs: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.037561000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/ssl/clients
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Certs
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/ssl/clients]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/ssl/clients/mcollective-public.pem]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/ssl/clients/mcollective-public.pem]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/profile/mcollective/agent.pp"
+    line: 40
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::profile::mcollective::agent: true
+        puppet_enterprise: true
+        profile: true
+        mcollective: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.053148000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/ssl/clients/mcollective-public.pem
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Profile::Mcollective::Agent
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/ssl/clients/mcollective-public.pem]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/ssl/ca.cert.pem]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/ssl/ca.cert.pem]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/server/certs.pp"
+    line: 38
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::certs: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        certs: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.053148000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/ssl/ca.cert.pem
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Certs
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/ssl/ca.cert.pem]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/ssl/win2012r2-agent.cert.pem]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/ssl/win2012r2-agent.cert.pem]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/server/certs.pp"
+    line: 42
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::certs: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        certs: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.053148000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/ssl/win2012r2-agent.cert.pem
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Certs
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/ssl/win2012r2-agent.cert.pem]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/ssl/win2012r2-agent.private_key.pem]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/ssl/win2012r2-agent.private_key.pem]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/server/certs.pp"
+    line: 46
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::certs: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        certs: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.053148000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/ssl/win2012r2-agent.private_key.pem
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Certs
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/ssl/win2012r2-agent.private_key.pem]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/ssl/mcollective-private.pem]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/ssl/mcollective-private.pem]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/server/certs.pp"
+    line: 50
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::certs: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        certs: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.053148000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/ssl/mcollective-private.pem
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Certs
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/ssl/mcollective-private.pem]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/ssl/mcollective-public.pem]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/ssl/mcollective-public.pem]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/server/certs.pp"
+    line: 56
+    evaluation_time: 0.015631
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::certs: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        certs: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.053148000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/ssl/mcollective-public.pem
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Certs
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/ssl/mcollective-public.pem]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/ssl/clients/puppet-dashboard-public.pem]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/ssl/clients/puppet-dashboard-public.pem]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/server/certs.pp"
+    line: 62
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::certs: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        certs: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.068779000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/ssl/clients/puppet-dashboard-public.pem
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Certs
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/ssl/clients/puppet-dashboard-public.pem]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/ssl/clients/peadmin-public.pem]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/ssl/clients/peadmin-public.pem]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/server/certs.pp"
+    line: 68
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server::certs: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        certs: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.068779000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/ssl/clients/peadmin-public.pem
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Certs
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/ssl/clients/peadmin-public.pem]
+  File[refresh-mcollective-metadata.bat]: !ruby/object:Puppet::Resource::Status
+    resource: File[refresh-mcollective-metadata.bat]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/server/facter.pp"
+    line: 31
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        refresh-mcollective-metadata.bat: true
+        class: true
+        puppet_enterprise::mcollective::server::facter: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        facter: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.068779000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: refresh-mcollective-metadata.bat
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Facter
+    - File[refresh-mcollective-metadata.bat]
+  File[refresh-mcollective-metadata.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[refresh-mcollective-metadata.rb]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/server/facter.pp"
+    line: 37
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        refresh-mcollective-metadata.rb: true
+        class: true
+        puppet_enterprise::mcollective::server::facter: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        facter: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.068779000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: refresh-mcollective-metadata.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Facter
+    - File[refresh-mcollective-metadata.rb]
+  Exec[bootstrap mcollective metadata]: !ruby/object:Puppet::Resource::Status
+    resource: Exec[bootstrap mcollective metadata]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/server/facter.pp"
+    line: 43
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        exec: true
+        class: true
+        puppet_enterprise::mcollective::server::facter: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        facter: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.068779000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: Exec
+    title: bootstrap mcollective metadata
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Facter
+    - Exec[bootstrap mcollective metadata]
+  Scheduled_task[pe-mcollective-metadata]: !ruby/object:Puppet::Resource::Status
+    resource: Scheduled_task[pe-mcollective-metadata]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/server/facter.pp"
+    line: 49
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        scheduled_task: true
+        pe-mcollective-metadata: true
+        class: true
+        puppet_enterprise::mcollective::server::facter: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        facter: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.084397000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: Scheduled_task
+    title: pe-mcollective-metadata
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server::Facter
+    - Scheduled_task[pe-mcollective-metadata]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/server.cfg]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/server.cfg]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/server.pp"
+    line: 64
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise: true
+        mcollective: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.084397000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/server.cfg
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Server
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/server.cfg]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/agent/discovery.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/agent/discovery.rb]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.084397000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/agent/discovery.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/agent/discovery.rb]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/agent/package.ddl]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/agent/package.ddl]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.084397000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/agent/package.ddl
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/agent/package.ddl]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/agent/package.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/agent/package.rb]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.084397000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/agent/package.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/agent/package.rb]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/agent/puppet.ddl]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/agent/puppet.ddl]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.084397000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/agent/puppet.ddl
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/agent/puppet.ddl]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/agent/puppet.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/agent/puppet.rb]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.084397000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/agent/puppet.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/agent/puppet.rb]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/agent/puppetral.ddl]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/agent/puppetral.ddl]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.084397000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/agent/puppetral.ddl
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/agent/puppetral.ddl]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/agent/puppetral.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/agent/puppetral.rb]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.084397000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/agent/puppetral.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/agent/puppetral.rb]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/agent/rpcutil.ddl]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/agent/rpcutil.ddl]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.084397000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/agent/rpcutil.ddl
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/agent/rpcutil.ddl]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/agent/rpcutil.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/agent/rpcutil.rb]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.084397000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/agent/rpcutil.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/agent/rpcutil.rb]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/agent/service.ddl]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/agent/service.ddl]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.084397000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/agent/service.ddl
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/agent/service.ddl]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/agent/service.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/agent/service.rb]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.084397000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/agent/service.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/agent/service.rb]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/aggregate/average.ddl]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/aggregate/average.ddl]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.084397000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/aggregate/average.ddl
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/aggregate/average.ddl]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/aggregate/average.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/aggregate/average.rb]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.084397000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/aggregate/average.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/aggregate/average.rb]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/aggregate/boolean_summary.ddl]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/aggregate/boolean_summary.ddl]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.084397000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/aggregate/boolean_summary.ddl
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/aggregate/boolean_summary.ddl]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/aggregate/boolean_summary.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/aggregate/boolean_summary.rb]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.084397000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/aggregate/boolean_summary.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/aggregate/boolean_summary.rb]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/aggregate/sum.ddl]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/aggregate/sum.ddl]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.015925
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.084397000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/aggregate/sum.ddl
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/aggregate/sum.ddl]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/aggregate/sum.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/aggregate/sum.rb]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.100322000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/aggregate/sum.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/aggregate/sum.rb]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/aggregate/summary.ddl]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/aggregate/summary.ddl]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.100322000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/aggregate/summary.ddl
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/aggregate/summary.ddl]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/aggregate/summary.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/aggregate/summary.rb]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.100322000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/aggregate/summary.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/aggregate/summary.rb]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/application/completion.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/application/completion.rb]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.100322000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/application/completion.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/application/completion.rb]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/application/facts.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/application/facts.rb]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.100322000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/application/facts.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/application/facts.rb]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/application/find.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/application/find.rb]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.100322000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/application/find.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/application/find.rb]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/application/help.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/application/help.rb]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.100322000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/application/help.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/application/help.rb]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/application/inventory.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/application/inventory.rb]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.100322000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/application/inventory.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/application/inventory.rb]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/application/package.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/application/package.rb]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.100322000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/application/package.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/application/package.rb]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/application/ping.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/application/ping.rb]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.100322000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/application/ping.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/application/ping.rb]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/application/plugin.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/application/plugin.rb]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.100322000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/application/plugin.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/application/plugin.rb]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/application/puppet.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/application/puppet.rb]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.100322000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/application/puppet.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/application/puppet.rb]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/application/rpc.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/application/rpc.rb]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.100322000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/application/rpc.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/application/rpc.rb]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/application/service.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/application/service.rb]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.100322000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/application/service.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/application/service.rb]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/audit/logfile.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/audit/logfile.rb]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.100322000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/audit/logfile.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/audit/logfile.rb]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/connector/activemq.ddl]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/connector/activemq.ddl]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.100322000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/connector/activemq.ddl
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/connector/activemq.ddl]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/connector/activemq.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/connector/activemq.rb]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.100322000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/connector/activemq.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/connector/activemq.rb]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/connector/rabbitmq.ddl]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/connector/rabbitmq.ddl]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.100322000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/connector/rabbitmq.ddl
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/connector/rabbitmq.ddl]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/connector/rabbitmq.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/connector/rabbitmq.rb]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.100322000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/connector/rabbitmq.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/connector/rabbitmq.rb]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/agent_data.ddl]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/agent_data.ddl]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.100322000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/agent_data.ddl
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/agent_data.ddl]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/agent_data.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/agent_data.rb]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.100322000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/agent_data.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/agent_data.rb]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/collective_data.ddl]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/collective_data.ddl]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.100322000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/collective_data.ddl
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/collective_data.ddl]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/collective_data.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/collective_data.rb]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.100322000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/collective_data.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/collective_data.rb]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/fact_data.ddl]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/fact_data.ddl]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.100322000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/fact_data.ddl
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/fact_data.ddl]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/fact_data.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/fact_data.rb]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.100322000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/fact_data.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/fact_data.rb]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/fstat_data.ddl]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/fstat_data.ddl]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.100322000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/fstat_data.ddl
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/fstat_data.ddl]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/fstat_data.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/fstat_data.rb]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.100322000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/fstat_data.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/fstat_data.rb]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/puppet_data.ddl]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/puppet_data.ddl]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.100322000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/puppet_data.ddl
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/puppet_data.ddl]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/puppet_data.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/puppet_data.rb]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.100322000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/puppet_data.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/puppet_data.rb]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/resource_data.ddl]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/resource_data.ddl]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.100322000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/resource_data.ddl
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/resource_data.ddl]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/resource_data.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/resource_data.rb]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.100322000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/resource_data.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/resource_data.rb]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/service_data.ddl]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/service_data.ddl]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.100322000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/service_data.ddl
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/service_data.ddl]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/service_data.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/service_data.rb]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.100322000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/service_data.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/data/service_data.rb]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/discovery/flatfile.ddl]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/discovery/flatfile.ddl]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.100322000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/discovery/flatfile.ddl
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/discovery/flatfile.ddl]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/discovery/flatfile.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/discovery/flatfile.rb]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.100322000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/discovery/flatfile.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/discovery/flatfile.rb]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/discovery/mc.ddl]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/discovery/mc.ddl]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.100322000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/discovery/mc.ddl
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/discovery/mc.ddl]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/discovery/mc.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/discovery/mc.rb]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.100322000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/discovery/mc.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/discovery/mc.rb]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/discovery/stdin.ddl]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/discovery/stdin.ddl]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.100322000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/discovery/stdin.ddl
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/discovery/stdin.ddl]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/discovery/stdin.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/discovery/stdin.rb]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.100322000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/discovery/stdin.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/discovery/stdin.rb]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/facts/yaml_facts.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/facts/yaml_facts.rb]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.100322000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/facts/yaml_facts.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/facts/yaml_facts.rb]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/registration/meta.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/registration/meta.rb]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.100322000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/registration/meta.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/registration/meta.rb]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/security/sshkey.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/security/sshkey.rb]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.100322000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/security/sshkey.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/security/sshkey.rb]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/util/package]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/util/package]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.100322000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/util/package
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/util/package]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/util/puppet_agent_mgr]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/util/puppet_agent_mgr]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.116498000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/util/puppet_agent_mgr
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/util/puppet_agent_mgr]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/util/service]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/util/service]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.116498000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/util/service
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/util/service]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/util/actionpolicy.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/util/actionpolicy.rb]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.116498000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/util/actionpolicy.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/util/actionpolicy.rb]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/util/puppet_agent_mgr.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/util/puppet_agent_mgr.rb]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.116498000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/util/puppet_agent_mgr.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/util/puppet_agent_mgr.rb]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/util/puppet_server_address_validation.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/util/puppet_server_address_validation.rb]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.116498000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/util/puppet_server_address_validation.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/util/puppet_server_address_validation.rb]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/util/puppetrunner.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/util/puppetrunner.rb]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.116498000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/util/puppetrunner.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/util/puppetrunner.rb]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/validator/puppet_resource_validator.ddl]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/validator/puppet_resource_validator.ddl]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.116498000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/validator/puppet_resource_validator.ddl
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/validator/puppet_resource_validator.ddl]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/validator/puppet_resource_validator.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/validator/puppet_resource_validator.rb]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.116498000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/validator/puppet_resource_validator.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/validator/puppet_resource_validator.rb]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/validator/puppet_server_address_validator.ddl]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/validator/puppet_server_address_validator.ddl]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.116498000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/validator/puppet_server_address_validator.ddl
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/validator/puppet_server_address_validator.ddl]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/validator/puppet_server_address_validator.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/validator/puppet_server_address_validator.rb]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.116498000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/validator/puppet_server_address_validator.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/validator/puppet_server_address_validator.rb]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/validator/puppet_tags_validator.ddl]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/validator/puppet_tags_validator.ddl]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.116498000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/validator/puppet_tags_validator.ddl
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/validator/puppet_tags_validator.ddl]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/validator/puppet_tags_validator.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/validator/puppet_tags_validator.rb]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.116498000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/validator/puppet_tags_validator.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/validator/puppet_tags_validator.rb]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/validator/puppet_variable_validator.ddl]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/validator/puppet_variable_validator.ddl]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.116498000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/validator/puppet_variable_validator.ddl
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/validator/puppet_variable_validator.ddl]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/validator/puppet_variable_validator.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/validator/puppet_variable_validator.rb]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.116498000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/validator/puppet_variable_validator.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/validator/puppet_variable_validator.rb]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/validator/service_name.ddl]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/validator/service_name.ddl]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.116498000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/validator/service_name.ddl
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/validator/service_name.ddl]
+  File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/validator/service_name.rb]: !ruby/object:Puppet::Resource::Status
+    resource: File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/validator/service_name.rb]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/cleanup.pp"
+    line: 88
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        file: true
+        class: true
+        puppet_enterprise::mcollective::cleanup: true
+        puppet_enterprise: true
+        mcollective: true
+        cleanup: true
+        puppet_enterprise::mcollective::server: true
+        server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.116498000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: File
+    title: C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/validator/service_name.rb
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Cleanup
+    - File[C:\ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/validator/service_name.rb]
+  Service[mcollective]: !ruby/object:Puppet::Resource::Status
+    resource: Service[mcollective]
+    file: "/opt/puppetlabs/puppet/modules/puppet_enterprise/manifests/mcollective/service.pp"
+    line: 3
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        service: true
+        mcollective: true
+        class: true
+        puppet_enterprise::mcollective::service: true
+        puppet_enterprise: true
+        puppet_enterprise::mcollective::server::facter: true
+        server: true
+        facter: true
+        puppet_enterprise::mcollective::server: true
+        puppet_enterprise::profile::mcollective::agent: true
+        profile: true
+        agent: true
+        node: true
+        default: true
+    time: 2016-02-24 23:07:42.116498000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: Service
+    title: mcollective
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Puppet_enterprise::Mcollective::Service
+    - Service[mcollective]
+  Exec[Create-Path-razorC-C:\inetpub\wwwroot\razorC]: !ruby/object:Puppet::Resource::Status
+    resource: Exec[Create-Path-razorC-C:\inetpub\wwwroot\razorC]
+    file: "/etc/puppetlabs/code/environments/production/modules/iis/manifests/createpath.pp"
+    line: 8
+    evaluation_time: 1.031322
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        exec: true
+        iis::createpath: true
+        iis: true
+        createpath: true
+        iis::manage_site: true
+        manage_site: true
+        razorc: true
+        class: true
+        windemo::mvcapp: true
+        windemo: true
+        mvcapp: true
+    time: 2016-02-24 23:07:42.116498000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: Exec
+    title: Create-Path-razorC-C:\inetpub\wwwroot\razorC
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Windemo::Mvcapp
+    - Iis::Manage_site[razorC]
+    - Iis::Createpath[razorC-C:\inetpub\wwwroot\razorC]
+    - Exec[Create-Path-razorC-C:\inetpub\wwwroot\razorC]
+  Exec[CreateSite-razorC]: !ruby/object:Puppet::Resource::Status
+    resource: Exec[CreateSite-razorC]
+    file: "/etc/puppetlabs/code/environments/production/modules/iis/manifests/manage_site.pp"
+    line: 32
+    evaluation_time: 1.014771
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        exec: true
+        createsite-razorc: true
+        iis::manage_site: true
+        iis: true
+        manage_site: true
+        razorc: true
+        class: true
+        windemo::mvcapp: true
+        windemo: true
+        mvcapp: true
+    time: 2016-02-24 23:07:43.147820000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: Exec
+    title: CreateSite-razorC
+    skipped: false
+    failed: false
+    containment_path:
+    - Stage[main]
+    - Windemo::Mvcapp
+    - Iis::Manage_site[razorC]
+    - Exec[CreateSite-razorC]
+  Schedule[puppet]: !ruby/object:Puppet::Resource::Status
+    resource: Schedule[puppet]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        schedule: true
+        puppet: true
+    time: 2016-02-24 23:07:44.162591000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: Schedule
+    title: puppet
+    skipped: false
+    failed: false
+    containment_path:
+    - Schedule[puppet]
+  Schedule[hourly]: !ruby/object:Puppet::Resource::Status
+    resource: Schedule[hourly]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        schedule: true
+        hourly: true
+    time: 2016-02-24 23:07:44.162591000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: Schedule
+    title: hourly
+    skipped: false
+    failed: false
+    containment_path:
+    - Schedule[hourly]
+  Schedule[daily]: !ruby/object:Puppet::Resource::Status
+    resource: Schedule[daily]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        schedule: true
+        daily: true
+    time: 2016-02-24 23:07:44.162591000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: Schedule
+    title: daily
+    skipped: false
+    failed: false
+    containment_path:
+    - Schedule[daily]
+  Schedule[weekly]: !ruby/object:Puppet::Resource::Status
+    resource: Schedule[weekly]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        schedule: true
+        weekly: true
+    time: 2016-02-24 23:07:44.162591000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: Schedule
+    title: weekly
+    skipped: false
+    failed: false
+    containment_path:
+    - Schedule[weekly]
+  Schedule[monthly]: !ruby/object:Puppet::Resource::Status
+    resource: Schedule[monthly]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        schedule: true
+        monthly: true
+    time: 2016-02-24 23:07:44.162591000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: Schedule
+    title: monthly
+    skipped: false
+    failed: false
+    containment_path:
+    - Schedule[monthly]
+  Schedule[never]: !ruby/object:Puppet::Resource::Status
+    resource: Schedule[never]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        schedule: true
+        never: true
+    time: 2016-02-24 23:07:44.162591000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: Schedule
+    title: never
+    skipped: false
+    failed: false
+    containment_path:
+    - Schedule[never]
+  Filebucket[puppet]: !ruby/object:Puppet::Resource::Status
+    resource: Filebucket[puppet]
+    file: 
+    line: 
+    evaluation_time: 0.0
+    change_count: 0
+    out_of_sync_count: 0
+    tags: !ruby/object:Puppet::Util::TagSet
+      hash:
+        filebucket: true
+        puppet: true
+    time: 2016-02-24 23:07:44.162591000 +00:00
+    events: []
+    out_of_sync: false
+    changed: false
+    resource_type: Filebucket
+    title: puppet
+    skipped: false
+    failed: false
+    containment_path:
+    - Filebucket[puppet]
+host: win2012r2-agent
+time: 2016-02-24 23:07:21.694017000 +00:00
+kind: apply
+report_format: 4
+puppet_version: 4.3.1
+configuration_version: 1456354776
+transaction_uuid: 691f00ee-86fa-4563-8b53-f60c1fdae601
+environment: production
+status: changed


### PR DESCRIPTION
Support parsing a last_run_report.yaml file containing Puppet objects -
sometimes introduced by resource types that don't serialize properly -
by dropping them from the report. We only look at a few known fields, so
it's safe to ignore the rest of the report.