### PR TITLE
(PCP-612) Re-enable Cisco IOS XR platform

### DIFF
--- a/acceptance/Rakefile
+++ b/acceptance/Rakefile
@@ -88,10 +88,6 @@ EOS
 
   target = ENV['TEST_TARGET']
 
-  if target =~ /^ciscoxr/
-    abort "PCP-685: Skipping tests on Cisco XR"
-  end
-
   master_host = ENV['MASTER_TEST_TARGET'] || 'redhat7-64m'
   if target && !target.start_with?(master_host)
     target = "#{master_host}-#{target}"

--- a/acceptance/config/aio/options.rb
+++ b/acceptance/config/aio/options.rb
@@ -10,6 +10,7 @@
     'setup/common/005_SyncTime.rb',
     'setup/aio/pre-suite/010_Install.rb',
     'setup/aio/021_InstallAristaModule.rb',
+    'setup/common/022_Remove_LD_PRELOAD.rb',
     'setup/common/035_StartPuppetServer.rb',
     'setup/common/040_ValidateSignCert.rb',
     'setup/common/045_SetPuppetServerOnAgents.rb',

--- a/acceptance/setup/common/022_Remove_LD_PRELOAD.rb
+++ b/acceptance/setup/common/022_Remove_LD_PRELOAD.rb
@@ -1,0 +1,11 @@
+platforms = hosts.map{|val| val[:platform]}
+skip_test "No Cisco XR hosts present" unless platforms.any? { |val| /^cisco_ios_xr-/ =~ val }
+test_name 'Cisco XR Switch Pre-suite' do
+  switchs = select_hosts({:platform => ['cisco_ios_xr-6-x86_64']})
+
+  step 'remove LD_PRELOAD setting from switch' do
+    switchs.each do |switch|
+      on(switch, "echo 'unset LD_PRELOAD' >> /etc/profile")
+    end
+  end
+end

--- a/acceptance/tests/restart_host_run_puppet.rb
+++ b/acceptance/tests/restart_host_run_puppet.rb
@@ -9,9 +9,9 @@ test_name 'C94777 - Ensure pxp-agent functions after agent host restart' do
     skip_test('QENG-3629 - AIX hosts cannot be restarted')
   end
 
-  applicable_agents = applicable_agents.select { |agent| agent['platform'] !~ /cisco_nexus/}
+  applicable_agents = applicable_agents.select { |agent| agent['platform'] !~ /cisco_nexus|cisco_ios_xr/ }
   unless applicable_agents.length > 0 then
-    skip_test('PCP-508 - CiscoNX hosts cannot be restarted')
+    skip_test('PCP-508 - CiscoNX and Cisco IOS XR hosts cannot be restarted')
   end
 
   applicable_agents = applicable_agents.select { |agent| agent['platform'] != "eos-4-i386"}


### PR DESCRIPTION
As in Facter, we have to unset LD_PRELOAD. Leaving it set results in
`errno` being set to non-zero at the start of execution.

This depends on https://github.com/puppetlabs/pl-build-tools-vanagon/pull/9 being merged and new packages built.