### PR TITLE
(PCP-469) Add hidden option for configuring ping interval

### DIFF
--- a/lib/inc/pxp-agent/agent.hpp
+++ b/lib/inc/pxp-agent/agent.hpp
@@ -60,6 +60,9 @@ class Agent {
     // Request Processor
     RequestProcessor request_processor_;
 
+    // Ping interval in seconds
+    uint32_t ping_interval_s_;
+
     // Callback for PCPClient::Connector handling incoming PXP
     // blocking requests; it will execute the requested action and,
     // once finished, reply to the sender with an PXP blocking

--- a/lib/inc/pxp-agent/configuration.hpp
+++ b/lib/inc/pxp-agent/configuration.hpp
@@ -138,6 +138,7 @@ class Configuration
         uint32_t association_request_ttl_s;
         uint32_t pcp_message_ttl_s;
         uint32_t allowed_keepalive_timeouts;
+        uint32_t ping_interval_s;
     };
 
     /// Reset the HorseWhisperer singleton.

--- a/lib/src/agent.cc
+++ b/lib/src/agent.cc
@@ -23,7 +23,8 @@ static const uint32_t ASSOCIATE_SESSION_TIMEOUT_PAUSE_S { 5 };
 Agent::Agent(const Configuration::Agent& agent_configuration)
         try
             : connector_ptr_ { new PXPConnector(agent_configuration) },
-              request_processor_ { connector_ptr_, agent_configuration } {
+              request_processor_ { connector_ptr_, agent_configuration },
+              ping_interval_s_ { agent_configuration.ping_interval_s } {
 } catch (const PCPClient::connection_config_error& e) {
     throw Agent::WebSocketConfigurationError { e.what() };
 }
@@ -69,7 +70,7 @@ void Agent::start() {
         // connector will keep trying to re-establish it indefinitely
         // (the max_connect_attempts is 0 by default).
         LOG_DEBUG("PCP connection established; about to start monitoring it");
-        connector_ptr_->monitorConnection();
+        connector_ptr_->monitorConnection(0, ping_interval_s_);
     } catch (const PCPClient::connection_config_error& e) {
         // WebSocket configuration failure
         throw Agent::WebSocketConfigurationError { e.what() };

--- a/lib/src/configuration.cc
+++ b/lib/src/configuration.cc
@@ -301,7 +301,8 @@ const Configuration::Agent& Configuration::getAgentConfiguration() const
         static_cast<uint32_t >(HW::GetFlag<int>("association-timeout")),
         static_cast<uint32_t >(HW::GetFlag<int>("association-request-ttl")),
         static_cast<uint32_t >(HW::GetFlag<int>("pcp-message-ttl")),
-        static_cast<uint32_t >(HW::GetFlag<int>("allowed-keepalive-timeouts")) };
+        static_cast<uint32_t >(HW::GetFlag<int>("allowed-keepalive-timeouts")),
+        static_cast<uint32_t >(HW::GetFlag<int>("ping-interval")) };
     return agent_configuration_;
 }
 
@@ -398,6 +399,16 @@ void Configuration::defineDefaultValues()
                     "<hidden>",
                     Types::Int,
                     2) } });
+
+    // Hidden option: interval between pings, default 15 s
+    defaults_.insert(
+        Option { "ping-interval",
+                 Base_ptr { new Entry<int>(
+                    "ping-interval",
+                    "",
+                    "<hidden>",
+                    Types::Int,
+                    15) } });
 
     // Hidden option: PCP Association timeout, default: 15 s
     defaults_.insert(


### PR DESCRIPTION
Adds a hidden option that can be used to configure the websocket ping
interval from the default of 15 seconds.