### PR TITLE
(PCP-545) Force interpreting Puppet's output as UTF-8 in C/POSIX locale

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: cpp
 compiler:
   - gcc
 sudo: false
+ruby: '2.1.9'
 addons:
   apt:
     sources:
@@ -28,6 +29,7 @@ before_install:
   # Install pxp-agent's dependencies
   - wget https://github.com/puppetlabs/leatherman/releases/download/${LEATHERMAN_VERSION}/leatherman.tar.gz
   - tar xzvf leatherman.tar.gz -C $USERDIR
+  - rvm install 2.1.9
 
 script:
   - ./.travis_target.sh

--- a/modules/Gemfile
+++ b/modules/Gemfile
@@ -1,7 +1,5 @@
 source 'https://rubygems.org'
 
-# Older json_pure required to work with Ruby 1.9
-gem 'json_pure', '~> 1.8'
 gem 'puppet', '~> 4.2'
 
 group :test do

--- a/modules/pxp-module-puppet
+++ b/modules/pxp-module-puppet
@@ -68,12 +68,21 @@ def last_run_result(exitcode)
           "version"          => 1}
 end
 
+def force_unicode(s)
+  # Puppet still returns UTF-8 when locale is C or POSIX, so force encoding to that.
+  if s.encoding == Encoding::ASCII_8BIT
+    s.force_encoding(Encoding::UTF_8)
+  else
+    s
+  end
+end
+
 def check_config_print(cli_arg, config)
   command_array = [config["puppet_bin"], "agent", "--configprint", cli_arg]
   process_output = Puppet::Util::Execution.execute(command_array,
                                                    {:custom_environment => get_env_fix_up(),
                                                     :override_locale => false})
-  return process_output.to_s.chomp
+  return force_unicode(process_output.to_s).chomp
 end
 
 def running?(run_result)
@@ -160,7 +169,7 @@ def start_run(config, action_input)
   end
 
   exitcode = run_result.exitstatus
-  puppet_output = run_result.to_s
+  puppet_output = force_unicode(run_result.to_s)
 
   if disabled?(puppet_output)
     return make_error_result(exitcode, Errors::Disabled,


### PR DESCRIPTION
In a C/POSIX locale, Puppet will still output unicode as UTF-8. Ensure
we parse as UTF-8 despite the locale. Without this change regex
comparison throws an exception when attempting to compare against
ASCII_8BIT output.