### PR TITLE
(PCP-577) Don't run tests that restart broker

### DIFF
--- a/acceptance/tests/restart_host_run_puppet.rb
+++ b/acceptance/tests/restart_host_run_puppet.rb
@@ -2,7 +2,7 @@ require 'pxp-agent/test_helper.rb'
 
 test_name 'C94777 - Ensure pxp-agent functions after agent host restart' do
 
-  applicable_agents = agents.select { |agent| agent['platform'] !~ /aix/}
+  applicable_agents = agents.select { |agent| agent['platform'] !~ /aix/ && !agent['roles'].include?('master') }
   unless applicable_agents.length > 0 then
     skip_test('All agent hosts are AIX and QENG-3629 prevents AIX hosts being restarted')
   end


### PR DESCRIPTION
Don't restart the broker when running tests to restart pxp-agent. This
prevents restarting the agent host when that host also includes the
master role, so that we only restart agents that don't include the
broker.