### PR TITLE
(PCP-571) Fix tests failing with Puppet timing out

### DIFF
--- a/acceptance/tests/pxp-module-puppet/run_puppet_during_puppet.rb
+++ b/acceptance/tests/pxp-module-puppet/run_puppet_during_puppet.rb
@@ -31,7 +31,7 @@ test_name 'Run Puppet while a Puppet Agent run is in-progress, wait for completi
   step 'Start long-running Puppet agent jobs' do
     agents.each do |agent|
       on agent, puppet('agent', '--test', '--environment', environment_name, '--server', "#{master}",
-                       '>/dev/null & echo $!')
+                       '</dev/null >/dev/null 2>&1 & echo $!')
     end
   end
 

--- a/acceptance/tests/pxp-module-puppet/run_puppet_killed_puppet.rb
+++ b/acceptance/tests/pxp-module-puppet/run_puppet_killed_puppet.rb
@@ -33,7 +33,7 @@ test_name 'Run Puppet while a Puppet Agent run is in-progress, wait for it to be
 
     agents.each do |agent|
       on agent, puppet('agent', '--test', '--environment', environment_name, '--server', "#{master}",
-                       '>/dev/null & echo $!')
+                       '</dev/null >/dev/null 2>&1 & echo $!')
     end
   end
 


### PR DESCRIPTION
On certain platforms the shell command to run Puppet in the background
was incorrect, leading to Puppet timing out. Fix shell commands.