### PR TITLE
(PCP-533) Merge test fix from master back to stable

### DIFF
--- a/acceptance/tests/pxp_agent_version.rb
+++ b/acceptance/tests/pxp_agent_version.rb
@@ -8,7 +8,9 @@ agents.each do |agent|
     # Vendored Ruby needs to be on path for Windows/cygwin.
     # Only do this for cygwin because other OSes (Cisco Nexus) do not handle setting env values inline.
     if windows?(agent) then
-      version_command = "PATH=\"#{agent['privatebindir']}:$PATH\"" + " " + version_command
+      puppet_bindir = '/cygdrive/c/Program Files (x86)/Puppet Labs/Puppet/puppet/bin:'+
+        '/cygdrive/c/Program Files/Puppet Labs/Puppet/puppet/bin'
+      version_command = "PATH=\"#{agent['privatebindir']}:#{puppet_bindir}:$PATH\"" + " " + version_command
     end
     on(agent, version_command) do |result|
       assert(/[0-9\.]*/ =~ result.stdout, "Version number should be numbers and periods but was \"#{result.stdout.to_s}\"")


### PR DESCRIPTION
The --version acceptance test requires a change to the lib path for Windows.
This commit copies the test fix from master back to stable.

[skip ci]