### PR TITLE
(PCP-605) Disable restart_host_run_puppet on Fedora

### DIFF
--- a/acceptance/tests/restart_host_run_puppet.rb
+++ b/acceptance/tests/restart_host_run_puppet.rb
@@ -15,7 +15,16 @@ test_name 'C94777 - Ensure pxp-agent functions after agent host restart' do
   applicable_agents = applicable_agents.select { |agent| agent['platform'] != "eos-4-i386"}
   unless applicable_agents.length > 0 then
     skip_test('RE-7673 - Arista hosts cannot be restarted')
-  end  
+  end
+
+  # QENG-4371 The fedora hosts in our VM Pooler consistently take 10+ minutes
+  # to reboot, causing this test to fail sporadically (~20% of the time). Once
+  # QENG-4371 is resolved, this platform should be returned to testing.
+  applicable_agents = applicable_agents.select { |agent| agent['platform'] !~ /fedora/ }
+  unless applicable_agents.length > 0 then
+    skip_test('QENG-4371 - Fedora hosts reboot time exceeds test timeout')
+  end
+
 
   step 'Ensure each agent host has pxp-agent service running and enabled' do
     applicable_agents.each do |agent|


### PR DESCRIPTION
Due to a bug (tracked by QENG-4371) the fedora hosts in our VM Pooler take
anywhere from 5 to 20 minutes to reboot, causing this test to time out and fail
consistently in Puppet Agent testing. Until this is resolved, the test running
on Fedora is causing consistent triage effort in Agent with little value. This
commit follows the existing pattern for excluding agents to exclude the Fedora
platform from testing. The long reboot times have been seen across fedora
arches and versions so this generically excludes the platform rather than a
specific version/arch target.

Signed-off-by: Moses Mendoza <moses@puppet.com>