### PR TITLE
(BKR-960) Skip timesync for ciscoxr-64a

### DIFF
--- a/acceptance/setup/common/005_SyncTime.rb
+++ b/acceptance/setup/common/005_SyncTime.rb
@@ -7,4 +7,8 @@ test_name 'Ensure hosts have synchronized clocks'
 # BKR-797 - If host is already running ntpd, manually running ntpdate will return 1
 # Affects OSX and Ubuntu on vmpooler
 applicable_hosts = hosts.select{|host| host['platform'] !~ /osx|ubuntu/}
+
+# BKR-960 - timesync does not work on Cisco XR
+applicable_hosts = applicable_hosts.select{|host| host['platform'] !~ /cisco_ios_xr/} 
+
 timesync(applicable_hosts, {:logger => logger})


### PR DESCRIPTION
BKR-960 is a beaker bug where the timesync helper method doesn't support cisco xr ios.
As a workaround, this commit just skips timesync for that platform.
This leaves the tests at risk of failing due to clock differences, but allows the tests to complete otherwise.

[skip ci]