### PR TITLE
(PCP-615) Acceptance - allow longer wait for sleep process on agent

### DIFF
--- a/acceptance/lib/pxp-agent/test_helper.rb
+++ b/acceptance/lib/pxp-agent/test_helper.rb
@@ -415,9 +415,9 @@ def wait_for_sleep_process(target)
   begin
     ps_cmd = target['platform'] =~ /win/ ? 'ps -efW' : 'ps -ef'
     sleep_process = target['platform'] =~ /win/ ? 'PING' : '/bin/sleep'
-    retry_on(target, "#{ps_cmd} | grep '#{sleep_process}' | grep -v 'grep'", {:max_retries => 15, :retry_interval => 2})
+    retry_on(target, "#{ps_cmd} | grep '#{sleep_process}' | grep -v 'grep'", {:max_retries => 120, :retry_interval => 1})
   rescue
-    fail("After triggering a puppet run on #{target} the expected sleep process did not appear in process list")
+    raise("After triggering a puppet run on #{target} the expected sleep process did not appear in process list")
   end
 end
 


### PR DESCRIPTION
acceptance/tests/pxp-module-puppet/restart_pxp_agent_during_non_blocking_run.rb fails on
slower hosts, where our helper allows 30 seconds (15 retries at 2 second interval) for
a sleep process to appear on agent, but the process takes longer to appear.

This commit increases the allowed time to 120 (120 retries at 1 second interval) to
allow substantially more time for sleep to be running.

Also changed the timeout behavior to raise() instead of fail() so that the calling test
gets a Error result instead of a Failed result.

[skip ci]