### PR TITLE
(PCP-614) Update beaker version to 3.1.0

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -12,11 +12,11 @@ def location_for(place, fake_version = nil)
   end
 end
 
-gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 2.19')
-gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.2")
+gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 3.1.0')
+gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.8")
 gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.2")
 gem 'rake'
-gem 'scooter', '~> 3.1.1'
+gem 'scooter', '~> 3.2.17'
 gem 'pcp-client', '~> 0.4'
 
 group(:test) do


### PR DESCRIPTION
Update the beaker gem version used in acceptance to beaker 3.1.0 to allow
for MacOS Sierra (10.12) testing.

This will also require bumps to:

beaker-hostgenerator: 0.8
scooter: 3.2.17

This is a cherrypick over to the LTS branch