### PR TITLE
(maint) Fix Rakefile when specifying BEAKER_HOSTS

### DIFF
--- a/acceptance/Rakefile
+++ b/acceptance/Rakefile
@@ -88,7 +88,7 @@ EOS
 
   target = ENV['TEST_TARGET']
   master_host = ENV['MASTER_TEST_TARGET'] || 'redhat7-64m'
-  if !target.start_with?(master_host)
+  if target && !target.start_with?(master_host)
     target = "#{master_host}-#{target}"
   end
   if config and File.exists?(config)


### PR DESCRIPTION
When specifying BEAKER_HOSTS, TEST_TARGET does not need to be set.
However, the Rakefile errors if run without TEST_TARGET set. Update to
check that TEST_TARGET is not nil before trying to check start_with.