### PR TITLE
(PCP-627) Send provisional response for conflicting transaction-id

### DIFF
--- a/acceptance/tests/pxp-module-puppet/rerun_transaction.rb
+++ b/acceptance/tests/pxp-module-puppet/rerun_transaction.rb
@@ -1,0 +1,60 @@
+require 'pxp-agent/test_helper.rb'
+
+
+STATUS_QUERY_MAX_RETRIES = 60
+STATUS_QUERY_INTERVAL_SECONDS = 1
+
+test_name 'C99777 - two runs with same transaction_id' do
+
+  step 'Ensure each agent host has pxp-agent running and associated' do
+    agents.each do |agent|
+      on agent, puppet('resource service pxp-agent ensure=stopped')
+      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
+      on agent, puppet('resource service pxp-agent ensure=running')
+      show_pcp_logs_on_failure do
+        assert(is_associated?(master, "pcp://#{agent}/agent"),
+               "Agent #{agent} with PCP identity pcp://#{agent}/agent should be associated with pcp-broker")
+      end
+    end
+  end
+
+  target_identities = agents.map {|agent| "pcp://#{agent}/agent"}
+  transaction_ids = []
+  run_results = []
+
+  step "run puppet to generate a transaction_id" do
+    transaction_ids = start_puppet_non_blocking_request(master, target_identities)
+    target_identities.zip(transaction_ids).each do |identity, transaction_id|
+      run_results << check_puppet_non_blocking_response(identity, transaction_id, STATUS_QUERY_MAX_RETRIES, STATUS_QUERY_INTERVAL_SECONDS, "unchanged")
+    end
+  end
+
+  step "restart pxp" do
+    agents.each do |agent|
+      on agent, puppet('resource service pxp-agent ensure=stopped')
+      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
+      on agent, puppet('resource service pxp-agent ensure=running')
+      show_pcp_logs_on_failure do
+        assert(is_associated?(master, "pcp://#{agent}/agent"),
+               "Agent #{agent} with PCP identity pcp://#{agent}/agent should be associated with pcp-broker")
+      end
+    end
+  end
+
+  step "rerun with same transaction_id, expect provisional response and status queryable" do
+    target_identities.zip(transaction_ids, run_results).each do |identity, transaction_id, first_run_result|
+      # This should fail!
+      response = rpc_request(master, [identity],
+                             'pxp-module-puppet', 'run',
+                             {:flags => ['--onetime',
+                                         '--no-daemonize',
+                                         '--environment', 'production']},
+                                         false,
+                                         transaction_id)[identity]
+
+      assert_equal(response[:envelope][:message_type], 'http://puppetlabs.com/rpc_provisional_response', 'Did not receive rpc provisional response')
+      second_run_result = check_puppet_non_blocking_response(identity, transaction_id, STATUS_QUERY_MAX_RETRIES, STATUS_QUERY_INTERVAL_SECONDS, "unchanged")
+      assert_equal(first_run_result, second_run_result, 'Run results were not identical, Puppet may have run again')
+    end
+  end
+end # test

--- a/lib/src/request_processor.cc
+++ b/lib/src/request_processor.cc
@@ -369,10 +369,11 @@ void RequestProcessor::processNonBlockingRequest(const ActionRequest& request)
         // same transaction_id
         pcp_util::lock_guard<pcp_util::mutex> lck { thread_container_mutex_ };
 
+        // If the task has already been started or run, return a provisional response again.
         if (thread_container_.find(request.transactionId())) {
-            err_msg =
-                lth_loc::format("already exists an ongoing task with transaction id {1}",
-                                request.transactionId());
+            LOG_DEBUG("already exists an ongoing task with transaction id {1}", request.transactionId());
+        } else if (storage_ptr_->find(request.transactionId())) {
+            LOG_DEBUG("already exists a previous task with transaction id {1}", request.transactionId());
         } else {
             try {
                 // Initialize the action metadata file

--- a/lib/tests/component/external_modules_interface_test.cc
+++ b/lib/tests/component/external_modules_interface_test.cc
@@ -165,7 +165,7 @@ TEST_CASE("Process correctly requests for external modules", "[component]") {
             REQUIRE_FALSE(c_ptr->sent_non_blocking_response);
         }
 
-        SECTION("send a pxp error when a duplicate request for an active"
+        SECTION("send a provisional response when a duplicate request for an active"
                 " action is received") {
             REQUIRE_FALSE(c_ptr->sent_provisional_response);
 
@@ -193,8 +193,9 @@ TEST_CASE("Process correctly requests for external modules", "[component]") {
             test_storage.updateMetadataFile(t_id, dummy_metadata);
 
             // Resend the same request
-            REQUIRE_THROWS_AS(r_p.processRequest(RequestType::NonBlocking, p_c),
-                              MockConnector::pxpError_msg);
+            c_ptr->sent_provisional_response = false;
+            REQUIRE_NOTHROW(r_p.processRequest(RequestType::NonBlocking, p_c));
+            REQUIRE(c_ptr->sent_provisional_response);
 
             // Verify metadata file wasn't updated, i.e. no action was run.
             REQUIRE(dummy_metadata.toString() == test_storage.getActionMetadata(t_id).toString());
@@ -233,8 +234,8 @@ TEST_CASE("Process correctly requests for external modules", "[component]") {
             REQUIRE_NOTHROW(r_p2.processRequest(RequestType::NonBlocking, p_c));
             REQUIRE(c_ptr->sent_provisional_response);
 
-            // Verify metadata file was updated, i.e. the action was re-run.
-            REQUIRE(dummy_metadata.toString() != test_storage.getActionMetadata(t_id).toString());
+            // Verify metadata file wasn't updated, i.e. no action was run.
+            REQUIRE(dummy_metadata.toString() == test_storage.getActionMetadata(t_id).toString());
         }
 
         SECTION("send a non-blocking response when the requested action succeeds") {

--- a/locales/pxp-agent.pot
+++ b/locales/pxp-agent.pot
@@ -793,8 +793,14 @@ msgid ""
 "ID as identifier)"
 msgstr ""
 
+#. debug
 #: lib/src/request_processor.cc
 msgid "already exists an ongoing task with transaction id {1}"
+msgstr ""
+
+#. debug
+#: lib/src/request_processor.cc
+msgid "already exists a previous task with transaction id {1}"
 msgstr ""
 
 #: lib/src/request_processor.cc


### PR DESCRIPTION
Changes the behavior of a duplicate nonblocking request to send a
provisional response instead of a pxp error.

Previously we checked to make sure the transaction ID was not
currently in a thread. This commit checks the on disk storage as well
in case the agent has restarted.