### PR TITLE
(PCP-557) Ensure broker runs with internal mirrors

### DIFF
--- a/.travis_target.sh
+++ b/.travis_target.sh
@@ -14,7 +14,7 @@ export CC=gcc-4.8 CXX=g++-4.8
 get_gettext() {
   wget https://s3.amazonaws.com/kylo-pl-bucket/gettext-0.19.6_install.tar.bz2
   tar xjvf gettext-0.19.6_install.tar.bz2 --strip 1 -C $USERDIR
-  rm -f ../locales/cpp-pcp-client.pot
+  rm -f ../locales/pxp-agent.pot
 }
 
 if [ ${TRAVIS_TARGET} == CPPCHECK ]; then

--- a/acceptance/lib/pxp-agent/test_helper.rb
+++ b/acceptance/lib/pxp-agent/test_helper.rb
@@ -71,7 +71,8 @@ end
 # Some helpers for working with a pcp-broker 'lein tk' instance
 def run_pcp_broker(host, instance=0)
   host[:pcp_broker_instance] = instance
-  on(host, "cd #{GIT_CLONE_FOLDER}/pcp-broker#{instance}; export LEIN_ROOT=ok; lein tk </dev/null >/var/log/pcp-broker.log 2>&1 &")
+  on(host, "cd #{GIT_CLONE_FOLDER}/pcp-broker#{instance}; export LEIN_ROOT=ok; \
+     lein with-profile internal-mirrors tk </dev/null >/var/log/pcp-broker.log 2>&1 &")
   assert(port_open_within?(host, PCP_BROKER_PORTS[instance], 60),
          "pcp-broker port #{PCP_BROKER_PORTS[instance].to_s} not open within 1 minutes of starting the broker")
   broker_state = nil


### PR DESCRIPTION
Periodically starting the broker will take a long time. It appears to be
downloading dependencies when `lein tk` is run, despite `lein deps`
being previously run. This is probably because we ran `lein with-profile
internal-mirrors deps`, but then run `lein tk` with a different profile.
Update to run `lein with-profile internal-mirrors tk`.

Also cherry-picks up fixing the Travis CI script. I apparently targeted that at master by accident.