### PR TITLE
(maint) Add MAINTAINERS file

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,36 @@
+{
+  "version": 1,
+  "file_format": "This MAINTAINERS file format is described at http://pup.pt/maintainers",
+  "issues": "https://tickets.puppet.com/browse/PCP",
+  "people": [
+    {
+      "github": "MikaelSmith",
+      "email": "michael.smith@puppet.com",
+      "name": "Michael Smith"
+    },
+    {
+      "github": "kylog",
+      "email": "kylo@puppet.com",
+      "name": "Kylo Ginsberg"
+    },
+    {
+      "github": "er0ck",
+      "email": "eric.thompson@puppet.com",
+      "name": "Eric Thompson"
+    },
+    {
+      "github": "mruzicka",
+      "name": "Michal Růžička"
+    },
+    {
+      "github": "james-stocks",
+      "email": "james.stocks@puppet.com",
+      "name": "James Stocks"
+    },
+    {
+      "github": "parisiale",
+      "email": "alessandro@puppet.com",
+      "name": "Alessandro Parisi"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -355,15 +355,9 @@ Don't become a daemon and execute on foreground on the associated terminal.
 
 The path of the PID file; the default is */var/run/puppetlabs/pxp-agent.pid*
 
-## Maintenance
+## Contributing
 
-Maintainers: Alessandro Parisi <alessandro@puppet.com>, Michael Smith
-<michael.smith@puppet.com>, Michal Ruzicka <michal.ruzicka@puppet.com>.
-
-Contributing: Please refer to [this][contributing] document.
-
-Tickets: File bug tickets at https://tickets.puppet.com/browse/PCP and add the
-`pxp-agent` component to the ticket.
+Please refer to [this][contributing] document.
 
 [cpp-pcp-client]: https://github.com/puppetlabs/cpp-pcp-client
 [leatherman]: https://github.com/puppetlabs/leatherman


### PR DESCRIPTION
Anticipating some possible questions:

* This PR add a MAINTAINERS file to document who is maintaining this repo. The list of people started with the top 10 PR mergers in the last year, plus a little conversation here https://github.com/puppetlabs/kylo_scratchpad/pull/1/files#r76349596
* If the list seems wrong, let's feel free to edit it.
* The format of the file is documented here: http://github.com/puppetlabs/maintainers
* And I used https://rubygems.org/gems/maintainers to construct the file
* I pushed the PR branch to the puppetlabs space (rather than mine) so that all parties can edit collaboratively as needed
* Note that this is a public repo. The email and name fields are optional here. As a starting point, I pre-populated them with the publicly available names/emails available for all of us on github (but took bogus or non-puppet emails as an indication that you may not want to share your puppet.com email). Please feel free to edit your email and name fields for any reason.

