### PR TITLE
(PCP-661) Test using PCP v2 by default

### DIFF
--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -7,3 +7,6 @@ They can be configured to test against other versions of pcp-broker by setting e
     PCP_BROKER_FORK=puppetlabs
     PCP_BROKER_REF=0.8.4
 
+To test using PCP v2 - when using a broker that supports it - use
+
+    PCP_VERSION=2

--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -7,6 +7,6 @@ They can be configured to test against other versions of pcp-broker by setting e
     PCP_BROKER_FORK=puppetlabs
     PCP_BROKER_REF=0.8.4
 
-To test using PCP v2 - when using a broker that supports it - use
+Default settings use PCP v2. To test using PCP v1 set
 
-    PCP_VERSION=2
+    PCP_VERSION=1

--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -10,3 +10,9 @@ They can be configured to test against other versions of pcp-broker by setting e
 Default settings use PCP v2. To test using PCP v1 set
 
     PCP_VERSION=1
+
+To run acceptance tests, a build of puppet-agent is required. An example of how to run them is
+
+    rake ci:test:aio SHA=1.8.2 TEST_TARGET=centos7-64a
+
+You can run `rake ci:test:aio` to get more detailed help about how to configure testing.

--- a/acceptance/lib/pxp-agent/config_helper.rb
+++ b/acceptance/lib/pxp-agent/config_helper.rb
@@ -7,7 +7,7 @@ PXP_CONFIG_DIR_POSIX   = '/etc/puppetlabs/pxp-agent/'
 PCP_BROKER_PORTS       = [8142, 8143]
 PCP_BROKER_REPL_PORTS  = [7888, 7889]
 
-PCP_VERSION = ENV['PCP_VERSION'] || '1'
+PCP_VERSION = ENV['PCP_VERSION'] || '2'
 
 def windows?(host)
   host.platform.upcase.start_with?('WINDOWS')

--- a/acceptance/lib/pxp-agent/test_helper.rb
+++ b/acceptance/lib/pxp-agent/test_helper.rb
@@ -365,7 +365,7 @@ def connect_pcp_client(broker)
 
     client_type = "ruby-pcp-client-#{$$}"
     client = PCP::Client.new({
-      :server => broker_ws_uri(broker)+client_type,
+      :server => broker_ws_uri(broker, 1)+client_type,
       :ssl_ca_cert => "tmp/ssl/certs/ca.pem",
       :ssl_cert => "tmp/ssl/certs/#{hostname.downcase}.pem",
       :ssl_key => "tmp/ssl/private_keys/#{hostname.downcase}.pem",

--- a/acceptance/setup/common/050_Setup_Broker.rb
+++ b/acceptance/setup/common/050_Setup_Broker.rb
@@ -16,7 +16,7 @@ NUM_BROKERS = 2
 have_broker_replica = NUM_BROKERS > 1
 
 PCP_BROKER_FORK = ENV['PCP_BROKER_FORK'] || nil
-PCP_BROKER_REF  = ENV['PCP_BROKER_REF'] || 'refs/tags/0.8.4'
+PCP_BROKER_REF  = ENV['PCP_BROKER_REF'] || 'refs/tags/1.0.0'
 
 step 'Clone pcp-broker to broker_hosts' do
   pcp_broker_url = build_git_url('pcp-broker', PCP_BROKER_FORK, nil, 'https')


### PR DESCRIPTION
Enable configuration of PCP version for testing, and use PCP v2 by default.

Blocked on https://github.com/puppetlabs/pxp-agent/pull/531.