### PR TITLE
(PCP-686) Bump version of pxp-agent to 1.2.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.2.2)
-project(pxp-agent VERSION 1.2.2)
+project(pxp-agent VERSION 1.2.3)
 
 if (NOT CMAKE_BUILD_TYPE)
     message(STATUS "Defaulting to a release build.")


### PR DESCRIPTION
For the upcoming puppet-agent 1.7.2 release