### PR TITLE
(PCP-625) Skip beaker time sync on Windows 10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,3 @@
 /lib/tests/resources/tmp/
 .idea/
 .DS_Store
-acceptance/empty.rb
-acceptance/tmp

--- a/acceptance/.gitignore
+++ b/acceptance/.gitignore
@@ -1,0 +1,9 @@
+.vagrant
+tmp
+empty.rb
+.bundle
+Gemfile.local
+Gemfile.lock
+log/
+merged_options.rb
+hosts.yaml

--- a/acceptance/setup/common/005_SyncTime.rb
+++ b/acceptance/setup/common/005_SyncTime.rb
@@ -8,9 +8,10 @@ test_name 'Ensure hosts have synchronized clocks'
 # Affects OSX and Ubuntu on vmpooler
 applicable_hosts = hosts.select{|host| host['platform'] !~ /osx|ubuntu/}
 
-# PCP-625 the beaker timesync method causes strange behavior on Windows Server 2016,
+# PCP-625 the beaker timesync method causes strange behavior on Windows Server 2016 and Windows 10,
 # temporarily setting the date far into the past, which breaks SSL certificate retrieval
 applicable_hosts = applicable_hosts.select{|host| host['platform'] !~ /windows-2016/}
+applicable_hosts = applicable_hosts.select{|host| host['platform'] !~ /windows-10/}
 
 # BKR-960 - timesync does not work on Cisco XR
 applicable_hosts = applicable_hosts.select{|host| host['platform'] !~ /cisco_ios_xr/} 


### PR DESCRIPTION
Previously we skipped timesync on Windows Server 2016 in commit cd33472
However Windows 10 shares the same kernel and requires a similar fix.  This
commit adds a Windows 10 exclusion for the beaker timesync process.

[skip ci]