### PR TITLE
(PCP-631) Use Beaker 3.6.0 for fix to reboot

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -12,7 +12,7 @@ def location_for(place, fake_version = nil)
   end
 end
 
-gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 3.1.0')
+gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 3.6.0')
 gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.8")
 gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.2")
 gem 'rake'

--- a/acceptance/tests/restart_host_run_puppet.rb
+++ b/acceptance/tests/restart_host_run_puppet.rb
@@ -48,23 +48,7 @@ test_name 'C94777 - Ensure pxp-agent functions after agent host restart' do
 
   step "restart each agent" do
     applicable_agents.each do |agent|
-      # Work-around reboot hanging on reply (BKR-971)
-      rebooter = Thread.start { agent.reboot }
-      sleep 5
-
-      # For the truly paranoid, we handle exceptions for closing the SSH connection and rejoining thread separately.
-      begin
-        agent.close
-      rescue Exception => e
-        logger.debug "Exception closing agent connection after reboot: #{e}"
-      end
-
-      begin
-        rebooter.join
-      rescue Exception => e
-        logger.debug "Exception waiting for ssh close after reboot: #{e}"
-      end
-
+      agent.reboot
       # BKR-812
       timeout = 30
       begin


### PR DESCRIPTION
Beaker 3.6.0 includes a fix for BKR-1006, which updates the Windows
reboot helper to close the SSH connection immediately. This avoids long
timeouts on the connection.

Also reverts a previous hack to try to work around the Beaker issue.