### PR TITLE
(maint) Use AppVeyor OpenSSL

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,9 +4,6 @@ environment:
 install:
   - choco install -y mingw-w64 -Version 4.8.3 -source https://www.myget.org/F/puppetlabs
   - choco install -y cmake -Version 3.2.2 -source https://www.myget.org/F/puppetlabs
-  - SET PATH=C:\tools\mingw64\bin;%PATH%
-  - ps: $env:PATH = $env:PATH.Replace("Git\bin", "Git\cmd")
-  - ps: $env:PATH = $env:PATH.Replace("Git\usr\bin", "Git\cmd")
 
   - ps: wget 'https://s3.amazonaws.com/kylo-pl-bucket/boost_1_58_0-x86_64_mingw-w64_4.8.3_win32_seh.7z' -OutFile "$pwd\boost.7z"
   - ps: 7z.exe x boost.7z -oC:\tools | FIND /V "ing  "
@@ -27,10 +24,14 @@ install:
   - git clone https://github.com/puppetlabs/cpp-pcp-client
   - cd cpp-pcp-client
   - git checkout master
+
+    # Minimize environment polution; previously we were linking against the wrong OpenSSL DLLs.
+    # Include Ruby for unit tests.
+  - SET PATH=C:\tools\bin;C:\tools\openssl\bin;C:\tools\mingw64\bin;C:\ProgramData\chocolatey\bin;C:\Ruby22-x64\bin;C:\Windows\system32;C:\Windows
+
   - ps: cmake -G "MinGW Makefiles" -DBOOST_ROOT="C:\tools\boost_1_58_0-x86_64_mingw-w64_4.8.3_win32_seh" -DBOOST_STATIC=ON -DCURL_STATIC=ON -DCMAKE_PREFIX_PATH="C:\tools\leatherman;C:\tools\curl-7.42.1-x86_64_mingw-w64_4.8.3_win32_seh" -Wno-dev -DCMAKE_INSTALL_PREFIX=C:\tools .
   - ps: mingw32-make install
   - cd ..
-  - SET PATH=C:\tools\bin;%PATH%
 
 build_script:
   - ps: cmake -G "MinGW Makefiles" -DBOOST_ROOT="C:\tools\boost_1_58_0-x86_64_mingw-w64_4.8.3_win32_seh" -DBOOST_STATIC=ON -DCURL_STATIC=ON -Wno-dev -DCMAKE_PREFIX_PATH="C:\tools\leatherman;C:\tools\curl-7.42.1-x86_64_mingw-w64_4.8.3_win32_seh;C:\tools;C:\tools\bin" -DCMAKE_INSTALL_PREFIX=C:\tools -DTEST_VIRTUAL=ON .


### PR DESCRIPTION
Stop fighting against AppVeyor including OpenSSL and use the
pre-installed version. Also restrict PATH to only use known paths. This
fixes builds that accidentally loaded a different OpenSSL from
C:\Windows\system32.