### PR TITLE
(PCP-676) Remove ping dependency on debug chunks

### DIFF
--- a/lib/src/modules/ping.cc
+++ b/lib/src/modules/ping.cc
@@ -33,21 +33,21 @@ lth_jc::JsonContainer Ping::ping(const ActionRequest& request) {
     lth_jc::JsonContainer data {};
 
     if (request.parsedChunks().debug.empty()) {
-        LOG_ERROR("Found no debug entry in the request message");
-        throw Module::ProcessingError { lth_loc::translate("no debug entry") };
-    }
+        LOG_DEBUG("Found no debug entry in the request message");
+        data.set<std::vector<lth_jc::JsonContainer>>("request_hops", {});
+    } else {
+        auto& debug_entry = request.parsedChunks().debug[0];
 
-    auto& debug_entry = request.parsedChunks().debug[0];
-
-    try {
-        data.set<std::vector<lth_jc::JsonContainer>>(
+        try {
+            data.set<std::vector<lth_jc::JsonContainer>>(
                 "request_hops",
                 debug_entry.get<std::vector<lth_jc::JsonContainer>>("hops"));
-    } catch (lth_jc::data_parse_error& e) {
-        LOG_ERROR("Failed to parse debug entry: {1}", e.what());
-        LOG_DEBUG("Debug entry: {1}", debug_entry.toString());
-        throw Module::ProcessingError {
-            lth_loc::translate("debug entry is not valid JSON") };
+        } catch (lth_jc::data_parse_error& e) {
+            LOG_ERROR("Failed to parse debug entry: {1}", e.what());
+            LOG_DEBUG("Debug entry: {1}", debug_entry.toString());
+            throw Module::ProcessingError {
+                lth_loc::translate("debug entry is not valid JSON") };
+        }
     }
     return data;
 }

--- a/lib/tests/unit/modules/ping_test.cc
+++ b/lib/tests/unit/modules/ping_test.cc
@@ -74,6 +74,22 @@ TEST_CASE("Modules::Ping::ping", "[modules]") {
         "}"
     };
 
+    SECTION("it should respond when debug chunks are omitted") {
+        auto data_txt = (data_format % "").str();
+        PCPClient::ParsedChunks other_chunks {
+                    lth_jc::JsonContainer(ENVELOPE_TXT),
+                    lth_jc::JsonContainer(PING_TXT),
+                    std::vector<lth_jc::JsonContainer>{},
+                    0 };
+        ActionRequest other_request { RequestType::Blocking, other_chunks };
+
+        auto result = ping_module.ping(other_request);
+        std::cout << result.toString() << std::endl;
+        auto hops = result.get<std::vector<lth_jc::JsonContainer>>(
+                        "request_hops");
+        REQUIRE(hops.empty());
+    }
+
     boost::format debug_format { "{ \"hops\" : %1% }" };  // vector<JsonContainer>
 
     SECTION("it should copy an empty hops entry") {

--- a/locales/pxp-agent.pot
+++ b/locales/pxp-agent.pot
@@ -585,13 +585,9 @@ msgstr ""
 msgid "Failed to execute the task for the {1}. {2}"
 msgstr ""
 
-#. error
+#. debug
 #: lib/src/modules/ping.cc
 msgid "Found no debug entry in the request message"
-msgstr ""
-
-#: lib/src/modules/ping.cc
-msgid "no debug entry"
 msgstr ""
 
 #. error


### PR DESCRIPTION
If no debug chunks are included, ping will respond with an empty
"request_hops" entry.