### PR TITLE
(PA-654)(PCP-611) Ensure puppet service is not running during acceptance

### DIFF
--- a/acceptance/lib/pxp-agent/test_helper.rb
+++ b/acceptance/lib/pxp-agent/test_helper.rb
@@ -411,6 +411,30 @@ MODULEPP
     on(master, "chmod 644 #{manifest}")
 end
 
+def get_puppet_agent_pids(host)
+  pids = []
+
+  case host['platform']
+  when /osx/
+    command = "ps -e -o pid,command | grep 'puppet agent' | grep -v 'grep' | sed 's/^[^0-9]*//g' | cut -d\\  -f1"
+  when /win/
+    # Puppet agent just appears as Ruby.exe in cygwin ps
+    # Need to check ruby's command line string to check it is actually puppet agent
+    # because pxp-module-puppet will also appear in ps as Ruby.exe
+    command = "cmd.exe /C WMIC path win32_process WHERE Name=\\\"Ruby.exe\\\" get CommandLine,ProcessId | "\
+              "grep 'puppet agent' | egrep -o '[0-9]+\s*$'"
+  else
+    command = "ps -ef | grep -e 'puppet agent' | grep -v 'grep' | grep -v 'true' | sed 's/^[^0-9]*//g' | cut -d\\  -f1"
+  end
+    
+  on(host, command, :accept_all_exit_codes => true) do |output|
+    pids = output.stdout.chomp.split
+  end
+    
+  pids
+
+end  
+
 def wait_for_sleep_process(target)
   begin
     ps_cmd = target['platform'] =~ /win/ ? 'ps -efW' : 'ps -ef'

--- a/acceptance/setup/aio/pre-suite/010_Install.rb
+++ b/acceptance/setup/aio/pre-suite/010_Install.rb
@@ -41,10 +41,17 @@ step "Install puppetserver..." do
   end
 end
 
-# make sure install is sane, beaker has already added puppet and ruby
-# to PATH in ~/.ssh/environment
-agents.each do |agent|
-  on agent, puppet('--version')
-  ruby = Puppet::Acceptance::CommandUtils.ruby_command(agent)
-  on agent, "#{ruby} --version"
+step 'Make sure install is sane' do 
+  # beaker has already added puppet and ruby to PATH in ~/.ssh/environment
+  agents.each do |agent|
+    on agent, puppet('--version')
+    ruby = Puppet::Acceptance::CommandUtils.ruby_command(agent)
+    on agent, "#{ruby} --version"
+  end
+end
+
+step 'Ensure puppet is not running or enabled as a service' do
+  # This step should not be needed as puppet should be stopped/disabled on install
+  # But pxp-agent tests should not fail if the installer gets this wrong. e.g. PA-654
+  on(agents, puppet('resource service puppet ensure=stopped enable=false'))
 end

--- a/acceptance/tests/pxp-module-puppet/run_puppet_twice.rb
+++ b/acceptance/tests/pxp-module-puppet/run_puppet_twice.rb
@@ -53,6 +53,62 @@ test_name 'Run Puppet while a Puppet Agent run is in-progress, wait for completi
     transaction_ids_2 = start_puppet_non_blocking_request(master, target_identities)
   end
 
+  # Wait for the 2nd puppet agent process to exit
+  #
+  # Passing case: 2nd puppet process starts, exits on puppet_already_running error, pxp-module-puppet waits to retry.
+  # Failing case: 2nd puppet process starts, exits on puppet_already_running error, pxp-module-puppet gives up.
+  #
+  # If the test continued without waiting for the 2nd instance to exit, the 1st agent instance might exit before the
+  # 2nd agent instance was fully started; causing a false positive test result.
+  # 
+  # Because beaker's sampling of the puppet agent PIDs might begin before the 2nd puppet agent appears, OR
+  # it might begin after the 2nd puppet agent has already shut down; this step needs to use a heuristic approach.
+  # It succeeds if either:
+  #   a. It observes 2 PIDs on one sample, then only 1 PID on the subsequent sample
+  #   b. It observes 1 PID for at least 10 concurrent samples
+  #
+  step 'Wait for only one puppet agent PID to exist' do
+    agents.each do |agent|
+
+      satisfied = false
+      pid_counting_attempts = 0
+      MAX_PID_COUNTING_ATTEMPTS = 30
+      concurrent_samples_of_1_pid = 0
+      REQUIRED_SAMPLES_OF_1_PID = 10
+      two_pids_observed = false
+
+      while pid_counting_attempts < MAX_PID_COUNTING_ATTEMPTS do
+        puppet_agent_pids = get_puppet_agent_pids(agent)
+        if puppet_agent_pids.length == 1 then
+          concurrent_samples_of_1_pid += 1
+          if two_pids_observed then
+            logger.debug "Determined that 2nd agent just stopped, there were 2 pids and now there is only 1."
+            satisfied = true
+          end
+          if !satisfied && concurrent_samples_of_1_pid >= REQUIRED_SAMPLES_OF_1_PID then
+            logger.debug "Assuming 2nd agent has stopped due to #{concurrent_samples_of_1_pid} concurrent "\
+                         "pid checks that only returned 1 running agent pid"
+            satisfied = true
+          end
+        elsif puppet_agent_pids.length == 2 then
+          concurrent_samples_of_1_pid = 0
+          two_pids_observed = true
+        else
+          # If there is not 1 or 2 pids then the test has lost control and should error
+          raise("Test relies on there being either 1 or 2 puppet-agent pids, "\
+                "but somehow #{puppet_agent_pids.length.to_s} pids were detected")
+        end
+        break if satisfied
+        pid_counting_attempts += 1
+        sleep 1
+      end
+
+      unless satisfied then
+        fail("After #{MAX_PID_COUNTING_ATTEMPTS} times checking, could not determine that the 2nd agent had stopped")
+      end
+    end
+  end
+
   step 'Signal sleep process to end so 1st Puppet run will complete' do
     stop_sleep_process(agents)
   end


### PR DESCRIPTION
Re-introduce the update to run_puppet_twice.rb that was failing on Ubuntu 14.04.
Adds a commit that fixes the issue with Ubuntu 14.04 - this turned out to be PA-654 where puppet was running as a service after installing puppet-agent. This commit ensures puppet service is stopped and disabled.

[skip ci]