### PR TITLE
(PA-777) Implement puppetserver reload

### DIFF
--- a/acceptance/tests/pxp-module-puppet/restart_pxp_agent_during_non_blocking_run.rb
+++ b/acceptance/tests/pxp-module-puppet/restart_pxp_agent_during_non_blocking_run.rb
@@ -71,8 +71,8 @@ test_name 'C94705 - Run Puppet (non-blocking request) and restart pxp-agent serv
     end
 
     step "Restart pxp-agent service on #{agent}" do
-      on agent, puppet('resource service pxp-agent ensure=stopped')
-      on agent, puppet('resource service pxp-agent ensure=running')
+      bounce_service(agent, 'pxp-agent')
+
       # Wait for the service to be reconnected
       unless is_associated?(master, agent_identity) then
         fail("Agent has not reconnected after #{PCP_INVENTORY_RETRIES} inventory queries")


### PR DESCRIPTION
This commit update how the puppetserver service is restarted in the
pxp-agent testing pipelines. Recently we added functionality into
puppetserver to allow for faster reload times. By taking advantage of
this functionality, we should be able to reduce the amount of time our
pxp-agent test pipelines take to execute.

This commit also sets the `restart_when_done beaker` option to false globally
in AIO, which requires Beaker 2.27.0 to work correctly and is already
the minimum beaker version we depend on for acceptance.