### PR TITLE
(PCP-611) Acceptance fixes for run_puppet_twice.rb

### DIFF
--- a/acceptance/lib/pxp-agent/test_helper.rb
+++ b/acceptance/lib/pxp-agent/test_helper.rb
@@ -424,7 +424,7 @@ def get_puppet_agent_pids(host)
     command = "cmd.exe /C WMIC path win32_process WHERE Name=\\\"Ruby.exe\\\" get CommandLine,ProcessId | "\
               "grep 'puppet agent' | egrep -o '[0-9]+\s*$'"
   else
-    command = "ps -ef | grep -e 'puppet agent' | grep -v 'grep' | grep -v 'true' | sed 's/^[^0-9]*//g' | cut -d\\  -f1"
+    command = "ps -ef | grep 'puppet agent' | grep -v 'grep' | grep -v 'true' | sed 's/^[^0-9]*//g' | cut -d\\  -f1"
   end
     
   on(host, command, :accept_all_exit_codes => true) do |output|

--- a/acceptance/setup/aio/pre-suite/010_Install.rb
+++ b/acceptance/setup/aio/pre-suite/010_Install.rb
@@ -54,4 +54,5 @@ step 'Ensure puppet is not running or enabled as a service' do
   # This step should not be needed as puppet should be stopped/disabled on install
   # But pxp-agent tests should not fail if the installer gets this wrong. e.g. PA-654
   on(agents, puppet('resource service puppet ensure=stopped enable=false'))
+  on(agents, puppet('config set daemonize false --section agent'))
 end


### PR DESCRIPTION
The code committed for PCP-611 fails in CI on some platforms. 
On OSX, the puppet service may be running in spite of the pre-suite stopping it. I believe this is expected behaviour on OSX, it will start up installed services it finds in a stopped state. This PR adds an extra pre-suite step to not have puppet agent daemonized; so it will not run and interfere with tests even if the service re-enables.

Additionally the test failed on Solaris because the helper method used the -e option that is not supported on Solaris' version of grep. This option is actually redundant on the platforms that do support it (as the argument to grep is a literal string and not an expression), so this PR simply removes it.

[skip ci]