### PR TITLE
(PCP-650) Pin pcp-broker to 0.8.4 in tests

### DIFF
--- a/acceptance/setup/common/050_Setup_Broker.rb
+++ b/acceptance/setup/common/050_Setup_Broker.rb
@@ -16,7 +16,7 @@ NUM_BROKERS = 2
 have_broker_replica = NUM_BROKERS > 1
 
 PCP_BROKER_FORK = ENV['PCP_BROKER_FORK'] || nil
-PCP_BROKER_REF  = ENV['PCP_BROKER_REF'] || nil
+PCP_BROKER_REF  = ENV['PCP_BROKER_REF'] || 'refs/tags/0.8.4'
 
 step 'Clone pcp-broker to broker_hosts' do
   pcp_broker_url = build_git_url('pcp-broker', PCP_BROKER_FORK, nil, 'https')


### PR DESCRIPTION
Pins pcp-broker to a specific version (0.8.4) during acceptance testing
to ensure reproducible tests and avoid breakage due to development on
pcp-broker.