### PR TITLE
(PCP-625) Skip beaker time sync on Windows Sever 2016

### DIFF
--- a/acceptance/setup/common/005_SyncTime.rb
+++ b/acceptance/setup/common/005_SyncTime.rb
@@ -8,6 +8,10 @@ test_name 'Ensure hosts have synchronized clocks'
 # Affects OSX and Ubuntu on vmpooler
 applicable_hosts = hosts.select{|host| host['platform'] !~ /osx|ubuntu/}
 
+# PCP-625 the beaker timesync method causes strange behavior on Windows Server 2016,
+# temporarily setting the date far into the past, which breaks SSL certificate retrieval
+applicable_hosts = applicable_hosts.select{|host| host['platform'] !~ /windows-2016/}
+
 # BKR-960 - timesync does not work on Cisco XR
 applicable_hosts = applicable_hosts.select{|host| host['platform'] !~ /cisco_ios_xr/} 
 


### PR DESCRIPTION
When testing a 32-bit puppet-agent MSI on Windows Server 2016, forcing a
time sync through beaker was causing the host to temporarily have a time
far in the past. This was preventing retrieval of the signed SSL
certificate from the master. However, the host appears to sync correctly
on its own, so this commit causes beaker to skip forcing a sync.