### PR TITLE
(PCP-631) Prevent hanging on Windows ssh after shutdown

### DIFF
--- a/acceptance/tests/restart_host_run_puppet.rb
+++ b/acceptance/tests/restart_host_run_puppet.rb
@@ -48,7 +48,23 @@ test_name 'C94777 - Ensure pxp-agent functions after agent host restart' do
 
   step "restart each agent" do
     applicable_agents.each do |agent|
-      agent.reboot
+      # Work-around reboot hanging on reply (BKR-971)
+      rebooter = Thread.start { agent.reboot }
+      sleep 5
+
+      # For the truly paranoid, we handle exceptions for closing the SSH connection and rejoining thread separately.
+      begin
+        agent.close
+      rescue Exception => e
+        logger.debug "Exception closing agent connection after reboot: #{e}"
+      end
+
+      begin
+        rebooter.join
+      rescue Exception => e
+        logger.debug "Exception waiting for ssh close after reboot: #{e}"
+      end
+
       # BKR-812
       timeout = 30
       begin


### PR DESCRIPTION
The beaker restart helper sends shutdown to Windows, but then hangs for
a long timeout as ssh doesn't close cleanly. This is filed as BKR-971.

As a work-around, add a 5s timeout after sending shutdown to allow it be
begin, then close the SSH connection and start attempting to reconnect.