### PR TITLE
(PCP-647) Add PCP version 2 connector and allow configuring it

### DIFF
--- a/.travis_target.sh
+++ b/.travis_target.sh
@@ -43,9 +43,7 @@ if [ ${TRAVIS_TARGET} == DEBUG ]; then
   TARGET_OPTS="-DCMAKE_BUILD_TYPE=Debug -DCOVERALLS=ON"
 fi
 
-# NB: TEST_VIRTUAL enables virtual functions in PXPConnector and the
-# unit tests that rely on them for mocking cpp-pcp-client's Connector.
-cmake $TARGET_OPTS -DCMAKE_PREFIX_PATH=$USERDIR -DCMAKE_INSTALL_PREFIX=$USERDIR -DTEST_VIRTUAL=ON .
+cmake $TARGET_OPTS -DCMAKE_PREFIX_PATH=$USERDIR -DCMAKE_INSTALL_PREFIX=$USERDIR .
 
 if [ ${TRAVIS_TARGET} == CPPLINT ]; then
   make cpplint

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,12 +7,7 @@ if (NOT CMAKE_BUILD_TYPE)
 endif()
 
 # Define further options
-option(TEST_VIRTUAL "ON - certain class member functions became virtual to enable mocking for unit tests" OFF)
 option(DEV_LOG_COLOR "Enable colorization for logging (development setting)" OFF)
-
-if(TEST_VIRTUAL)
-    add_definitions(-DTEST_VIRTUAL)
-endif()
 
 if(DEV_LOG_COLOR)
     add_definitions(-DDEV_LOG_COLOR)

--- a/README.md
+++ b/README.md
@@ -95,10 +95,8 @@ Build
 
   Thanks to the CMake, the project can be built out-of-source tree, which allows for
   multiple independent builds.
-  Aside from the standard CMake switches the build supports the following options:
+  Aside from the standard CMake switches the build supports the following option:
 
-   * **TEST_VIRTUAL** when set to _ON_ certain class member functions become virtual
-     to enable mocking for unit tests (default _OFF_)
    * **DEV_LOG_COLOR** enables colorization for logging (development setting)
      (default _OFF_)
 
@@ -113,7 +111,7 @@ Build
 
       mkdir debug
       cd debug
-      cmake -DCMAKE_BUILD_TYPE=Debug -DTEST_VIRTUAL=ON -DDEV_LOG_COLOR=ON ..
+      cmake -DCMAKE_BUILD_TYPE=Debug -DDEV_LOG_COLOR=ON ..
       make
 
 Usage

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,7 +34,7 @@ install:
   - cd ..
 
 build_script:
-  - ps: cmake -G "MinGW Makefiles" -DBOOST_ROOT="C:\tools\boost_1_58_0-x86_64_mingw-w64_4.8.3_win32_seh" -DBOOST_STATIC=ON -DCURL_STATIC=ON -Wno-dev -DCMAKE_PREFIX_PATH="C:\tools\leatherman;C:\tools\curl-7.42.1-x86_64_mingw-w64_4.8.3_win32_seh;C:\tools;C:\tools\bin" -DCMAKE_INSTALL_PREFIX=C:\tools -DTEST_VIRTUAL=ON .
+  - ps: cmake -G "MinGW Makefiles" -DBOOST_ROOT="C:\tools\boost_1_58_0-x86_64_mingw-w64_4.8.3_win32_seh" -DBOOST_STATIC=ON -DCURL_STATIC=ON -Wno-dev -DCMAKE_PREFIX_PATH="C:\tools\leatherman;C:\tools\curl-7.42.1-x86_64_mingw-w64_4.8.3_win32_seh;C:\tools;C:\tools\bin" -DCMAKE_INSTALL_PREFIX=C:\tools .
   - ps: mingw32-make install
 
 test_script:

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -18,7 +18,8 @@ set(LIBRARY_COMMON_SOURCES
     src/configuration.cc
     src/external_module.cc
     src/module.cc
-    src/pxp_connector.cc
+    src/pxp_connector_v1.cc
+    src/pxp_connector_v2.cc
     src/pxp_schemas.cc
     src/request_processor.cc
     src/results_mutex.cc

--- a/lib/inc/pxp-agent/agent.hpp
+++ b/lib/inc/pxp-agent/agent.hpp
@@ -2,16 +2,16 @@
 #define SRC_AGENT_ENDPOINT_H_
 
 #include <pxp-agent/request_processor.hpp>
-#include <pxp-agent/action_request.hpp>
-#include <pxp-agent/pxp_connector.hpp>
 #include <pxp-agent/configuration.hpp>
 
-#include <cpp-pcp-client/protocol/chunks.hpp>      // ParsedChunk
+#include <cpp-pcp-client/protocol/parsed_chunks.hpp>
 
 #include <memory>
 #include <string>
 
 namespace PXPAgent {
+
+class PXPConnector;
 
 class Agent {
   public:
@@ -67,7 +67,7 @@ class Agent {
     // blocking requests; it will execute the requested action and,
     // once finished, reply to the sender with an PXP blocking
     // response containing the action outcome.
-    void blockingRequestCallback(const PCPClient::ParsedChunks& parsed_chunks);
+    void blockingRequestCallback(const PCPClient::v1::ParsedChunks&);
 
     // Callback for PCPClient::Connector handling incoming PXP
     // non-blocking requests; it will start a job for the requested
@@ -76,7 +76,7 @@ class Agent {
     // In case the request has the notify_outcome field flagged, it
     // will send a PXP non-blocking response containing the action
     // outcome when finished.
-    void nonBlockingRequestCallback(const PCPClient::ParsedChunks& parsed_chunks);
+    void nonBlockingRequestCallback(const PCPClient::v1::ParsedChunks&);
 };
 
 }  // namespace PXPAgent

--- a/lib/inc/pxp-agent/configuration.hpp
+++ b/lib/inc/pxp-agent/configuration.hpp
@@ -126,6 +126,7 @@ class Configuration
     {
         std::string modules_dir;
         std::vector<std::string> broker_ws_uris;
+        std::string pcp_version;
         std::string ca;
         std::string crt;
         std::string key;

--- a/lib/inc/pxp-agent/module.hpp
+++ b/lib/inc/pxp-agent/module.hpp
@@ -5,7 +5,6 @@
 #include <pxp-agent/action_request.hpp>
 #include <pxp-agent/module_type.hpp>
 
-#include <cpp-pcp-client/protocol/chunks.hpp>      // ParsedChunks
 #include <cpp-pcp-client/validator/validator.hpp>  // Validator
 
 #include <leatherman/json_container/json_container.hpp>

--- a/lib/inc/pxp-agent/pxp_connector_v1.hpp
+++ b/lib/inc/pxp-agent/pxp_connector_v1.hpp
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <pxp-agent/pxp_connector.hpp>
+#include <pxp-agent/action_request.hpp>
+#include <pxp-agent/action_response.hpp>
+#include <pxp-agent/configuration.hpp>
+
+#include <cpp-pcp-client/connector/v1/connector.hpp>
+
+#include <cstdint>
+
+namespace PXPAgent {
+
+class PXPConnectorV1 : public PCPClient::v1::Connector, public PXPConnector {
+  public:
+    PXPConnectorV1(const Configuration::Agent& agent_configuration);
+
+    void sendPCPError(const std::string& request_id,
+                      const std::string& description,
+                      const std::vector<std::string>& endpoints) override;
+
+    void sendProvisionalResponse(const ActionRequest& request) override;
+
+    void sendPXPError(const ActionRequest& request,
+                      const std::string& description) override;
+
+    // Asserts that the ActionResponse arg has all needed entries.
+    void sendPXPError(const ActionResponse& response) override;
+
+    // Asserts that the ActionResponse arg has all needed entries.
+    void sendBlockingResponse(const ActionResponse& response,
+                              const ActionRequest& request) override;
+
+    // Asserts that the ActionResponse arg has all needed entries.
+    void sendStatusResponse(const ActionResponse& response,
+                            const ActionRequest& request) override;
+
+    // Asserts that the ActionResponse arg has all needed entries.
+    void sendNonBlockingResponse(const ActionResponse& response) override;
+
+    void connect(int max_connect_attempts = 0) override;
+
+    void monitorConnection(uint32_t max_connect_attempts = 0,
+                           uint32_t connection_check_interval_s = 15) override;
+
+    void registerMessageCallback(const PCPClient::Schema& schema,
+                                 MessageCallback callback) override;
+
+  private:
+    uint32_t pcp_message_ttl_s;
+
+    void sendBlockingResponse_(const ActionResponse::ResponseType& response_type,
+                               const ActionResponse& response,
+                               const ActionRequest& request);
+};
+
+}  // namespace PXPAgent

--- a/lib/inc/pxp-agent/pxp_connector_v2.hpp
+++ b/lib/inc/pxp-agent/pxp_connector_v2.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <pxp-agent/pxp_connector.hpp>
+#include <pxp-agent/action_request.hpp>
+#include <pxp-agent/action_response.hpp>
+#include <pxp-agent/configuration.hpp>
+
+#include <cpp-pcp-client/connector/v2/connector.hpp>
+
+namespace PXPAgent {
+
+class PXPConnectorV2 : public PCPClient::v2::Connector, public PXPConnector {
+  public:
+    PXPConnectorV2(const Configuration::Agent& agent_configuration);
+
+    void sendPCPError(const std::string& request_id,
+                      const std::string& description,
+                      const std::vector<std::string>& endpoints) override;
+
+    void sendProvisionalResponse(const ActionRequest& request) override;
+
+    void sendPXPError(const ActionRequest& request,
+                      const std::string& description) override;
+
+    // Asserts that the ActionResponse arg has all needed entries.
+    void sendPXPError(const ActionResponse& response) override;
+
+    // Asserts that the ActionResponse arg has all needed entries.
+    void sendBlockingResponse(const ActionResponse& response,
+                              const ActionRequest& request) override;
+
+    // Asserts that the ActionResponse arg has all needed entries.
+    void sendStatusResponse(const ActionResponse& response,
+                            const ActionRequest& request) override;
+
+    // Asserts that the ActionResponse arg has all needed entries.
+    void sendNonBlockingResponse(const ActionResponse& response) override;
+
+    void connect(int max_connect_attempts = 0) override;
+
+    void monitorConnection(uint32_t max_connect_attempts = 0,
+                           uint32_t connection_check_interval_s = 15) override;
+
+    void registerMessageCallback(const PCPClient::Schema& schema,
+                                 MessageCallback callback) override;
+
+  private:
+    void sendBlockingResponse_(const ActionResponse::ResponseType& response_type,
+                               const ActionResponse& response,
+                               const ActionRequest& request);
+};
+
+}  // namespace PXPAgent

--- a/lib/src/pxp_connector_v1.cc
+++ b/lib/src/pxp_connector_v1.cc
@@ -1,0 +1,225 @@
+#include <pxp-agent/pxp_connector_v1.hpp>
+#include <pxp-agent/pxp_schemas.hpp>
+
+#include <leatherman/json_container/json_container.hpp>
+
+#define LEATHERMAN_LOGGING_NAMESPACE "puppetlabs.pxp_agent.pxp_connector"
+#include <leatherman/logging/logging.hpp>
+
+#include <utility>
+
+namespace PXPAgent {
+
+namespace lth_jc = leatherman::json_container;
+
+//
+// PXPConnector V1
+//
+
+std::vector<lth_jc::JsonContainer>
+wrapDebug(const PCPClient::ParsedChunks& parsed_chunks)
+{
+    auto request_id = parsed_chunks.envelope.get<std::string>("id");
+    if (parsed_chunks.num_invalid_debug) {
+        // TODO(ale): deal with locale & plural (PCP-257)
+        if (parsed_chunks.num_invalid_debug == 1) {
+            LOG_WARNING("Message {1} contained {2} bad debug chunk",
+                        request_id, parsed_chunks.num_invalid_debug);
+        } else {
+            LOG_WARNING("Message {1} contained {2} bad debug chunks",
+                        request_id, parsed_chunks.num_invalid_debug);
+        }
+    }
+    std::vector<lth_jc::JsonContainer> debug {};
+    for (auto& debug_entry : parsed_chunks.debug) {
+        debug.push_back(debug_entry);
+    }
+    return debug;
+}
+
+PXPConnectorV1::PXPConnectorV1(const Configuration::Agent& agent_configuration)
+        : PCPClient::v1::Connector(agent_configuration.broker_ws_uris,
+                                   agent_configuration.client_type,
+                                   agent_configuration.ca,
+                                   agent_configuration.crt,
+                                   agent_configuration.key,
+                                   agent_configuration.ws_connection_timeout_ms,
+                                   agent_configuration.association_timeout_s,
+                                   agent_configuration.association_request_ttl_s,
+                                   agent_configuration.allowed_keepalive_timeouts+1),
+          pcp_message_ttl_s { agent_configuration.pcp_message_ttl_s }
+{
+}
+
+void PXPConnectorV1::sendPCPError(const std::string& request_id,
+                                  const std::string& description,
+                                  const std::vector<std::string>& endpoints)
+{
+    lth_jc::JsonContainer pcp_error_data {};
+    pcp_error_data.set<std::string>("id", request_id);
+    pcp_error_data.set<std::string>("description", description);
+
+    try {
+        sendError(endpoints,
+             pcp_message_ttl_s,
+             request_id,
+             description);
+        LOG_INFO("Replied to request {1} with a PCP error message",
+                 request_id);
+    } catch (PCPClient::connection_error& e) {
+        LOG_ERROR("Failed to send PCP error message for request {1}: {2}",
+                  request_id, e.what());
+    }
+}
+
+void PXPConnectorV1::sendProvisionalResponse(const ActionRequest& request)
+{
+    auto debug = wrapDebug(request.parsedChunks());
+    lth_jc::JsonContainer provisional_data {};
+    provisional_data.set<std::string>("transaction_id", request.transactionId());
+
+    try {
+        send(std::vector<std::string> { request.sender() },
+             PXPSchemas::PROVISIONAL_RESPONSE_TYPE,
+             pcp_message_ttl_s,
+             provisional_data,
+             debug);
+        LOG_INFO("Sent provisional response for the {1} by {2}",
+                 request.prettyLabel(), request.sender());
+    } catch (PCPClient::connection_error& e) {
+        LOG_ERROR("Failed to send provisional response for the {1} by {2} "
+                  "(no further attempts will be made): {3}",
+                  request.prettyLabel(), request.sender(), e.what());
+    }
+}
+
+void PXPConnectorV1::sendPXPError(const ActionRequest& request,
+                                  const std::string& description)
+{
+    lth_jc::JsonContainer pxp_error_data {};
+    pxp_error_data.set<std::string>("transaction_id", request.transactionId());
+    pxp_error_data.set<std::string>("id", request.id());
+    pxp_error_data.set<std::string>("description", description);
+
+    try {
+        send(std::vector<std::string> { request.sender() },
+             PXPSchemas::PXP_ERROR_MSG_TYPE,
+             pcp_message_ttl_s,
+             pxp_error_data);
+        LOG_INFO("Replied to {1} by {2}, request ID {3}, with a PXP error message",
+                 request.prettyLabel(), request.sender(), request.id());
+    } catch (PCPClient::connection_error& e) {
+        LOG_ERROR("Failed to send a PXP error message for the {1} by {2} "
+                  "(no further sending attempts will be made): {3}",
+                  request.prettyLabel(), request.sender(), description);
+    }
+}
+
+void PXPConnectorV1::sendPXPError(const ActionResponse& response)
+{
+    assert(response.valid(ActionResponse::ResponseType::RPCError));
+
+    try {
+        send(std::vector<std::string> {
+                response.action_metadata.get<std::string>("requester") },
+             PXPSchemas::PXP_ERROR_MSG_TYPE,
+             pcp_message_ttl_s,
+             response.toJSON(ActionResponse::ResponseType::RPCError));
+        LOG_INFO("Replied to {1} by {2}, request ID {3}, with a PXP error message",
+                 response.prettyRequestLabel(),
+                 response.action_metadata.get<std::string>("requester"),
+                 response.action_metadata.get<std::string>("request_id"));
+    } catch (PCPClient::connection_error& e) {
+        LOG_ERROR("Failed to send a PXP error message for the {1} by {2} "
+                  "(no further sending attempts will be made): {3}",
+                  response.prettyRequestLabel(),
+                  response.action_metadata.get<std::string>("requester"),
+                  response.action_metadata.get<std::string>("execution_error"));
+    }
+}
+
+void PXPConnectorV1::sendBlockingResponse(const ActionResponse& response,
+                                          const ActionRequest& request)
+{
+    assert(response.valid(ActionResponse::ResponseType::Blocking));
+    sendBlockingResponse_(ActionResponse::ResponseType::Blocking,
+                          response,
+                          request);
+}
+
+void PXPConnectorV1::sendStatusResponse(const ActionResponse& response,
+                                        const ActionRequest& request)
+{
+    assert(response.valid(ActionResponse::ResponseType::StatusOutput));
+    sendBlockingResponse_(ActionResponse::ResponseType::StatusOutput,
+                          response,
+                          request);
+}
+
+void PXPConnectorV1::sendNonBlockingResponse(const ActionResponse& response)
+{
+    assert(response.valid(ActionResponse::ResponseType::NonBlocking));
+    assert(response.action_metadata.get<std::string>("status") != "undetermined");
+
+    try {
+        // NOTE(ale): assuming debug was sent in provisional response
+        send(std::vector<std::string> {
+                response.action_metadata.get<std::string>("requester") },
+             PXPSchemas::NON_BLOCKING_RESPONSE_TYPE,
+             pcp_message_ttl_s,
+             response.toJSON(ActionResponse::ResponseType::NonBlocking));
+        LOG_INFO("Sent response for the {1} by {2}",
+                 response.prettyRequestLabel(),
+                 response.action_metadata.get<std::string>("requester"));
+    } catch (PCPClient::connection_error& e) {
+        LOG_ERROR("Failed to reply to {1} by {2}, (no further attempts will "
+                  "be made): {3}",
+                  response.prettyRequestLabel(),
+                  response.action_metadata.get<std::string>("requester"),
+                  e.what());
+    }
+}
+
+void PXPConnectorV1::connect(int max_connect_attempts)
+{
+    PCPClient::v1::Connector::connect(max_connect_attempts);
+}
+
+void PXPConnectorV1::monitorConnection(uint32_t max_connect_attempts,
+                                       uint32_t connection_check_interval_s)
+{
+    PCPClient::v1::Connector::monitorConnection(max_connect_attempts, connection_check_interval_s);
+}
+
+void PXPConnectorV1::registerMessageCallback(const PCPClient::Schema& schema,
+                                             MessageCallback callback)
+{
+    PCPClient::v1::Connector::registerMessageCallback(schema, callback);
+}
+
+//
+// Private interface
+//
+
+void PXPConnectorV1::sendBlockingResponse_(
+        const ActionResponse::ResponseType& response_type,
+        const ActionResponse& response,
+        const ActionRequest& request)
+{
+    auto debug = wrapDebug(request.parsedChunks());
+
+    try {
+        send(std::vector<std::string> { request.sender() },
+             PXPSchemas::BLOCKING_RESPONSE_TYPE,
+             pcp_message_ttl_s,
+             response.toJSON(response_type),
+             debug);
+        LOG_INFO("Sent response for the {1} by {2}",
+                 request.prettyLabel(), request.sender());
+    } catch (PCPClient::connection_error& e) {
+        LOG_ERROR("Failed to reply to the {1} by {2}: {3}",
+                  request.prettyLabel(), request.sender(), e.what());
+    }
+}
+
+}  // namesapce PXPAgent

--- a/lib/src/pxp_connector_v2.cc
+++ b/lib/src/pxp_connector_v2.cc
@@ -1,7 +1,7 @@
-#include <pxp-agent/pxp_connector.hpp>
+#include <pxp-agent/pxp_connector_v2.hpp>
 #include <pxp-agent/pxp_schemas.hpp>
 
-#include <cpp-pcp-client/protocol/schemas.hpp>
+#include <leatherman/json_container/json_container.hpp>
 
 #define LEATHERMAN_LOGGING_NAMESPACE "puppetlabs.pxp_agent.pxp_connector"
 #include <leatherman/logging/logging.hpp>
@@ -12,54 +12,29 @@ namespace PXPAgent {
 
 namespace lth_jc = leatherman::json_container;
 
-std::vector<lth_jc::JsonContainer>
-wrapDebug(const PCPClient::ParsedChunks& parsed_chunks)
-{
-    auto request_id = parsed_chunks.envelope.get<std::string>("id");
-    if (parsed_chunks.num_invalid_debug) {
-        // TODO(ale): deal with locale & plural (PCP-257)
-        if (parsed_chunks.num_invalid_debug == 1) {
-            LOG_WARNING("Message {1} contained {2} bad debug chunk",
-                        request_id, parsed_chunks.num_invalid_debug);
-        } else {
-            LOG_WARNING("Message {1} contained {2} bad debug chunks",
-                        request_id, parsed_chunks.num_invalid_debug);
-        }
-    }
-    std::vector<lth_jc::JsonContainer> debug {};
-    for (auto& debug_entry : parsed_chunks.debug) {
-        debug.push_back(debug_entry);
-    }
-    return debug;
-}
+//
+// PXPConnector V2
+//
 
-PXPConnector::PXPConnector(const Configuration::Agent& agent_configuration)
-        : PCPClient::Connector(agent_configuration.broker_ws_uris,
-                               agent_configuration.client_type,
-                               agent_configuration.ca,
-                               agent_configuration.crt,
-                               agent_configuration.key,
-                               agent_configuration.ws_connection_timeout_ms,
-                               agent_configuration.association_timeout_s,
-                               agent_configuration.association_request_ttl_s,
-                               agent_configuration.allowed_keepalive_timeouts+1),
-          pcp_message_ttl_s { agent_configuration.pcp_message_ttl_s }
+PXPConnectorV2::PXPConnectorV2(const Configuration::Agent& agent_configuration)
+        : PCPClient::v2::Connector(agent_configuration.broker_ws_uris,
+                                   agent_configuration.client_type,
+                                   agent_configuration.ca,
+                                   agent_configuration.crt,
+                                   agent_configuration.key,
+                                   agent_configuration.ws_connection_timeout_ms,
+                                   agent_configuration.allowed_keepalive_timeouts+1)
 {
 }
 
-void PXPConnector::sendPCPError(const std::string& request_id,
-                                const std::string& description,
-                                const std::vector<std::string>& endpoints)
+void PXPConnectorV2::sendPCPError(const std::string& request_id,
+                                  const std::string& description,
+                                  const std::vector<std::string>& endpoints)
 {
-    lth_jc::JsonContainer pcp_error_data {};
-    pcp_error_data.set<std::string>("id", request_id);
-    pcp_error_data.set<std::string>("description", description);
-
     try {
-        send(endpoints,
-             PCPClient::Protocol::ERROR_MSG_TYPE,
-             pcp_message_ttl_s,
-             pcp_error_data);
+        sendError(endpoints.front(),
+                  request_id,
+                  description);
         LOG_INFO("Replied to request {1} with a PCP error message",
                  request_id);
     } catch (PCPClient::connection_error& e) {
@@ -68,18 +43,15 @@ void PXPConnector::sendPCPError(const std::string& request_id,
     }
 }
 
-void PXPConnector::sendProvisionalResponse(const ActionRequest& request)
+void PXPConnectorV2::sendProvisionalResponse(const ActionRequest& request)
 {
-    auto debug = wrapDebug(request.parsedChunks());
     lth_jc::JsonContainer provisional_data {};
     provisional_data.set<std::string>("transaction_id", request.transactionId());
 
     try {
-        send(std::vector<std::string> { request.sender() },
+        send(request.sender(),
              PXPSchemas::PROVISIONAL_RESPONSE_TYPE,
-             pcp_message_ttl_s,
-             provisional_data,
-             debug);
+             provisional_data);
         LOG_INFO("Sent provisional response for the {1} by {2}",
                  request.prettyLabel(), request.sender());
     } catch (PCPClient::connection_error& e) {
@@ -89,8 +61,8 @@ void PXPConnector::sendProvisionalResponse(const ActionRequest& request)
     }
 }
 
-void PXPConnector::sendPXPError(const ActionRequest& request,
-                                const std::string& description)
+void PXPConnectorV2::sendPXPError(const ActionRequest& request,
+                                  const std::string& description)
 {
     lth_jc::JsonContainer pxp_error_data {};
     pxp_error_data.set<std::string>("transaction_id", request.transactionId());
@@ -98,9 +70,8 @@ void PXPConnector::sendPXPError(const ActionRequest& request,
     pxp_error_data.set<std::string>("description", description);
 
     try {
-        send(std::vector<std::string> { request.sender() },
+        send(request.sender(),
              PXPSchemas::PXP_ERROR_MSG_TYPE,
-             pcp_message_ttl_s,
              pxp_error_data);
         LOG_INFO("Replied to {1} by {2}, request ID {3}, with a PXP error message",
                  request.prettyLabel(), request.sender(), request.id());
@@ -111,15 +82,13 @@ void PXPConnector::sendPXPError(const ActionRequest& request,
     }
 }
 
-void PXPConnector::sendPXPError(const ActionResponse& response)
+void PXPConnectorV2::sendPXPError(const ActionResponse& response)
 {
     assert(response.valid(ActionResponse::ResponseType::RPCError));
 
     try {
-        send(std::vector<std::string> {
-                response.action_metadata.get<std::string>("requester") },
+        send(response.action_metadata.get<std::string>("requester"),
              PXPSchemas::PXP_ERROR_MSG_TYPE,
-             pcp_message_ttl_s,
              response.toJSON(ActionResponse::ResponseType::RPCError));
         LOG_INFO("Replied to {1} by {2}, request ID {3}, with a PXP error message",
                  response.prettyRequestLabel(),
@@ -134,8 +103,8 @@ void PXPConnector::sendPXPError(const ActionResponse& response)
     }
 }
 
-void PXPConnector::sendBlockingResponse(const ActionResponse& response,
-                                        const ActionRequest& request)
+void PXPConnectorV2::sendBlockingResponse(const ActionResponse& response,
+                                          const ActionRequest& request)
 {
     assert(response.valid(ActionResponse::ResponseType::Blocking));
     sendBlockingResponse_(ActionResponse::ResponseType::Blocking,
@@ -143,8 +112,8 @@ void PXPConnector::sendBlockingResponse(const ActionResponse& response,
                           request);
 }
 
-void PXPConnector::sendStatusResponse(const ActionResponse& response,
-                                      const ActionRequest& request)
+void PXPConnectorV2::sendStatusResponse(const ActionResponse& response,
+                                        const ActionRequest& request)
 {
     assert(response.valid(ActionResponse::ResponseType::StatusOutput));
     sendBlockingResponse_(ActionResponse::ResponseType::StatusOutput,
@@ -152,17 +121,15 @@ void PXPConnector::sendStatusResponse(const ActionResponse& response,
                           request);
 }
 
-void PXPConnector::sendNonBlockingResponse(const ActionResponse& response)
+void PXPConnectorV2::sendNonBlockingResponse(const ActionResponse& response)
 {
     assert(response.valid(ActionResponse::ResponseType::NonBlocking));
     assert(response.action_metadata.get<std::string>("status") != "undetermined");
 
     try {
         // NOTE(ale): assuming debug was sent in provisional response
-        send(std::vector<std::string> {
-                response.action_metadata.get<std::string>("requester") },
+        send(response.action_metadata.get<std::string>("requester"),
              PXPSchemas::NON_BLOCKING_RESPONSE_TYPE,
-             pcp_message_ttl_s,
              response.toJSON(ActionResponse::ResponseType::NonBlocking));
         LOG_INFO("Sent response for the {1} by {2}",
                  response.prettyRequestLabel(),
@@ -176,23 +143,36 @@ void PXPConnector::sendNonBlockingResponse(const ActionResponse& response)
     }
 }
 
+void PXPConnectorV2::connect(int max_connect_attempts)
+{
+    PCPClient::v2::Connector::connect(max_connect_attempts);
+}
+
+void PXPConnectorV2::monitorConnection(uint32_t max_connect_attempts,
+                                       uint32_t connection_check_interval_s)
+{
+    PCPClient::v2::Connector::monitorConnection(max_connect_attempts, connection_check_interval_s);
+}
+
+void PXPConnectorV2::registerMessageCallback(const PCPClient::Schema& schema,
+                                             MessageCallback callback)
+{
+    PCPClient::v2::Connector::registerMessageCallback(schema, callback);
+}
+
 //
 // Private interface
 //
 
-void PXPConnector::sendBlockingResponse_(
+void PXPConnectorV2::sendBlockingResponse_(
         const ActionResponse::ResponseType& response_type,
         const ActionResponse& response,
         const ActionRequest& request)
 {
-    auto debug = wrapDebug(request.parsedChunks());
-
     try {
-        send(std::vector<std::string> { request.sender() },
+        send(request.sender(),
              PXPSchemas::BLOCKING_RESPONSE_TYPE,
-             pcp_message_ttl_s,
-             response.toJSON(response_type),
-             debug);
+             response.toJSON(response_type));
         LOG_INFO("Sent response for the {1} by {2}",
                  request.prettyLabel(), request.sender());
     } catch (PCPClient::connection_error& e) {

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -18,6 +18,8 @@ set(COMMON_TEST_SOURCES
     unit/configuration_test.cc
     unit/external_module_test.cc
     unit/module_test.cc
+    unit/pxp_connector_v1_test.cc
+    unit/pxp_connector_v2_test.cc
     unit/request_processor_test.cc
     unit/results_mutex_test.cc
     unit/results_storage_test.cc

--- a/lib/tests/common/mock_connector.cc
+++ b/lib/tests/common/mock_connector.cc
@@ -2,11 +2,8 @@
 
 namespace PXPAgent {
 
-#ifdef TEST_VIRTUAL
-
 MockConnector::MockConnector()
-        : PXPConnector { AGENT_CONFIGURATION },
-          sent_provisional_response { false },
+        : sent_provisional_response { false },
           sent_non_blocking_response { false },
           sent_blocking_response { false }
 {
@@ -36,6 +33,12 @@ void MockConnector::sendBlockingResponse(const ActionResponse&,
     sent_blocking_response = true;
 }
 
+void MockConnector::sendStatusResponse(const ActionResponse& response,
+                                       const ActionRequest& request)
+{
+    throw MockConnector::pxpError_msg {};
+}
+
 void MockConnector::sendNonBlockingResponse(const ActionResponse&)
 {
     sent_non_blocking_response = true;
@@ -46,6 +49,21 @@ void MockConnector::sendProvisionalResponse(const ActionRequest&)
     sent_provisional_response = true;
 }
 
-#endif  // TEST_VIRTUAL
+void MockConnector::connect(int max_connect_attempts)
+{
+    throw MockConnector::pxpError_msg {};
+}
+
+void MockConnector::monitorConnection(uint32_t max_connect_attempts,
+                                      uint32_t connection_check_interval_s)
+{
+    throw MockConnector::pxpError_msg {};
+}
+
+void MockConnector::registerMessageCallback(const PCPClient::Schema& schema,
+                                            MessageCallback callback)
+{
+    throw MockConnector::pxpError_msg {};
+}
 
 }  // namespace PXPAgent

--- a/lib/tests/component/external_modules_interface_test.cc
+++ b/lib/tests/component/external_modules_interface_test.cc
@@ -21,8 +21,6 @@
 
 namespace PXPAgent {
 
-#ifdef TEST_VIRTUAL
-
 namespace lth_jc = leatherman::json_container;
 namespace lth_util = leatherman::util;
 namespace pcp_util = PCPClient::Util;
@@ -188,7 +186,5 @@ TEST_CASE("Process correctly requests for external modules", "[component]") {
 
     fs::remove_all(SPOOL);
 }
-
-#endif  // TEST_VIRTUAL
 
 }  // namespace PXPAgent

--- a/lib/tests/unit/agent_test.cc
+++ b/lib/tests/unit/agent_test.cc
@@ -21,6 +21,7 @@ const std::string SPOOL { std::string { PXP_AGENT_ROOT_PATH }
 TEST_CASE("Agent::Agent", "[agent]") {
     Configuration::Agent agent_configuration { MODULES,
                                                TEST_BROKER_WS_URIS,
+                                               "1",  // PCPv1
                                                getCaPath(),
                                                getCertPath(),
                                                getKeyPath(),
@@ -28,7 +29,7 @@ TEST_CASE("Agent::Agent", "[agent]") {
                                                "0d",  // don't purge!
                                                "",  // modules config dir
                                                "test_agent",
-                                               5000, 10, 5, 5, 2 };
+                                               5000, 10, 5, 5, 2, 15 };
 
     SECTION("does not throw if it fails to find the external modules directory") {
         agent_configuration.modules_dir = MODULES + "/fake_dir";

--- a/lib/tests/unit/configuration_test.cc
+++ b/lib/tests/unit/configuration_test.cc
@@ -48,6 +48,7 @@ static const char* ARGV[] = {
     "test-command",
     "--config-file", CONFIG.data(),
     "--broker-ws-uri", TEST_BROKER_WS_URI.data(),
+    "--pcp-version=2",
     "--ssl-ca-cert", CA.data(),
     "--ssl-cert", CERT.data(),
     "--ssl-key", KEY.data(),
@@ -56,7 +57,7 @@ static const char* ARGV[] = {
     "--spool-dir", SPOOL_DIR.data(),
     "--foreground=true",
     nullptr };
-static const int ARGC = 18;
+static const int ARGC = 19;
 
 static void configureTest() {
     if (!fs::exists(SPOOL_DIR) && !fs::create_directories(SPOOL_DIR)) {
@@ -186,8 +187,8 @@ TEST_CASE("Configuration::get", "[configuration]") {
         }
 
         SECTION("return the default value if the flag was not set") {
-            // NB: ignoring --foreground in ARGV since argc is set to 17
-            Configuration::Instance().parseOptions(17, const_cast<char**>(ARGV));
+            // NB: ignoring --foreground in ARGV since argc is set to 19
+            Configuration::Instance().parseOptions(18, const_cast<char**>(ARGV));
 #ifndef _WIN32
             HW::SetFlag<std::string>("pidfile", SPOOL_DIR + "/test.pid");
 #endif
@@ -227,6 +228,12 @@ TEST_CASE("Configuration::validate", "[configuration]") {
 
     SECTION("it throws an Error when the broker WebSocket URi is invalid") {
         HW::SetFlag<std::string>("broker-ws-uri", "ws://");
+        REQUIRE_THROWS_AS(Configuration::Instance().validate(),
+                          Configuration::Error);
+    }
+
+    SECTION("it throws an Error when the PCP version is invalid") {
+        HW::SetFlag<std::string>("pcp-version", "3");
         REQUIRE_THROWS_AS(Configuration::Instance().validate(),
                           Configuration::Error);
     }

--- a/lib/tests/unit/pxp_connector_v1_test.cc
+++ b/lib/tests/unit/pxp_connector_v1_test.cc
@@ -1,0 +1,15 @@
+#include "../common/mock_connector.hpp"
+
+#include <pxp-agent/pxp_connector_v1.hpp>
+
+#include <catch.hpp>
+
+namespace PXPAgent {
+
+TEST_CASE("PXPConnectorV1::PXPConnectorV1", "[agent]") {
+    SECTION("successfully instantiates with valid arguments") {
+        REQUIRE_NOTHROW(PXPConnectorV1{AGENT_CONFIGURATION});
+    };
+}
+
+}  // namespace PXPAgent

--- a/lib/tests/unit/pxp_connector_v2_test.cc
+++ b/lib/tests/unit/pxp_connector_v2_test.cc
@@ -1,0 +1,15 @@
+#include "../common/mock_connector.hpp"
+
+#include <pxp-agent/pxp_connector_v2.hpp>
+
+#include <catch.hpp>
+
+namespace PXPAgent {
+
+TEST_CASE("PXPConnectorV2::PXPConnectorV2", "[agent]") {
+    SECTION("successfully instantiates with valid arguments") {
+        REQUIRE_NOTHROW(PXPConnectorV2{AGENT_CONFIGURATION});
+    };
+}
+
+}  // namespace PXPAgent

--- a/lib/tests/unit/request_processor_test.cc
+++ b/lib/tests/unit/request_processor_test.cc
@@ -24,7 +24,7 @@ namespace pcp_util = PCPClient::Util;
 namespace fs = boost::filesystem;
 
 TEST_CASE("RequestProcessor::RequestProcessor", "[agent]") {
-    auto c_ptr = std::make_shared<PXPConnector>(AGENT_CONFIGURATION);
+    auto c_ptr = std::make_shared<MockConnector>();
 
     SECTION("successfully instantiates with valid arguments") {
         REQUIRE_NOTHROW(RequestProcessor(c_ptr, AGENT_CONFIGURATION));
@@ -42,7 +42,7 @@ TEST_CASE("RequestProcessor::RequestProcessor", "[agent]") {
 
 TEST_CASE("RequestProcessor::hasModule", "[agent]") {
     AGENT_CONFIGURATION.modules_config_dir = VALID_MODULES_CONFIG;
-    auto c_ptr = std::make_shared<PXPConnector>(AGENT_CONFIGURATION);
+    auto c_ptr = std::make_shared<MockConnector>();
     RequestProcessor r_p { c_ptr, AGENT_CONFIGURATION };
 
     SECTION("returns true if the requested module was loaded") {
@@ -57,7 +57,7 @@ TEST_CASE("RequestProcessor::hasModule", "[agent]") {
 TEST_CASE("RequestProcessor::hasModuleConfig", "[agent]") {
     SECTION("valid module configuration") {
         AGENT_CONFIGURATION.modules_config_dir = VALID_MODULES_CONFIG;
-        auto c_ptr = std::make_shared<PXPConnector>(AGENT_CONFIGURATION);
+        auto c_ptr = std::make_shared<MockConnector>();
         RequestProcessor r_p { c_ptr, AGENT_CONFIGURATION };
 
         REQUIRE(r_p.hasModuleConfig("reverse_valid"));
@@ -65,7 +65,7 @@ TEST_CASE("RequestProcessor::hasModuleConfig", "[agent]") {
 
     SECTION("badly formatted module configuration") {
         AGENT_CONFIGURATION.modules_config_dir = BAD_FORMAT_MODULES_CONFIG;
-        auto c_ptr = std::make_shared<PXPConnector>(AGENT_CONFIGURATION);
+        auto c_ptr = std::make_shared<MockConnector>();
         RequestProcessor r_p { c_ptr, AGENT_CONFIGURATION };
 
         REQUIRE(r_p.hasModuleConfig("reverse_valid"));
@@ -73,7 +73,7 @@ TEST_CASE("RequestProcessor::hasModuleConfig", "[agent]") {
 
     SECTION("non existent module configuration") {
         AGENT_CONFIGURATION.modules_config_dir = VALID_MODULES_CONFIG;
-        auto c_ptr = std::make_shared<PXPConnector>(AGENT_CONFIGURATION);
+        auto c_ptr = std::make_shared<MockConnector>();
         RequestProcessor r_p { c_ptr, AGENT_CONFIGURATION };
 
         REQUIRE_FALSE(r_p.hasModuleConfig("this_module_here_does_not_exist"));
@@ -83,7 +83,7 @@ TEST_CASE("RequestProcessor::hasModuleConfig", "[agent]") {
 TEST_CASE("RequestProcessor::getModuleConfig", "[agent]") {
     SECTION("valid module configuration") {
         AGENT_CONFIGURATION.modules_config_dir = VALID_MODULES_CONFIG;
-        auto c_ptr = std::make_shared<PXPConnector>(AGENT_CONFIGURATION);
+        auto c_ptr = std::make_shared<MockConnector>();
         RequestProcessor r_p { c_ptr, AGENT_CONFIGURATION };
         auto json_txt = r_p.getModuleConfig("reverse_valid");
 
@@ -97,7 +97,7 @@ TEST_CASE("RequestProcessor::getModuleConfig", "[agent]") {
 
     SECTION("badly formatted module configuration") {
         AGENT_CONFIGURATION.modules_config_dir = BAD_FORMAT_MODULES_CONFIG;
-        auto c_ptr = std::make_shared<PXPConnector>(AGENT_CONFIGURATION);
+        auto c_ptr = std::make_shared<MockConnector>();
         RequestProcessor r_p { c_ptr, AGENT_CONFIGURATION };
 
         REQUIRE(r_p.getModuleConfig("reverse_valid") ==  "null");
@@ -105,15 +105,13 @@ TEST_CASE("RequestProcessor::getModuleConfig", "[agent]") {
 
     SECTION("non existent module configuration") {
         AGENT_CONFIGURATION.modules_config_dir = VALID_MODULES_CONFIG;
-        auto c_ptr = std::make_shared<PXPConnector>(AGENT_CONFIGURATION);
+        auto c_ptr = std::make_shared<MockConnector>();
         RequestProcessor r_p { c_ptr, AGENT_CONFIGURATION };
 
         REQUIRE_THROWS_AS(r_p.getModuleConfig("this_module_here_does_not_exist"),
                           RequestProcessor::Error);
     }
 }
-
-#ifdef TEST_VIRTUAL
 
 // NOTE(ale): the following tests require the MockConnector since they
 // trigger WebSocket functions.
@@ -156,7 +154,5 @@ TEST_CASE("RequestProcessor::processRequest", "[agent]") {
 
     fs::remove_all(SPOOL);
 }
-
-#endif  // TEST_VIRTUAL
 
 }  // namespace PXPAgent

--- a/locales/pxp-agent.pot
+++ b/locales/pxp-agent.pot
@@ -118,6 +118,16 @@ msgstr ""
 msgid "invalid action metadata"
 msgstr ""
 
+#. info
+#: lib/src/agent.cc
+msgid "Connecting using PCP v1"
+msgstr ""
+
+#. info
+#: lib/src/agent.cc
+msgid "Connecting using PCP v2"
+msgstr ""
+
 #. warning
 #: lib/src/agent.cc
 msgid ""
@@ -216,6 +226,10 @@ msgid "WebSocket URI of the PCP broker"
 msgstr ""
 
 #: lib/src/configuration.cc
+msgid "PCP version to use for communication"
+msgstr ""
+
+#: lib/src/configuration.cc
 msgid "Timeout (in seconds) for starting the WebSocket handshake, default: 5 s"
 msgstr ""
 
@@ -308,6 +322,10 @@ msgstr ""
 
 #: lib/src/configuration.cc
 msgid "broker-ws-uri or broker-ws-uris must be defined"
+msgstr ""
+
+#: lib/src/configuration.cc
+msgid "pcp-version must be either '1' or '2'"
 msgstr ""
 
 #. info
@@ -609,61 +627,70 @@ msgid "debug entry is not valid JSON"
 msgstr ""
 
 #. warning
-#: lib/src/pxp_connector.cc
+#: lib/src/pxp_connector_v1.cc
 msgid "Message {1} contained {2} bad debug chunk"
 msgstr ""
 
 #. warning
-#: lib/src/pxp_connector.cc
+#: lib/src/pxp_connector_v1.cc
 msgid "Message {1} contained {2} bad debug chunks"
 msgstr ""
 
 #. info
-#: lib/src/pxp_connector.cc
+#: lib/src/pxp_connector_v1.cc
+#: lib/src/pxp_connector_v2.cc
 msgid "Replied to request {1} with a PCP error message"
 msgstr ""
 
 #. error
-#: lib/src/pxp_connector.cc
+#: lib/src/pxp_connector_v1.cc
+#: lib/src/pxp_connector_v2.cc
 msgid "Failed to send PCP error message for request {1}: {2}"
 msgstr ""
 
 #. info
-#: lib/src/pxp_connector.cc
+#: lib/src/pxp_connector_v1.cc
+#: lib/src/pxp_connector_v2.cc
 msgid "Sent provisional response for the {1} by {2}"
 msgstr ""
 
 #. error
-#: lib/src/pxp_connector.cc
+#: lib/src/pxp_connector_v1.cc
+#: lib/src/pxp_connector_v2.cc
 msgid ""
 "Failed to send provisional response for the {1} by {2} (no further attempts "
 "will be made): {3}"
 msgstr ""
 
 #. info
-#: lib/src/pxp_connector.cc
+#: lib/src/pxp_connector_v1.cc
+#: lib/src/pxp_connector_v2.cc
 msgid "Replied to {1} by {2}, request ID {3}, with a PXP error message"
 msgstr ""
 
 #. error
-#: lib/src/pxp_connector.cc
+#: lib/src/pxp_connector_v1.cc
+#: lib/src/pxp_connector_v2.cc
 msgid ""
 "Failed to send a PXP error message for the {1} by {2} (no further sending "
 "attempts will be made): {3}"
 msgstr ""
 
 #. info
-#: lib/src/pxp_connector.cc
+#: lib/src/pxp_connector_v1.cc
+#: lib/src/pxp_connector_v2.cc
 msgid "Sent response for the {1} by {2}"
 msgstr ""
 
 #. error
-#: lib/src/pxp_connector.cc
+#: lib/src/pxp_connector_v1.cc
+#: lib/src/pxp_connector_v2.cc
 msgid "Failed to reply to {1} by {2}, (no further attempts will be made): {3}"
 msgstr ""
 
 #. error
-#: lib/src/pxp_connector.cc
+#: lib/src/pxp_connector_v1.cc
+#: lib/src/pxp_connector_v2.cc
 msgid "Failed to reply to the {1} by {2}: {3}"
 msgstr ""
 


### PR DESCRIPTION
Adds a connector for PCP version 2 while retaining a PCP version
1-compatible connector as well. Adds `pcp-version` option to select
between `1` and `2`.

Depends on https://github.com/puppetlabs/cpp-pcp-client/pull/211.