### PR TITLE
(packaging) Bump version to 1.3.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.2.2)
-project(pxp-agent VERSION 1.3.2)
+project(pxp-agent VERSION 1.3.3)
 
 if (NOT CMAKE_BUILD_TYPE)
     message(STATUS "Defaulting to a release build.")


### PR DESCRIPTION
This commit updates pxp-agent's version to 1.3.3 following the release
of 1.3.2 as part of puppet-agent 1.8.3