### PR TITLE
(PCP-529) Archive logs from acceptance runs

### DIFF
--- a/acceptance/config/aio/options.rb
+++ b/acceptance/config/aio/options.rb
@@ -17,4 +17,7 @@
     'setup/common/050_Setup_Broker.rb',
     'setup/common/060_Setup_PCP_Client.rb',
   ],
+  :post_suite => [
+    'teardown/common/099_Archive_Logs.rb',
+  ],
 }

--- a/acceptance/lib/pxp-agent/test_helper.rb
+++ b/acceptance/lib/pxp-agent/test_helper.rb
@@ -55,31 +55,6 @@ def expect_file_on_host_to_contain(host, file, expected, seconds=30)
   end
 end
 
-# Show the logs of the broker and agents - useful to see why a test failed
-def show_pcp_logs
-  logger.notify "---- Broker log -----"
-  on(master, "cat /var/log/puppetlabs/pcp-broker.log") do |result|
-    logger.notify result.stdout
-  end
-
-  agents.each do |agent|
-    logger.notify "----- agent #{agent} log -----"
-    on(agent, "cat #{logfile(agent)}") do |result|
-      logger.notify result.stdout
-    end
-  end
-end
-
-# Evaluate the block, show logs if test assertions were triggered
-def show_pcp_logs_on_failure(&block)
-  yield
-rescue MiniTest::Assertion => exception
-  logger.notify "Assertion failed in test: #{exception}"
-  logger.notify "Fetching logs for inspection"
-  show_pcp_logs
-  raise exception
-end
-
 # Some helpers for working with a pcp-broker 'lein tk' instance
 def run_pcp_broker(host, instance=0)
   host[:pcp_broker_instance] = instance

--- a/acceptance/lib/pxp-agent/test_helper.rb
+++ b/acceptance/lib/pxp-agent/test_helper.rb
@@ -5,6 +5,7 @@ require 'net/http'
 require 'openssl'
 require 'socket'
 require 'json'
+require 'securerandom'
 
 # This file contains general test helper methods for pxp-agent acceptance tests
 
@@ -12,15 +13,26 @@ require 'json'
 GIT_CLONE_FOLDER = '/opt/puppet-git-repos'
 
 # Some helpers for working with the log file
-PXP_LOG_FILE_CYGPATH = '/cygdrive/c/ProgramData/PuppetLabs/pxp-agent/var/log/pxp-agent.log'
-PXP_LOG_FILE_POSIX = '/var/log/puppetlabs/pxp-agent/pxp-agent.log'
+PXP_LOG_DIR_CYGPATH = '/cygdrive/c/ProgramData/PuppetLabs/pxp-agent/var/log'
+PXP_LOG_DIR_POSIX = '/var/log/puppetlabs/pxp-agent'
+
+def logdir(host)
+  windows?(host)?
+    PXP_LOG_DIR_CYGPATH :
+    PXP_LOG_DIR_POSIX
+end
 
 # @param host the beaker host you want the path to the log file on
 # @return The path to the log file on the host. For Windows, a cygpath is returned
 def logfile(host)
-  windows?(host)?
-    PXP_LOG_FILE_CYGPATH :
-    PXP_LOG_FILE_POSIX
+  logdir(host)+'/pxp-agent.log'
+end
+
+def reset_logfile(host)
+  old_logfile = logfile(host)
+  new_logfile = old_logfile+'.'+SecureRandom.uuid
+  logger.notify "---- Saving pxp-agent logfile to #{new_logfile}"
+  retry_on(host, "test ! -f #{old_logfile} || mv #{old_logfile} #{new_logfile}")
 end
 
 # A general helper for waiting for a file to contain some string, and failing the test if it doesn't appear
@@ -46,7 +58,7 @@ end
 # Show the logs of the broker and agents - useful to see why a test failed
 def show_pcp_logs
   logger.notify "---- Broker log -----"
-  on(master, "cat /var/log/pcp-broker.log") do |result|
+  on(master, "cat /var/log/puppetlabs/pcp-broker.log") do |result|
     logger.notify result.stdout
   end
 
@@ -72,7 +84,7 @@ end
 def run_pcp_broker(host, instance=0)
   host[:pcp_broker_instance] = instance
   on(host, "cd #{GIT_CLONE_FOLDER}/pcp-broker#{instance}; export LEIN_ROOT=ok; \
-     lein with-profile internal-mirrors tk </dev/null >/var/log/pcp-broker.log 2>&1 &")
+     lein with-profile internal-mirrors tk </dev/null >/var/log/puppetlabs/pcp-broker.log 2>&1 &")
   assert(port_open_within?(host, PCP_BROKER_PORTS[instance], 60),
          "pcp-broker port #{PCP_BROKER_PORTS[instance].to_s} not open within 1 minutes of starting the broker")
   broker_state = nil

--- a/acceptance/teardown/common/099_Archive_Logs.rb
+++ b/acceptance/teardown/common/099_Archive_Logs.rb
@@ -1,0 +1,11 @@
+require 'pxp-agent/test_helper'
+
+step 'Archive files created during tests' do
+  ## Copy file(s) from master
+  archive_file_from(master, '/var/log/puppetlabs')
+
+  ## Copy file(s) from agents
+  agents.each do |agent|
+    archive_file_from(agent, logdir(agent))
+  end
+end

--- a/acceptance/tests/failover/intentional_shutdown_failover.rb
+++ b/acceptance/tests/failover/intentional_shutdown_failover.rb
@@ -18,11 +18,10 @@ test_name 'C97934 - agent should use next broker if primary is intentionally shu
       create_remote_file(agent, pxp_agent_config_file(agent), pxp_config.to_json.to_s)
       reset_logfile(agent)
       on agent, puppet('resource service pxp-agent ensure=running')
-      show_pcp_logs_on_failure do
-        assert_equal(master[:pcp_broker_instance], PRIMARY_BROKER_INSTANCE, "broker instance is not set correctly: #{master[:pcp_broker_instance]}")
-        assert(is_associated?(master, "pcp://#{agent}/agent"),
-               "Agent identity pcp://#{agent}/agent for agent host #{agent} does not appear in pcp-broker's (#{broker_ws_uri(master)}) client inventory after ~#{PCP_INVENTORY_RETRIES} seconds")
-      end
+
+      assert_equal(master[:pcp_broker_instance], PRIMARY_BROKER_INSTANCE, "broker instance is not set correctly: #{master[:pcp_broker_instance]}")
+      assert(is_associated?(master, "pcp://#{agent}/agent"),
+             "Agent identity pcp://#{agent}/agent for agent host #{agent} does not appear in pcp-broker's (#{broker_ws_uri(master)}) client inventory after ~#{PCP_INVENTORY_RETRIES} seconds")
     end
   end
 

--- a/acceptance/tests/failover/intentional_shutdown_failover.rb
+++ b/acceptance/tests/failover/intentional_shutdown_failover.rb
@@ -16,7 +16,7 @@ test_name 'C97934 - agent should use next broker if primary is intentionally shu
       num_brokers = 2
       pxp_config = pxp_config_hash_using_puppet_certs(master, agent, num_brokers)
       create_remote_file(agent, pxp_agent_config_file(agent), pxp_config.to_json.to_s)
-      retry_on(agent, "rm -rf #{logfile(agent)}")
+      reset_logfile(agent)
       on agent, puppet('resource service pxp-agent ensure=running')
       show_pcp_logs_on_failure do
         assert_equal(master[:pcp_broker_instance], PRIMARY_BROKER_INSTANCE, "broker instance is not set correctly: #{master[:pcp_broker_instance]}")

--- a/acceptance/tests/failover/timeout_failover.rb
+++ b/acceptance/tests/failover/timeout_failover.rb
@@ -18,7 +18,7 @@ test_name 'C97964 - agent should use next broker if primary is timing out' do
       pxp_config = pxp_config_hash_using_puppet_certs(master, agent, num_brokers)
       pxp_config['allowed-keepalive-timeouts'] = 0
       create_remote_file(agent, pxp_agent_config_file(agent), pxp_config.to_json.to_s)
-      retry_on(agent, "rm -rf #{logfile(agent)}")
+      reset_logfile(agent)
       on agent, puppet('resource service pxp-agent ensure=running')
       show_pcp_logs_on_failure do
         assert_equal(master[:pcp_broker_instance], PRIMARY_BROKER_INSTANCE, "broker instance is not set correctly: #{master[:pcp_broker_instance]}")

--- a/acceptance/tests/failover/timeout_failover.rb
+++ b/acceptance/tests/failover/timeout_failover.rb
@@ -20,11 +20,10 @@ test_name 'C97964 - agent should use next broker if primary is timing out' do
       create_remote_file(agent, pxp_agent_config_file(agent), pxp_config.to_json.to_s)
       reset_logfile(agent)
       on agent, puppet('resource service pxp-agent ensure=running')
-      show_pcp_logs_on_failure do
-        assert_equal(master[:pcp_broker_instance], PRIMARY_BROKER_INSTANCE, "broker instance is not set correctly: #{master[:pcp_broker_instance]}")
-        assert(is_associated?(master, "pcp://#{agent}/agent"),
-               "Agent identity pcp://#{agent}/agent for agent host #{agent} does not appear in pcp-broker's (#{broker_ws_uri(master)}) client inventory after ~#{PCP_INVENTORY_RETRIES} seconds")
-      end
+
+      assert_equal(master[:pcp_broker_instance], PRIMARY_BROKER_INSTANCE, "broker instance is not set correctly: #{master[:pcp_broker_instance]}")
+      assert(is_associated?(master, "pcp://#{agent}/agent"),
+             "Agent identity pcp://#{agent}/agent for agent host #{agent} does not appear in pcp-broker's (#{broker_ws_uri(master)}) client inventory after ~#{PCP_INVENTORY_RETRIES} seconds")
     end
   end
 

--- a/acceptance/tests/invalid_ssl_config.rb
+++ b/acceptance/tests/invalid_ssl_config.rb
@@ -35,10 +35,9 @@ agents.each do |agent|
     on agent, puppet('resource service pxp-agent ensure=stopped')
     create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
     on agent, puppet('resource service pxp-agent ensure=running')
-    show_pcp_logs_on_failure do
-      assert(is_associated?(master, "pcp://#{agent}/agent"),
-             "Agent #{agent} with PCP identity pcp://#{agent}/agent should be associated with pcp-broker")
-    end
+
+    assert(is_associated?(master, "pcp://#{agent}/agent"),
+           "Agent #{agent} with PCP identity pcp://#{agent}/agent should be associated with pcp-broker")
   end
 
   step 'Setup - Stop pxp-agent service and wipe its log' do
@@ -105,11 +104,10 @@ agents.each do |agent|
 
     step 'Start pxp-agent and assert that it does not connect to pcp-broker'
     on agent, puppet('resource service pxp-agent ensure=running')
-    show_pcp_logs_on_failure do
-      assert(is_not_associated?(master, "pcp://#{agent}/agent"),
-             "Agent identity pcp://#{agent}/agent for agent host #{agent} should not appear in pcp-broker's inventory " \
-             "when pxp-agent is using the wrong CA cert")
-    end
+
+    assert(is_not_associated?(master, "pcp://#{agent}/agent"),
+           "Agent identity pcp://#{agent}/agent for agent host #{agent} should not appear in pcp-broker's inventory " \
+           "when pxp-agent is using the wrong CA cert")
     expect_file_on_host_to_contain(agent, logfile(agent), 'TLS handshake failed')
   end
 
@@ -126,11 +124,10 @@ agents.each do |agent|
 
     step 'Start pxp-agent and assert that it does not connect to broker'
     on agent, puppet('resource service pxp-agent ensure=running')
-    show_pcp_logs_on_failure do
-      assert(is_not_associated?(master, "pcp://#{agent}/agent"),
-             "Agent identity pcp://#{agent}/agent for agent host #{agent} should not appear in pcp-broker's inventory " \
-             "when pxp-agent attempts to connect by broker IP instead of broker certified hostname")
-    end
+
+    assert(is_not_associated?(master, "pcp://#{agent}/agent"),
+           "Agent identity pcp://#{agent}/agent for agent host #{agent} should not appear in pcp-broker's inventory " \
+           "when pxp-agent attempts to connect by broker IP instead of broker certified hostname")
     expect_file_on_host_to_contain(agent, logfile(agent), 'TLS handshake failed')
   end
 end

--- a/acceptance/tests/invalid_ssl_config.rb
+++ b/acceptance/tests/invalid_ssl_config.rb
@@ -43,7 +43,7 @@ agents.each do |agent|
 
   step 'Setup - Stop pxp-agent service and wipe its log' do
     on agent, puppet('resource service pxp-agent ensure=stopped')
-    retry_on(agent, "rm -rf #{logfile(agent)}")
+    reset_logfile(agent)
   end
 
   step "Setup - Change pxp-agent config to use a cert that doesn't match private key" do
@@ -66,7 +66,7 @@ agents.each do |agent|
 
   step "Ensure pxp-agent service is stopped, and wipe log" do
     on agent, puppet('resource service pxp-agent ensure=stopped')
-    retry_on(agent, "rm -rf #{logfile(agent)}")
+    reset_logfile(agent)
   end
 
   step "Change pxp-agent config so the cert and key match but they are of a different ca than the broker" do
@@ -96,7 +96,7 @@ agents.each do |agent|
 
     step 'Stop pxp-agent and wipe its existing log file'
     on agent, puppet('resource service pxp-agent ensure=stopped')
-    retry_on(agent, "rm -rf #{logfile(agent)}")
+    reset_logfile(agent)
 
     step 'Create pxp-agent.conf with an alternate CA cert'
     pxp_config = pxp_config_hash_using_puppet_certs(master, agent)
@@ -116,7 +116,7 @@ agents.each do |agent|
   step 'C97366 - Attempt to connect to pcp-broker without using its certified hostname' do
     step 'Stop pxp-agent and wipe its existing log file'
     on agent, puppet('resource service pxp-agent ensure=stopped')
-    retry_on(agent, "rm -rf #{logfile(agent)}")
+    reset_logfile(agent)
 
     step 'Create pxp-agent.conf that connects to pcp-broker using its IP address'
     pxp_config = pxp_config_hash_using_puppet_certs(master, agent)

--- a/acceptance/tests/pxp-module-puppet/restart_pxp_agent_during_non_blocking_run.rb
+++ b/acceptance/tests/pxp-module-puppet/restart_pxp_agent_during_non_blocking_run.rb
@@ -44,10 +44,9 @@ test_name 'C94705 - Run Puppet (non-blocking request) and restart pxp-agent serv
       on agent, puppet('resource service pxp-agent ensure=stopped')
       create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
       on agent, puppet('resource service pxp-agent ensure=running enable=true')
-      show_pcp_logs_on_failure do
-        assert(is_associated?(master, "pcp://#{agent}/agent"),
-               "Agent #{agent} with PCP identity pcp://#{agent}/agent should be associated with pcp-broker")
-      end
+
+      assert(is_associated?(master, "pcp://#{agent}/agent"),
+             "Agent #{agent} with PCP identity pcp://#{agent}/agent should be associated with pcp-broker")
     end
   end
 

--- a/acceptance/tests/pxp-module-puppet/run_puppet.rb
+++ b/acceptance/tests/pxp-module-puppet/run_puppet.rb
@@ -7,10 +7,9 @@ test_name 'C95972 - pxp-module-puppet run' do
       on agent, puppet('resource service pxp-agent ensure=stopped')
       create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
       on agent, puppet('resource service pxp-agent ensure=running')
-      show_pcp_logs_on_failure do
-        assert(is_associated?(master, "pcp://#{agent}/agent"),
-               "Agent #{agent} with PCP identity pcp://#{agent}/agent should be associated with pcp-broker")
-      end
+
+      assert(is_associated?(master, "pcp://#{agent}/agent"),
+             "Agent #{agent} with PCP identity pcp://#{agent}/agent should be associated with pcp-broker")
     end
   end
 

--- a/acceptance/tests/pxp-module-puppet/run_puppet_agent_disabled.rb
+++ b/acceptance/tests/pxp-module-puppet/run_puppet_agent_disabled.rb
@@ -10,10 +10,9 @@ test_name 'C93065 - Run puppet and expect puppet agent disabled' do
       on agent, puppet('resource service pxp-agent ensure=stopped')
       create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
       on agent, puppet('resource service pxp-agent ensure=running')
-      show_pcp_logs_on_failure do
-        assert(is_associated?(master, "pcp://#{agent}/agent"),
-               "At the start of the test, #{agent} (with PCP identity pcp://#{agent}/agent ) should be associated with pcp-broker")
-      end
+
+      assert(is_associated?(master, "pcp://#{agent}/agent"),
+             "At the start of the test, #{agent} (with PCP identity pcp://#{agent}/agent ) should be associated with pcp-broker")
     end
   end
 

--- a/acceptance/tests/pxp-module-puppet/run_puppet_nonASCII.rb
+++ b/acceptance/tests/pxp-module-puppet/run_puppet_nonASCII.rb
@@ -22,10 +22,9 @@ SITEPP
       on agent, puppet('resource service pxp-agent ensure=stopped')
       create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
       on agent, puppet('resource service pxp-agent ensure=running')
-      show_pcp_logs_on_failure do
-        assert(is_associated?(master, "pcp://#{agent}/agent"),
-               "Agent #{agent} with PCP identity pcp://#{agent}/agent should be associated with pcp-broker")
-      end
+
+      assert(is_associated?(master, "pcp://#{agent}/agent"),
+             "Agent #{agent} with PCP identity pcp://#{agent}/agent should be associated with pcp-broker")
     end
   end
 

--- a/acceptance/tests/pxp-module-puppet/run_puppet_result_changed.rb
+++ b/acceptance/tests/pxp-module-puppet/run_puppet_result_changed.rb
@@ -22,10 +22,9 @@ SITEPP
       on agent, puppet('resource service pxp-agent ensure=stopped')
       create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
       on agent, puppet('resource service pxp-agent ensure=running')
-      show_pcp_logs_on_failure do
-        assert(is_associated?(master, "pcp://#{agent}/agent"),
-               "Agent #{agent} with PCP identity pcp://#{agent}/agent should be associated with pcp-broker")
-      end
+
+      assert(is_associated?(master, "pcp://#{agent}/agent"),
+             "Agent #{agent} with PCP identity pcp://#{agent}/agent should be associated with pcp-broker")
     end
   end
 

--- a/acceptance/tests/pxp_agent_associate.rb
+++ b/acceptance/tests/pxp_agent_associate.rb
@@ -11,11 +11,9 @@ agents.each do |agent|
   end
 
   step 'Assert that the agent is not listed in pcp-broker inventory' do
-    show_pcp_logs_on_failure do
-      assert(is_not_associated?(master, "pcp://#{agent}/agent"),
-             "Agent identity pcp://#{agent}/agent for agent host #{agent} appears in pcp-broker's client inventory " \
-             "but pxp-agent service is supposed to be stopped")
-    end
+    assert(is_not_associated?(master, "pcp://#{agent}/agent"),
+           "Agent identity pcp://#{agent}/agent for agent host #{agent} appears in pcp-broker's client inventory " \
+           "but pxp-agent service is supposed to be stopped")
   end
 
   step 'Start pxp-agent service' do
@@ -23,9 +21,7 @@ agents.each do |agent|
   end
 
   step 'Assert that agent is listed in pcp-broker inventory' do
-    show_pcp_logs_on_failure do
-      assert(is_associated?(master, "pcp://#{agent}/agent"),
-             "Agent identity pcp://#{agent}/agent for agent host #{agent} does not appear in pcp-broker's client inventory")
-    end
+    assert(is_associated?(master, "pcp://#{agent}/agent"),
+           "Agent identity pcp://#{agent}/agent for agent host #{agent} does not appear in pcp-broker's client inventory")
   end
 end

--- a/acceptance/tests/reconnect_after_broker_unavailable.rb
+++ b/acceptance/tests/reconnect_after_broker_unavailable.rb
@@ -9,10 +9,9 @@ step 'Ensure each agent host has pxp-agent running and associated' do
     create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
     reset_logfile(agent)
     on agent, puppet('resource service pxp-agent ensure=running')
-    show_pcp_logs_on_failure do
-      assert(is_associated?(master, "pcp://#{agent}/agent"),
-             "Agent identity pcp://#{agent}/agent for agent host #{agent} does not appear in pcp-broker's client inventory")
-    end
+
+    assert(is_associated?(master, "pcp://#{agent}/agent"),
+           "Agent identity pcp://#{agent}/agent for agent host #{agent} does not appear in pcp-broker's client inventory")
   end
 end
 

--- a/acceptance/tests/reconnect_after_broker_unavailable.rb
+++ b/acceptance/tests/reconnect_after_broker_unavailable.rb
@@ -7,7 +7,7 @@ step 'Ensure each agent host has pxp-agent running and associated' do
   agents.each do |agent|
     on agent, puppet('resource service pxp-agent ensure=stopped')
     create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
-    retry_on(agent, "rm -rf #{logfile(agent)}")
+    reset_logfile(agent)
     on agent, puppet('resource service pxp-agent ensure=running')
     show_pcp_logs_on_failure do
       assert(is_associated?(master, "pcp://#{agent}/agent"),

--- a/acceptance/tests/restart_host_run_puppet.rb
+++ b/acceptance/tests/restart_host_run_puppet.rb
@@ -39,10 +39,9 @@ test_name 'C94777 - Ensure pxp-agent functions after agent host restart' do
       on agent, puppet('resource service pxp-agent ensure=stopped')
       create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
       on agent, puppet('resource service pxp-agent ensure=running enable=true')
-      show_pcp_logs_on_failure do
-        assert(is_associated?(master, "pcp://#{agent}/agent"),
-               "Agent #{agent} with PCP identity pcp://#{agent}/agent should be associated with pcp-broker")
-      end
+
+      assert(is_associated?(master, "pcp://#{agent}/agent"),
+             "Agent #{agent} with PCP identity pcp://#{agent}/agent should be associated with pcp-broker")
     end
   end
 


### PR DESCRIPTION
@james-stocks what would you suggest for addressing the places we delete log files? It'd be useful to keep most of the logs, so maybe we should use different locations for the tests that want to use a fresh log file.