### PR TITLE
(PCP-558) Give UTF8 test case its own acceptance test

### DIFF
--- a/acceptance/tests/pxp-module-puppet/run_puppet_nonASCII.rb
+++ b/acceptance/tests/pxp-module-puppet/run_puppet_nonASCII.rb
@@ -1,13 +1,14 @@
 require 'pxp-agent/test_helper.rb'
-
-ENVIRONMENT_NAME = 'non_ASCII'
+require 'puppet/acceptance/environment_utils'
 
 test_name 'C98107 - Run puppet with non-ASCII characters in Puppet code' do
+  extend Puppet::Acceptance::EnvironmentUtils
+
+  env_name = test_file_name = File.basename(__FILE__, '.*')
+  environment_name = mk_tmp_environment(env_name)
 
   step 'On master, create a new environment that includes a non-ASCII character and will result in Changed' do
-    environmentpath = master.puppet['environmentpath']
-    site_manifest = "#{environmentpath}/#{ENVIRONMENT_NAME}/manifests/site.pp"
-    on(master, "cp -r #{environmentpath}/production #{environmentpath}/#{ENVIRONMENT_NAME}")
+    site_manifest = "#{environmentpath}/#{environment_name}/manifests/site.pp"
     create_remote_file(master, site_manifest, <<-SITEPP)
 node default {
   notify {'☃':}
@@ -37,7 +38,7 @@ SITEPP
     begin
       responses = rpc_blocking_request(master, target_identities,
                                       'pxp-module-puppet', 'run',
-                                      {:env => [], :flags => ['--environment', ENVIRONMENT_NAME]})
+                                      {:env => [], :flags => ['--environment', environment_name]})
     rescue => exception
       fail("Exception occurred when trying to run Puppet on all agents: #{exception.message}")
     end
@@ -48,8 +49,8 @@ SITEPP
         # The test's pass/fail criteria is only the value of 'status'. However, if something goes wrong and Puppet needs to default
         # the environment to 'production' and results in 'unchanged' then it's better to fail specifically on the environment.
         assert(action_result.has_key?('environment'), "Results for pxp-module-puppet run on #{agent} should contain an 'environment' field")
-        assert_equal(ENVIRONMENT_NAME, action_result['environment'], "Result of pxp-module-puppet run on #{agent} should run with the "\
-                                                                     "#{ENVIRONMENT_NAME} environment")
+        assert_equal(environment_name, action_result['environment'], "Result of pxp-module-puppet run on #{agent} should run with the "\
+                                                                     "#{environment_name} environment")
         assert(action_result.has_key?('status'), "Results for pxp-module-puppet run on #{agent} should contain a 'status' field")
         assert_equal('changed', action_result['status'], "Result of pxp-module-puppet run on #{agent} should be 'changed'")
       end

--- a/acceptance/tests/pxp-module-puppet/run_puppet_nonASCII.rb
+++ b/acceptance/tests/pxp-module-puppet/run_puppet_nonASCII.rb
@@ -1,16 +1,16 @@
 require 'pxp-agent/test_helper.rb'
 
-ENVIRONMENT_NAME = 'changed_result'
+ENVIRONMENT_NAME = 'non_ASCII'
 
-test_name 'C93062 - Run puppet and expect \'changed\' result' do
+test_name 'C98107 - Run puppet with non-ASCII characters in Puppet code' do
 
-  step 'On master, create a new environment that will result in Changed' do
+  step 'On master, create a new environment that includes a non-ASCII character and will result in Changed' do
     environmentpath = master.puppet['environmentpath']
     site_manifest = "#{environmentpath}/#{ENVIRONMENT_NAME}/manifests/site.pp"
     on(master, "cp -r #{environmentpath}/production #{environmentpath}/#{ENVIRONMENT_NAME}")
     create_remote_file(master, site_manifest, <<-SITEPP)
 node default {
-  notify {'Notify resources cause a Puppet run to have a \\'changed\\' outcome':}
+  notify {'☃':}
 }
 SITEPP
     on(master, "chmod 644 #{site_manifest}")

--- a/acceptance/tests/pxp-module-puppet/run_puppet_nonASCII.rb
+++ b/acceptance/tests/pxp-module-puppet/run_puppet_nonASCII.rb
@@ -45,6 +45,8 @@ SITEPP
     agents.each_with_index do |agent|
       step "Check Run Puppet response for #{agent}" do
         identity = "pcp://#{agent}/agent"
+        assert(responses[identity][:data].has_key?("results"),
+              "Agent #{agent} received a response for rpc_blocking_request but it is missing a 'results' entry: #{responses[identity]}")
         action_result = responses[identity][:data]["results"]
         # The test's pass/fail criteria is only the value of 'status'. However, if something goes wrong and Puppet needs to default
         # the environment to 'production' and results in 'unchanged' then it's better to fail specifically on the environment.

--- a/acceptance/tests/pxp-module-puppet/run_puppet_result_changed.rb
+++ b/acceptance/tests/pxp-module-puppet/run_puppet_result_changed.rb
@@ -1,13 +1,14 @@
 require 'pxp-agent/test_helper.rb'
-
-ENVIRONMENT_NAME = 'changed_result'
+require 'puppet/acceptance/environment_utils'
 
 test_name 'C93062 - Run puppet and expect \'changed\' result' do
+  extend Puppet::Acceptance::EnvironmentUtils
+
+  env_name = test_file_name = File.basename(__FILE__, '.*')
+  environment_name = mk_tmp_environment(env_name)
 
   step 'On master, create a new environment that will result in Changed' do
-    environmentpath = master.puppet['environmentpath']
-    site_manifest = "#{environmentpath}/#{ENVIRONMENT_NAME}/manifests/site.pp"
-    on(master, "cp -r #{environmentpath}/production #{environmentpath}/#{ENVIRONMENT_NAME}")
+    site_manifest = "#{environmentpath}/#{environment_name}/manifests/site.pp"
     create_remote_file(master, site_manifest, <<-SITEPP)
 node default {
   notify {'Notify resources cause a Puppet run to have a \\'changed\\' outcome':}
@@ -37,7 +38,7 @@ SITEPP
     begin
       responses = rpc_blocking_request(master, target_identities,
                                       'pxp-module-puppet', 'run',
-                                      {:env => [], :flags => ['--environment', ENVIRONMENT_NAME]})
+                                      {:env => [], :flags => ['--environment', environment_name]})
     rescue => exception
       fail("Exception occurred when trying to run Puppet on all agents: #{exception.message}")
     end
@@ -48,8 +49,8 @@ SITEPP
         # The test's pass/fail criteria is only the value of 'status'. However, if something goes wrong and Puppet needs to default
         # the environment to 'production' and results in 'unchanged' then it's better to fail specifically on the environment.
         assert(action_result.has_key?('environment'), "Results for pxp-module-puppet run on #{agent} should contain an 'environment' field")
-        assert_equal(ENVIRONMENT_NAME, action_result['environment'], "Result of pxp-module-puppet run on #{agent} should run with the "\
-                                                                     "#{ENVIRONMENT_NAME} environment")
+        assert_equal(environment_name, action_result['environment'], "Result of pxp-module-puppet run on #{agent} should run with the "\
+                                                                     "#{environment_name} environment")
         assert(action_result.has_key?('status'), "Results for pxp-module-puppet run on #{agent} should contain a 'status' field")
         assert_equal('changed', action_result['status'], "Result of pxp-module-puppet run on #{agent} should be 'changed'")
       end


### PR DESCRIPTION
PCP-494 added a UTF8 character into an existing pxp-module-puppet test case to ensure we support them (commit 85e36fb).
This is currently failing on some platforms in CI (see PCP-558).
This PR splits the test with a UTF8 character into its own test, so it gets its own result in our result matrices. It also adds a specific assertion so that if PCP-494 does regress, we get an explicit assertion failure for it.

[skip ci]