### PR TITLE
(PCP-545) Always force Puppet output to UTF-8

### DIFF
--- a/acceptance/tests/pxp-module-puppet/run_puppet_nonASCII.rb
+++ b/acceptance/tests/pxp-module-puppet/run_puppet_nonASCII.rb
@@ -11,7 +11,7 @@ test_name 'C98107 - Run puppet with non-ASCII characters in Puppet code' do
     site_manifest = "#{environmentpath}/#{environment_name}/manifests/site.pp"
     create_remote_file(master, site_manifest, <<-SITEPP)
 node default {
-  notify {'☃':}
+  notify {'ᚠᛇᚻ☃':}
 }
 SITEPP
     on(master, "chmod 644 #{site_manifest}")

--- a/modules/pxp-module-puppet
+++ b/modules/pxp-module-puppet
@@ -32,13 +32,19 @@ env_fix_up = nil
 # use this way of defining the `get_env_fix_up` method so that it can "see"
 # the `env_fix_up` variable
 self.class.send(:define_method, :get_env_fix_up) do
+  # If running in a C or POSIX locale, ask Puppet to use UTF-8
+  base_env = {}
+  if Encoding.default_external == Encoding::US_ASCII
+    base_env = {"RUBYOPT" => "#{ENV['RUBYOPT']} -EUTF-8"}
+  end
+
   # Prepare an environment fix-up to make up for its cleansing performed
   # by the Puppet::Util::Execution.execute function.
   # This fix-up is meant for running puppet under a non-root user;
   # puppet cannot find the user's HOME directory otherwise.
   env_fix_up ||= if Puppet.features.microsoft_windows? || Process.euid == 0
     # no environment fix-up is needed on windows or for root
-    {}
+    base_env
   else
     begin
       require 'etc'
@@ -47,13 +53,13 @@ self.class.send(:define_method, :get_env_fix_up) do
 
       {"USER"    => pwentry.name,
        "LOGNAME" => pwentry.name,
-       "HOME"    => pwentry.dir}
+       "HOME"    => pwentry.dir}.merge base_env
     rescue => e
       # oh well ..., let's give it a try without the environment fix-up
       myname = File.basename($0)
       $stderr.puts "#{myname}: Could not fix environment for effective UID #{Process.euid}: #{e.message}"
       $stderr.puts "#{myname}: Expect puppet run problems"
-      {}
+      base_env
     end
   end
 end
@@ -69,11 +75,13 @@ def last_run_result(exitcode)
 end
 
 def force_unicode(s)
-  # Puppet still returns UTF-8 when locale is C or POSIX, so force encoding to that.
-  if s.encoding == Encoding::ASCII_8BIT
+  begin
+    # Later comparisons assume UTF-8. Convert to that encoding now.
+    s.encode(Encoding::UTF_8)
+  rescue Encoding::InvalidByteSequenceError
+    # Found non-native characters, hope it's a UTF-8 string. Since this is Puppet, and
+    # incorrect characters probably means we're in a C or POSIX locale, this is usually safe.
     s.force_encoding(Encoding::UTF_8)
-  else
-    s
   end
 end
 

--- a/modules/spec/unit/modules/puppet_spec.rb
+++ b/modules/spec/unit/modules/puppet_spec.rb
@@ -42,7 +42,7 @@ describe "pxp-module-puppet" do
       expect(Puppet::Util::Execution).to receive(:execute).with(cli_vec,
                                                                 {:custom_environment => {"FIXVAR" => "fixvalue"},
                                                                  :override_locale => false}).
-                                                                 and_return("value☃".force_encoding(Encoding::ASCII_8BIT))
+                                                                 and_return("value☃".force_encoding(Encoding::US_ASCII))
       expect(check_config_print("value", default_configuration)).to be == "value☃"
     end
   end
@@ -292,8 +292,8 @@ describe "pxp-module-puppet" do
       start_run(default_configuration, default_input)
     end
 
-    it "processes output when puppet's output is ASCII_8BIT (POSIX or C locale) and contains non-ASCII" do
-      output = "everything normal, we're all fine here ☃".force_encoding(Encoding::ASCII_8BIT)
+    it "processes output when puppet's output is US_ASCII (POSIX or C locale) and contains non-ASCII" do
+      output = "everything normal, we're all fine here ☃".force_encoding(Encoding::US_ASCII)
       allow(Puppet::Util::Execution).to receive(:execute).and_return(output)
       allow(output).to receive(:exitstatus).and_return(0)
       allow(output).to receive(:to_s).and_return(output)


### PR DESCRIPTION
Puppet output is always UTF-8 encoded. Even if the locale implies
otherwise, interpret output as UTF-8.