### PR TITLE
(maint) Reset acceptance to use pcp-broker#master

### DIFF
--- a/acceptance/setup/common/050_Setup_Broker.rb
+++ b/acceptance/setup/common/050_Setup_Broker.rb
@@ -16,7 +16,7 @@ NUM_BROKERS = 2
 have_broker_replica = NUM_BROKERS > 1
 
 PCP_BROKER_FORK = ENV['PCP_BROKER_FORK'] || nil
-PCP_BROKER_REF  = ENV['PCP_BROKER_REF'] || 'refs/tags/1.0.0'
+PCP_BROKER_REF  = ENV['PCP_BROKER_REF'] || 'master'
 
 step 'Clone pcp-broker to broker_hosts' do
   pcp_broker_url = build_git_url('pcp-broker', PCP_BROKER_FORK, nil, 'https')


### PR DESCRIPTION
Updates acceptance tests to operate against pcp-broker#master. This
helps catch compatibility failures between client and master.