### PR TITLE
(PCP-549) Wait for other Puppet runs to finish

### DIFF
--- a/acceptance/lib/pxp-agent/test_helper.rb
+++ b/acceptance/lib/pxp-agent/test_helper.rb
@@ -394,3 +394,112 @@ def have_all_rpc_responses?(targets, responses)
   end
   return true
 end
+
+# A suite of functions for creating a manifest that sleeps for a long period
+# and interacting with Puppet runs of that manifest.
+def create_sleep_manifest(master, manifest, seconds_to_sleep)
+    create_remote_file(master, manifest, <<-MODULEPP)
+node default {
+  case $::osfamily {
+    'windows': { exec { 'sleep': command => 'C:/Windows/system32/ping.exe 127.0.0.1 -n #{seconds_to_sleep}', returns => 1 } }
+    'Darwin':  { exec { 'sleep': command => '/bin/sleep #{seconds_to_sleep} || /usr/bin/true', } }
+    default:   { exec { 'sleep': command => '/bin/sleep #{seconds_to_sleep} || /bin/true', } }
+  }
+}
+MODULEPP
+    on(master, "chmod 644 #{manifest}")
+end
+
+def wait_for_sleep_process(target)
+  begin
+    ps_cmd = target['platform'] =~ /win/ ? 'ps -efW' : 'ps -ef'
+    sleep_process = target['platform'] =~ /win/ ? 'PING' : '/bin/sleep'
+    retry_on(target, "#{ps_cmd} | grep '#{sleep_process}' | grep -v 'grep'", {:max_retries => 15, :retry_interval => 2})
+  rescue
+    fail("After triggering a puppet run on #{target} the expected sleep process did not appear in process list")
+  end
+end
+
+def stop_sleep_process(targets)
+  targets = [targets].flatten
+
+  targets.each do |target|
+    case target['platform']
+    when /osx/
+      command = "ps -e -o pid,comm | grep sleep | sed 's/^[^0-9]*//g' | cut -d\\  -f1"
+    when /win/
+      command = "ps -efW | grep PING | sed 's/^[^0-9]*[0-9]*[^0-9]*//g' | cut -d ' ' -f1"
+    else
+      command = "ps -ef | grep 'bin/sleep ' | grep -v 'grep' | grep -v 'true' | sed 's/^[^0-9]*//g' | cut -d\\  -f1"
+    end
+
+    # A failed test may leave an orphaned sleep process, handle multiple matches.
+    pids = nil
+    on(target, command) do |output|
+      pids = output.stdout.chomp.split
+      if pids.empty?
+        fail('Did not find a pid for the sleep process holding up Puppet - cannot test PXP response if Puppet isn\'t sleeping')
+      end
+    end
+
+    pids.each do |pid|
+      target['platform'] =~ /win/ ?
+        on(target, "taskkill /F /pid #{pid}") :
+        on(target, "kill -s ALRM #{pid}")
+    end
+  end
+end
+
+# Initiates an rpc_non_blocking_request, verifies that it receives a provisional response for each target,
+# and returns the transaction ids.
+def start_puppet_non_blocking_request(broker, targets, environment = 'production')
+  transaction_ids = []
+
+  provisional_responses = nil
+  begin
+    provisional_responses = rpc_non_blocking_request(broker, targets,
+                                                     'pxp-module-puppet', 'run',
+                                                     {:flags => ['--onetime',
+                                                                 '--no-daemonize',
+                                                                 '--environment', environment]})
+  rescue => exception
+    fail("Exception occured when trying to send rpc_non_blocking_request to all agents: #{exception}")
+  end
+
+  targets.each do |identity|
+    assert_equal("http://puppetlabs.com/rpc_provisional_response",
+                 provisional_responses[identity][:envelope][:message_type],
+                 "Did not receive expected rpc_provisional_response in reply to non-blocking request")
+    transaction_ids << provisional_responses[identity][:data]["transaction_id"]
+  end
+  transaction_ids
+end
+
+def check_puppet_non_blocking_response(identity, transaction_id, max_retries, query_interval,
+                                       expected_result, expected_environment = 'production')
+  puppet_run_result = nil
+  query_attempts = 0
+  until (query_attempts == max_retries || puppet_run_result) do
+    query_responses = rpc_blocking_request(master, [identity],
+                                           'status', 'query', {:transaction_id => transaction_id})
+    action_result = query_responses[identity][:data]["results"]
+    assert(action_result, "Response to status query was an error: #{query_responses[identity][:data]}")
+    if (action_result.has_key?('stdout') && (action_result['stdout'] != ""))
+      rpc_action_status = action_result['status']
+      puppet_run_result = JSON.parse(action_result['stdout'])['status']
+      puppet_run_environment = JSON.parse(action_result['stdout'])['environment']
+    end
+    query_attempts += 1
+    if (!puppet_run_result)
+      sleep query_interval
+    end
+  end
+  if (!puppet_run_result)
+    fail("Run puppet non-blocking transaction did not contain stdout of puppet run after #{query_attempts} attempts " \
+         "and #{query_attempts * query_interval} seconds")
+  else
+    assert_equal("success", rpc_action_status, "PXP run puppet action did not have expected 'success' result")
+    assert_equal(expected_environment, puppet_run_environment, "Puppet run did not use the expected environment")
+    assert_equal(expected_result, puppet_run_result, "Puppet run did not have expected result of '#{expected_result}'")
+  end
+end

--- a/acceptance/tests/pxp-module-puppet/restart_pxp_agent_during_non_blocking_run.rb
+++ b/acceptance/tests/pxp-module-puppet/restart_pxp_agent_during_non_blocking_run.rb
@@ -1,25 +1,23 @@
 require 'pxp-agent/test_helper.rb'
+require 'puppet/acceptance/environment_utils'
 require 'json'
 
-ENVIRONMENT_NAME = 'sleep'
-MODULE_NAME = 'sleep'
 SECONDS_TO_SLEEP = 500 # The test will use SIGALARM to end this as soon as required
 STATUS_QUERY_MAX_RETRIES = 60
 STATUS_QUERY_INTERVAL_SECONDS = 5
 
 test_name 'C94705 - Run Puppet (non-blocking request) and restart pxp-agent service during run' do
+  extend Puppet::Acceptance::EnvironmentUtils
 
   applicable_agents = agents.select { |agent| agent['platform'] !~ /win/}
   if applicable_agents.empty? then
     skip_test('Skipping - All agent hosts are Windows and are not applicable to this test (see PCP-276)')
   end
 
-  master_environment_path = master.puppet['environmentpath']
+  env_name = test_file_name = File.basename(__FILE__, '.*')
+  environment_name = mk_tmp_environment(env_name)
 
   teardown do
-    unless master_environment_path.to_s == ''
-      on(master, "rm -rf #{master_environment_path}/#{ENVIRONMENT_NAME}")
-    end
     if (!applicable_agents.empty?)
       applicable_agents.each do |agent|
         # If puppet agent run has been left running by this test failing, terminate it
@@ -30,45 +28,9 @@ test_name 'C94705 - Run Puppet (non-blocking request) and restart pxp-agent serv
     end
   end
 
-  step 'On master, create a new environment with a module that will take some time to apply' do
-
-    # Create the environment in a unique tmp folder and create a symbolic link to the Puppet environmentpath
-    # The symbolic link will be deleted on teardown; but the tmp folder persists for debugging
-
-    step 'Create a temp dir for the environment'
-    tmp_environment_dir = master.tmpdir(ENVIRONMENT_NAME)
-    on(master, "chmod 655 #{tmp_environment_dir}")
-    on(master, "cp -r #{master_environment_path}/production/* #{tmp_environment_dir}")
-
-    step 'Create the site manifest file'
-    site_manifest = "#{tmp_environment_dir}/manifests/site.pp"
-    create_remote_file(master, site_manifest, <<-SITEPP)
-node default {
-  include #{MODULE_NAME}
-}
-SITEPP
-    on(master, "chmod 644 #{site_manifest}")
-
-    step 'Create a module that will execute sleep on the agent'
-    on(master, "mkdir -p #{tmp_environment_dir}/modules/#{MODULE_NAME}/manifests")
-    module_manifest = "#{tmp_environment_dir}/modules/#{MODULE_NAME}/manifests/init.pp"
-    create_remote_file(master, module_manifest, <<-MODULEPP)
-class #{MODULE_NAME} {
-  case $::osfamily {
-    'windows': { exec { 'sleep':
-                        command => 'true',
-                        unless  => 'sleep #{SECONDS_TO_SLEEP}', #PUP-5806
-                        path    => 'C:\\cygwin64\\bin',} }
-    'Darwin':  { exec { 'sleep': command => '/bin/sleep #{SECONDS_TO_SLEEP} || /usr/bin/true', } }
-    default:   { exec { 'sleep': command => '/bin/sleep #{SECONDS_TO_SLEEP} || /bin/true', } }
-  }
-}
-MODULEPP
-    on(master, "chmod 644 #{module_manifest}")
-
-    step 'Link the environment\'s temp dir to the actual Puppet environmentpath'
-    on(master, "rm -rf #{master_environment_path}/#{ENVIRONMENT_NAME}") # Ensure folder does not pre-exist, or ln will create link inside it
-    on(master, "ln -s #{tmp_environment_dir} #{master_environment_path}/#{ENVIRONMENT_NAME}")
+  step 'On master, create a new environment that will result in a slow run' do
+    site_manifest = "#{environmentpath}/#{environment_name}/manifests/site.pp"
+    create_sleep_manifest(master, site_manifest, SECONDS_TO_SLEEP)
   end
 
   step 'Ensure each agent host has pxp-agent running and associated' do
@@ -91,7 +53,7 @@ MODULEPP
                                       'pxp-module-puppet', 'run',
                                       {:env => [], :flags => ['--onetime',
                                                               '--no-daemonize',
-                                                              "--environment", "'#{ENVIRONMENT_NAME}'"]})
+                                                              "--environment", "'#{environment_name}'"]})
       assert_equal(provisional_responses[agent_identity][:envelope][:message_type],
                    "http://puppetlabs.com/rpc_provisional_response",
                    "Did not receive expected rpc_provisional_response in reply to non-blocking request")
@@ -99,11 +61,7 @@ MODULEPP
     end
 
     step 'Wait to ensure that Puppet has time to execute manifest' do
-      begin
-        retry_on(agent, "ps -ef | grep 'bin/sleep' | grep -v 'grep'", {:max_retries => 15, :retry_interval => 2})
-      rescue
-        fail("After triggering a puppet run on #{agent} the expected sleep process did not appear in process list")
-      end
+      wait_for_sleep_process(agent)
     end
 
     step "Restart pxp-agent service on #{agent}" do
@@ -112,45 +70,13 @@ MODULEPP
     end
 
     step 'Signal sleep process to end so Puppet run will complete' do
-      agent['platform'] =~ /osx/ ?
-        command = "ps -e -o pid,comm | grep sleep | sed 's/^[^0-9]*//g' | cut -d\\  -f1" :
-        command = "ps -ef | grep 'bin/sleep' | grep -v 'grep' | grep -v 'true' | sed 's/^[^0-9]*//g' | cut -d\\  -f1"
-      on(agent, command) do |output|
-        pid = output.stdout.chomp
-        if (!pid || pid == '')
-          fail('Did not find a pid for the sleep process holding up Puppet - cannot test PXP response if Puppet isn\'t sleeping')
-        end
-        agent['platform'] =~ /cisco_nexus/ ?
-          on(agent, "kill -s ALRM #{pid}") :
-          on(agent, "kill SIGALARM #{pid}")
-      end
+      stop_sleep_process(agent)
     end
 
     step 'Check response of puppet run' do
-      puppet_run_result = nil
-      query_attempts = 0
-      until (query_attempts == STATUS_QUERY_MAX_RETRIES || puppet_run_result) do
-        query_responses = rpc_blocking_request(master, [agent_identity],
-                                        'status', 'query', {:transaction_id => transaction_id})
-        action_result = query_responses[agent_identity][:data]["results"]
-        if (action_result.has_key?('stdout') && (action_result['stdout'] != ""))
-          rpc_action_status = action_result['status']
-          puppet_run_result = JSON.parse(action_result['stdout'])['status']
-          puppet_run_environment = JSON.parse(action_result['stdout'])['environment']
-        end
-        query_attempts += 1
-        if (!puppet_run_result)
-          sleep STATUS_QUERY_INTERVAL_SECONDS
-        end
-      end
-      if (!puppet_run_result)
-        fail("Run puppet non-blocking transaction did not contain stdout of puppet run after #{query_attempts} attempts " \
-             "and #{query_attempts * STATUS_QUERY_INTERVAL_SECONDS} seconds")
-      else
-        assert_equal(rpc_action_status, "success", "PXP run puppet action did not have expected 'success' result")
-        assert_equal(puppet_run_environment, ENVIRONMENT_NAME, "Puppet run did not use the expected environment")
-        assert_equal(puppet_run_result, "changed", "Puppet run did not have expected result of 'changed'")
-      end
+      check_puppet_non_blocking_response(agent_identity, transaction_id,
+                                         STATUS_QUERY_MAX_RETRIES, STATUS_QUERY_INTERVAL_SECONDS,
+                                         'changed', environment_name)
     end
   end
 end

--- a/acceptance/tests/pxp-module-puppet/run_puppet_during_puppet.rb
+++ b/acceptance/tests/pxp-module-puppet/run_puppet_during_puppet.rb
@@ -1,0 +1,95 @@
+require 'pxp-agent/test_helper.rb'
+require 'puppet/acceptance/environment_utils'
+
+test_name 'Run Puppet while a Puppet Agent run is in-progress, wait for completion' do
+  extend Puppet::Acceptance::EnvironmentUtils
+
+  env_name = test_file_name = File.basename(__FILE__, '.*')
+  environment_name = mk_tmp_environment(env_name)
+
+  step 'On master, create a new environment that will result in a slow run' do
+    site_manifest = "#{environmentpath}/#{environment_name}/manifests/site.pp"
+    create_remote_file(master, site_manifest, <<-SITEPP)
+node default {
+  case $::osfamily {
+    'windows': { exec { 'sleep':
+                        command => 'true',
+                        unless  => 'sleep 10', #PUP-5806
+                        path    => 'C:\\cygwin64\\bin',} }
+    default:  { exec { '/bin/sleep 10': } }
+  }
+}
+SITEPP
+    on(master, "chmod 644 #{site_manifest}")
+  end
+
+  step 'Ensure each agent host has pxp-agent running and associated' do
+    agents.each do |agent|
+      on agent, puppet('resource service pxp-agent ensure=stopped')
+      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
+      on agent, puppet('resource service pxp-agent ensure=running')
+      show_pcp_logs_on_failure do
+        assert(is_associated?(master, "pcp://#{agent}/agent"),
+               "Agent #{agent} with PCP identity pcp://#{agent}/agent should be associated with pcp-broker")
+      end
+    end
+  end
+
+  lockfiles = []
+  agents.each do |agent|
+    step "Get lockfile location for #{agent}" do
+      on agent, puppet('agent', '--configprint', 'agent_catalog_run_lockfile') do |result|
+        lockfiles << result.stdout.chomp
+      end
+    end
+  end
+
+  agents.each do |agent|
+    step "Start a long-running Puppet agent job on #{agent}" do
+      on agent, puppet('agent', '--test', '--environment', environment_name, '--server', "#{master}",
+                       '>/dev/null & echo $!')
+    end
+  end
+
+  # TODO: switch to checking all agents after each sleep
+  step 'Check for lockfile on agents' do
+    agents.zip(lockfiles).each do |agent, lockfile|
+      step "Check for lockfile on #{agent}" do
+        lockfile_exists = false
+        for i in 1..50
+          lockfile_exists |= agent.file_exist?(lockfile)
+          if lockfile_exists
+            break
+          end
+          sleep 0.2
+        end
+        assert(lockfile_exists, 'Agent run did not generate a lock file')
+      end
+    end
+  end
+
+  target_identities = []
+  agents.each do |agent|
+    target_identities << "pcp://#{agent}/agent"
+  end
+  responses = nil # Declare here so not local to begin/rescue below
+
+  step "Run Puppet on agents" do
+    begin
+      responses = rpc_blocking_request(master, target_identities,
+                                       'pxp-module-puppet', 'run',
+                                       {:flags => ['--onetime',
+                                                   '--no-daemonize']})
+    rescue => exception
+      fail("Exception occurred when trying to run Puppet on all agents: #{exception.message}")
+    end
+  end
+
+  target_identities.each do |identity|
+    step "Check response to blocking request for #{identity}" do
+      action_result = responses[identity][:data]["results"]
+      assert(action_result.has_key?('status'), "Results for pxp-module-puppet run on #{identity} should contain a 'status' field")
+      assert_equal('unchanged', action_result['status'], "Result of pxp-module-puppet run on #{identity} should be 'unchanged'")
+    end
+  end
+end

--- a/acceptance/tests/pxp-module-puppet/run_puppet_killed_puppet.rb
+++ b/acceptance/tests/pxp-module-puppet/run_puppet_killed_puppet.rb
@@ -1,0 +1,132 @@
+require 'pxp-agent/test_helper.rb'
+require 'pxp-agent/config_helper.rb'
+require 'puppet/acceptance/environment_utils'
+
+STATUS_QUERY_MAX_RETRIES = 60
+STATUS_QUERY_INTERVAL_SECONDS = 1
+
+test_name 'Run Puppet while a Puppet Agent run is in-progress, wait for it to be killed' do
+  extend Puppet::Acceptance::EnvironmentUtils
+
+  env_name = test_file_name = File.basename(__FILE__, '.*')
+  environment_name = mk_tmp_environment(env_name)
+
+  step 'On master, create a new environment that will result in a slow run' do
+    site_manifest = "#{environmentpath}/#{environment_name}/manifests/site.pp"
+    create_remote_file(master, site_manifest, <<-SITEPP)
+node default {
+  case $::osfamily {
+    'windows': { exec { 'sleep':
+                        command => 'true',
+                        unless  => 'sleep 10', #PUP-5806
+                        path    => 'C:\\cygwin64\\bin',} }
+    default:  { exec { '/bin/sleep 30': } }
+  }
+}
+SITEPP
+    on(master, "chmod 644 #{site_manifest}")
+  end
+
+  step 'Ensure each agent host has pxp-agent running and associated' do
+    agents.each do |agent|
+      on agent, puppet('resource service pxp-agent ensure=stopped')
+      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
+      on agent, puppet('resource service pxp-agent ensure=running')
+      show_pcp_logs_on_failure do
+        assert(is_associated?(master, "pcp://#{agent}/agent"),
+               "Agent #{agent} with PCP identity pcp://#{agent}/agent should be associated with pcp-broker")
+      end
+    end
+  end
+
+  lockfiles = []
+  agents.each do |agent|
+    step "Get lockfile location for #{agent}" do
+      on agent, puppet('agent', '--configprint', 'agent_catalog_run_lockfile') do |result|
+        lockfiles << result.stdout.chomp
+      end
+    end
+  end
+
+  agents.each do |agent|
+    step "Start a long-running Puppet agent job on #{agent}" do
+      on agent, puppet('agent', '--test', '--environment', environment_name, '--server', "#{master}",
+                       '>/dev/null & echo $!')
+    end
+  end
+
+  # TODO: switch to checking all agents after each sleep
+  agents.zip(lockfiles).each do |agent, lockfile|
+    step "Check for lockfile on #{agent}" do
+      lockfile_exists = false
+      for i in 1..50
+        lockfile_exists |= agent.file_exist?(lockfile)
+        if lockfile_exists
+          break
+        end
+        sleep 0.2
+      end
+      assert(lockfile_exists, 'Agent run did not generate a lock file')
+    end
+  end
+
+  target_identities = []
+  agents.each do |agent|
+    target_identities << "pcp://#{agent}/agent"
+  end
+
+  transaction_ids = []
+  step "Run Puppet on #{agent}" do
+    provisional_responses = rpc_non_blocking_request(master, target_identities,
+                                                     'pxp-module-puppet', 'run',
+                                                     {:flags => ['--onetime',
+                                                                 '--no-daemonize']})
+    target_identities.each do |identity|
+      assert_equal("http://puppetlabs.com/rpc_provisional_response",
+                   provisional_responses[identity][:envelope][:message_type],
+                   "Did not receive expected rpc_provisional_response in reply to non-blocking request")
+      transaction_ids << provisional_responses[identity][:data]["transaction_id"]
+    end
+  end
+
+  # Ensure time has passed for pxp-module-puppet to begin waiting
+  sleep 3
+
+  agents.zip(lockfiles).each do |agent, lockfile|
+    step "Kill the first agent run on #{agent}" do
+      assert(agent.file_exist?(lockfile), 'First agent run completed before non-blocking-request returned')
+      if windows?(agent)
+        on agent, "taskkill /pid `cat #{lockfile}`"
+      else
+        on agent, "kill -9 `cat #{lockfile}`"
+      end
+    end
+  end
+
+  target_identities.zip(transaction_ids).each do |identity, transaction_id|
+    step "Check response to blocking request for #{identity}" do
+      puppet_run_result = nil
+      query_attempts = 0
+      until (query_attempts == STATUS_QUERY_MAX_RETRIES || puppet_run_result) do
+        query_responses = rpc_blocking_request(master, [identity],
+                                               'status', 'query', {:transaction_id => transaction_id})
+        action_result = query_responses[identity][:data]["results"]
+        if (action_result.has_key?('stdout') && (action_result['stdout'] != ""))
+          rpc_action_status = action_result['status']
+          puppet_run_result = JSON.parse(action_result['stdout'])['status']
+        end
+        query_attempts += 1
+        if (!puppet_run_result)
+          sleep STATUS_QUERY_INTERVAL_SECONDS
+        end
+      end
+      if (!puppet_run_result)
+        fail("Run puppet non-blocking transaction did not contain stdout of puppet run after #{query_attempts} attempts " \
+             "and #{query_attempts * STATUS_QUERY_INTERVAL_SECONDS} seconds")
+      else
+        assert_equal("success", rpc_action_status, "PXP run puppet action did not have expected 'success' result")
+        assert_equal("unchanged", puppet_run_result, "Puppet run did not have expected result of 'unchanged'")
+      end
+    end
+  end
+end

--- a/acceptance/tests/pxp-module-puppet/run_puppet_twice.rb
+++ b/acceptance/tests/pxp-module-puppet/run_puppet_twice.rb
@@ -1,0 +1,95 @@
+require 'pxp-agent/test_helper.rb'
+require 'puppet/acceptance/environment_utils'
+
+test_name 'Run Puppet while a Puppet Agent run is in-progress, wait for completion' do
+  extend Puppet::Acceptance::EnvironmentUtils
+
+  env_name = test_file_name = File.basename(__FILE__, '.*')
+  environment_name = mk_tmp_environment(env_name)
+
+  step 'On master, create a new environment that will result in a slow run' do
+    site_manifest = "#{environmentpath}/#{environment_name}/manifests/site.pp"
+    create_remote_file(master, site_manifest, <<-SITEPP)
+node default {
+  case $::osfamily {
+    'windows': { exec { 'sleep':
+                        command => 'true',
+                        unless  => 'sleep 10', #PUP-5806
+                        path    => 'C:\\cygwin64\\bin',} }
+    default:  { exec { '/bin/sleep 10': } }
+  }
+}
+SITEPP
+    on(master, "chmod 644 #{site_manifest}")
+  end
+
+  step 'Ensure each agent host has pxp-agent running and associated' do
+    agents.each do |agent|
+      on agent, puppet('resource service pxp-agent ensure=stopped')
+      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
+      on agent, puppet('resource service pxp-agent ensure=running')
+      show_pcp_logs_on_failure do
+        assert(is_associated?(master, "pcp://#{agent}/agent"),
+               "Agent #{agent} with PCP identity pcp://#{agent}/agent should be associated with pcp-broker")
+      end
+    end
+  end
+
+  step 'Send two requests to all agents, the first with a long-running task' do
+    target_identities = []
+    agents.each do |agent|
+      target_identities << "pcp://#{agent}/agent"
+    end
+
+    provisional_responses = rpc_non_blocking_request(master, target_identities,
+                                                     'pxp-module-puppet', 'run',
+                                                     {:flags => ['--onetime',
+                                                                 '--no-daemonize',
+                                                                 '--environment', environment_name]})
+
+    responses = nil # Declare here so not local to begin/rescue below
+    begin
+      responses = rpc_blocking_request(master, target_identities,
+                                      'pxp-module-puppet', 'run',
+                                      {:flags => ['--onetime',
+                                                  '--no-daemonize']})
+    rescue => exception
+      fail("Exception occurred when trying to run Puppet on all agents: #{exception.message}")
+    end
+
+    agents.each_with_index do |agent|
+      identity = "pcp://#{agent}/agent"
+
+      step "Check response to non-blocking request for #{agent}" do
+        # The first runs should be done, because the 2nd run shouldn't have even started until
+        # the first finished.
+        assert_equal("http://puppetlabs.com/rpc_provisional_response",
+                     provisional_responses[identity][:envelope][:message_type],
+                     "Did not receive expected rpc_provisional_response in reply to non-blocking request")
+        transaction_id = provisional_responses[identity][:data]["transaction_id"]
+
+        query_responses = rpc_blocking_request(master, [identity],
+                                               'status', 'query', {:transaction_id => transaction_id})
+        action_result = query_responses[identity][:data]["results"]
+
+        puppet_run_result = nil
+        rpc_action_status = action_result['status']
+        if (action_result.has_key?('stdout') && (action_result['stdout'] != ""))
+          puppet_run_result = JSON.parse(action_result['stdout'])['status']
+        end
+
+        if (!puppet_run_result)
+          fail("Run puppet non-blocking transaction did not contain stdout of puppet run")
+        else
+          assert_equal("success", rpc_action_status, "PXP run puppet action did not have expected 'success' result")
+        end
+      end
+
+      step "Check response to blocking request for #{agent}" do
+        action_result = responses[identity][:data]["results"]
+        assert(action_result.has_key?('status'), "Results for pxp-module-puppet run on #{agent} should contain a 'status' field")
+        assert_equal('unchanged', action_result['status'], "Result of pxp-module-puppet run on #{agent} should be 'unchanged'")
+      end
+    end
+  end
+end

--- a/acceptance/tests/pxp-module-puppet/run_puppet_twice.rb
+++ b/acceptance/tests/pxp-module-puppet/run_puppet_twice.rb
@@ -1,6 +1,10 @@
 require 'pxp-agent/test_helper.rb'
 require 'puppet/acceptance/environment_utils'
 
+SECONDS_TO_SLEEP = 500 # The test will use SIGALARM to end this as soon as required
+STATUS_QUERY_MAX_RETRIES = 60
+STATUS_QUERY_INTERVAL_SECONDS = 1
+
 test_name 'Run Puppet while a Puppet Agent run is in-progress, wait for completion' do
   extend Puppet::Acceptance::EnvironmentUtils
 
@@ -9,18 +13,7 @@ test_name 'Run Puppet while a Puppet Agent run is in-progress, wait for completi
 
   step 'On master, create a new environment that will result in a slow run' do
     site_manifest = "#{environmentpath}/#{environment_name}/manifests/site.pp"
-    create_remote_file(master, site_manifest, <<-SITEPP)
-node default {
-  case $::osfamily {
-    'windows': { exec { 'sleep':
-                        command => 'true',
-                        unless  => 'sleep 10', #PUP-5806
-                        path    => 'C:\\cygwin64\\bin',} }
-    default:  { exec { '/bin/sleep 10': } }
-  }
-}
-SITEPP
-    on(master, "chmod 644 #{site_manifest}")
+    create_sleep_manifest(master, site_manifest, SECONDS_TO_SLEEP)
   end
 
   step 'Ensure each agent host has pxp-agent running and associated' do
@@ -35,61 +28,44 @@ SITEPP
     end
   end
 
-  step 'Send two requests to all agents, the first with a long-running task' do
-    target_identities = []
+  target_identities = []
+  agents.each do |agent|
+    target_identities << "pcp://#{agent}/agent"
+  end
+
+  transaction_ids = []
+  step 'Run Puppet on agents with long-running catalog' do
+    transaction_ids = start_puppet_non_blocking_request(master, target_identities, environment_name)
+  end
+
+  step 'Wait until Puppet starts executing' do
     agents.each do |agent|
-      target_identities << "pcp://#{agent}/agent"
+      wait_for_sleep_process(agent)
     end
+  end
 
-    provisional_responses = rpc_non_blocking_request(master, target_identities,
-                                                     'pxp-module-puppet', 'run',
-                                                     {:flags => ['--onetime',
-                                                                 '--no-daemonize',
-                                                                 '--environment', environment_name]})
+  transaction_ids_2 = []
+  step 'Run Puppet on agents again' do
+    transaction_ids_2 = start_puppet_non_blocking_request(master, target_identities)
+  end
 
-    responses = nil # Declare here so not local to begin/rescue below
-    begin
-      responses = rpc_blocking_request(master, target_identities,
-                                      'pxp-module-puppet', 'run',
-                                      {:flags => ['--onetime',
-                                                  '--no-daemonize']})
-    rescue => exception
-      fail("Exception occurred when trying to run Puppet on all agents: #{exception.message}")
+  step 'Signal sleep process to end so 1st Puppet run will complete' do
+    stop_sleep_process(agents)
+  end
+
+  target_identities.zip(transaction_ids).each do |identity, transaction_id|
+    step "Check response to 1st non-blocking request for #{identity}" do
+      check_puppet_non_blocking_response(identity, transaction_id,
+                                         STATUS_QUERY_MAX_RETRIES, STATUS_QUERY_INTERVAL_SECONDS,
+                                         'changed', environment_name)
     end
+  end
 
-    agents.each_with_index do |agent|
-      identity = "pcp://#{agent}/agent"
-
-      step "Check response to non-blocking request for #{agent}" do
-        # The first runs should be done, because the 2nd run shouldn't have even started until
-        # the first finished.
-        assert_equal("http://puppetlabs.com/rpc_provisional_response",
-                     provisional_responses[identity][:envelope][:message_type],
-                     "Did not receive expected rpc_provisional_response in reply to non-blocking request")
-        transaction_id = provisional_responses[identity][:data]["transaction_id"]
-
-        query_responses = rpc_blocking_request(master, [identity],
-                                               'status', 'query', {:transaction_id => transaction_id})
-        action_result = query_responses[identity][:data]["results"]
-
-        puppet_run_result = nil
-        rpc_action_status = action_result['status']
-        if (action_result.has_key?('stdout') && (action_result['stdout'] != ""))
-          puppet_run_result = JSON.parse(action_result['stdout'])['status']
-        end
-
-        if (!puppet_run_result)
-          fail("Run puppet non-blocking transaction did not contain stdout of puppet run")
-        else
-          assert_equal("success", rpc_action_status, "PXP run puppet action did not have expected 'success' result")
-        end
-      end
-
-      step "Check response to blocking request for #{agent}" do
-        action_result = responses[identity][:data]["results"]
-        assert(action_result.has_key?('status'), "Results for pxp-module-puppet run on #{agent} should contain a 'status' field")
-        assert_equal('unchanged', action_result['status'], "Result of pxp-module-puppet run on #{agent} should be 'unchanged'")
-      end
+  target_identities.zip(transaction_ids_2).each do |identity, transaction_id, transaction_id_2|
+    step "Check response to 2nd non-blocking request for #{identity}" do
+      check_puppet_non_blocking_response(identity, transaction_id,
+                                         STATUS_QUERY_MAX_RETRIES, STATUS_QUERY_INTERVAL_SECONDS,
+                                         'unchanged')
     end
   end
 end

--- a/modules/pxp-module-puppet
+++ b/modules/pxp-module-puppet
@@ -169,6 +169,12 @@ def get_result_from_report(last_run_report, exitcode, config, start_time)
   return run_result
 end
 
+def wait_for_lockfile(lockfile = '')
+  while File.exist?(lockfile)
+    sleep 0.1
+  end
+end
+
 def start_run(config, action_input)
   exitcode = DEFAULT_EXITCODE
   cmd = make_command_array(config, action_input)
@@ -179,29 +185,44 @@ def start_run(config, action_input)
     return make_error_result(exitcode, Errors::NoLastRunReport,
                              "could not find the location of the last run report")
   end
-  start_time = File.mtime(last_run_report) if File.exist?(last_run_report)
 
-  run_result = Puppet::Util::Execution.execute(cmd, {:failonfail => false,
-                                                     :custom_environment => env,
-                                                     :override_locale => false})
+  # Initially ignore the lockfile. It might be out-dated, so we give Puppet a chance
+  # to clean it up and run.
+  lockfile = ''
+  while true
+    wait_for_lockfile(lockfile)
 
-  if !run_result
-    return make_error_result(exitcode, Errors::FailedToStart,
-                             "Failed to start Puppet agent")
+    start_time = File.mtime(last_run_report) if File.exist?(last_run_report)
+
+    run_result = Puppet::Util::Execution.execute(cmd, {:failonfail => false,
+                                                       :custom_environment => env,
+                                                       :override_locale => false})
+
+    if !run_result
+      return make_error_result(exitcode, Errors::FailedToStart,
+                               "Failed to start Puppet agent")
+    end
+
+    exitcode = run_result.exitstatus
+    puppet_output = force_unicode(run_result.to_s)
+
+    if disabled?(puppet_output)
+      return make_error_result(exitcode, Errors::Disabled,
+                               "Puppet agent is disabled")
+    elsif running?(puppet_output)
+      # Puppet is already running, attempt to wait until it finishes and retry.
+      lockfile = check_config_print('agent_catalog_run_lockfile', config)
+      if lockfile.empty?
+        # Can't identify lockfile, just report an error.
+        return make_error_result(exitcode, Errors::AlreadyRunning,
+                                 "Puppet agent is already performing a run; it also appears to be" +
+                                 " misconfigured, agent_catalog_run_lockfile is an empty string")
+      end
+      next
+    end
+
+    return get_result_from_report(last_run_report, exitcode, config, start_time)
   end
-
-  exitcode = run_result.exitstatus
-  puppet_output = force_unicode(run_result.to_s)
-
-  if disabled?(puppet_output)
-    return make_error_result(exitcode, Errors::Disabled,
-                             "Puppet agent is disabled")
-  elsif running?(puppet_output)
-    return make_error_result(exitcode, Errors::AlreadyRunning,
-                             "Puppet agent is already performing a run")
-  end
-
-  return get_result_from_report(last_run_report, exitcode, config, start_time)
 end
 
 # TODO(ale): remove `env` from input before bumping to the next version

--- a/modules/pxp-module-puppet
+++ b/modules/pxp-module-puppet
@@ -169,9 +169,13 @@ def get_result_from_report(last_run_report, exitcode, config, start_time)
   return run_result
 end
 
-def wait_for_lockfile(lockfile = '')
-  while File.exist?(lockfile)
-    sleep 0.1
+# Wait for the lockfile to be removed. If it hasn't after 30 seconds, give up.
+def wait_for_lockfile(lockfile = '', check_interval = 0.1, give_up_after = 30)
+  number_of_tries = give_up_after / check_interval
+  count = 0
+  while File.exist?(lockfile) && count < number_of_tries
+    sleep check_interval
+    count += 1
   end
 end
 


### PR DESCRIPTION
When `pxp-module-puppet run` is triggered and Puppet was already
running, the module would previously identify the failure and return an
error message saying Puppet could not be run because another run was in
progress. This leads to a potentially slow feedback cycle of retrying
Puppet until it can run, when all the module user wants is to ensure a
Puppet run happens with the arguments they specified.

Change pxp-module-puppet to wait until the prior Puppet run completes
and attempt to run again until it succeeds or encounters a different
error.