### PR TITLE
(PA-652) Bump pxp-agent version to 1.3.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.2.2)
-project(pxp-agent VERSION 1.3.0)
+project(pxp-agent VERSION 1.3.1)
 
 if (NOT CMAKE_BUILD_TYPE)
     message(STATUS "Defaulting to a release build.")

--- a/locales/pxp-agent.pot
+++ b/locales/pxp-agent.pot
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: pxp-agent 1.3.0\n"
+"Project-Id-Version: pxp-agent 1.3.1\n"
 "Report-Msgid-Bugs-To: docs@puppet.com\n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"


### PR DESCRIPTION
This bumps the version of pxp-agent to 1.3.1 following the release of
1.3.0 as part of puppet-agent 1.8.0.