### PR TITLE
(PCP-572) Update how acceptance terminates sleep processes

### DIFF
--- a/acceptance/tests/pxp-module-puppet/restart_pxp_agent_during_non_blocking_run.rb
+++ b/acceptance/tests/pxp-module-puppet/restart_pxp_agent_during_non_blocking_run.rb
@@ -14,6 +14,12 @@ test_name 'C94705 - Run Puppet (non-blocking request) and restart pxp-agent serv
     skip_test('Skipping - All agent hosts are Windows and are not applicable to this test (see PCP-276)')
   end
 
+  teardown do
+    unless applicable_agents.empty? then
+      stop_sleep_process(applicable_agents, true)
+    end
+  end  
+
   env_name = test_file_name = File.basename(__FILE__, '.*')
   environment_name = mk_tmp_environment(env_name)
 

--- a/acceptance/tests/pxp-module-puppet/run_puppet_twice.rb
+++ b/acceptance/tests/pxp-module-puppet/run_puppet_twice.rb
@@ -11,6 +11,10 @@ test_name 'Run Puppet while a Puppet Agent run is in-progress, wait for completi
   env_name = test_file_name = File.basename(__FILE__, '.*')
   environment_name = mk_tmp_environment(env_name)
 
+  teardown do
+    stop_sleep_process(agents, true)
+  end
+
   step 'On master, create a new environment that will result in a slow run' do
     site_manifest = "#{environmentpath}/#{environment_name}/manifests/site.pp"
     create_sleep_manifest(master, site_manifest, SECONDS_TO_SLEEP)


### PR DESCRIPTION
The method of ending a running sleep process using SIGALRM does not work on Solaris 10.
We don't need SIGALRM specifically, we just need 'sleep' to terminate; so this commit sends SIGTERM instead of SIGALRM.

Because the Solaris failure caused knock-on failures in other tests; this commit also adds a teardown to the tests that make use of sleep/kill.

[skip ci]