### PR TITLE
(PCP-354) Acceptance - pcp-broker should use internal mirror for deps

### DIFF
--- a/acceptance/setup/common/050_Setup_Broker.rb
+++ b/acceptance/setup/common/050_Setup_Broker.rb
@@ -29,7 +29,7 @@ end
 step 'Run lein deps to download dependencies' do
   # 'lein tk' will download dependencies automatically, but downloading them will take
   # some time and will eat into the polling period we allow for the broker to start
-  on master, "cd #{GIT_CLONE_FOLDER}/pcp-broker; export LEIN_ROOT=ok; lein deps"
+  on master, "cd #{GIT_CLONE_FOLDER}/pcp-broker; export LEIN_ROOT=ok; lein with-profile internal-mirrors deps"
 end
 
 step 'Replace PCP test certs with the Puppet certs of this SUT' do


### PR DESCRIPTION
The acceptance test suite relies on being able to download all the dependencies for pcp-broker from clojars.org.
This commit changes the 'lein deps' command to use a new profile that will also add our internal clojar repo URL.

[skip ci]