### PR TITLE
(PCP-529) Remove show_pcp_logs_on_failure from new tests

### DIFF
--- a/acceptance/tests/pxp-module-puppet/run_puppet_during_puppet.rb
+++ b/acceptance/tests/pxp-module-puppet/run_puppet_during_puppet.rb
@@ -22,10 +22,8 @@ test_name 'Run Puppet while a Puppet Agent run is in-progress, wait for completi
       on agent, puppet('resource service pxp-agent ensure=stopped')
       create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
       on agent, puppet('resource service pxp-agent ensure=running')
-      show_pcp_logs_on_failure do
-        assert(is_associated?(master, "pcp://#{agent}/agent"),
-               "Agent #{agent} with PCP identity pcp://#{agent}/agent should be associated with pcp-broker")
-      end
+      assert(is_associated?(master, "pcp://#{agent}/agent"),
+             "Agent #{agent} with PCP identity pcp://#{agent}/agent should be associated with pcp-broker")
     end
   end
 

--- a/acceptance/tests/pxp-module-puppet/run_puppet_killed_puppet.rb
+++ b/acceptance/tests/pxp-module-puppet/run_puppet_killed_puppet.rb
@@ -23,10 +23,8 @@ test_name 'Run Puppet while a Puppet Agent run is in-progress, wait for it to be
       on agent, puppet('resource service pxp-agent ensure=stopped')
       create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
       on agent, puppet('resource service pxp-agent ensure=running')
-      show_pcp_logs_on_failure do
-        assert(is_associated?(master, "pcp://#{agent}/agent"),
-               "Agent #{agent} with PCP identity pcp://#{agent}/agent should be associated with pcp-broker")
-      end
+      assert(is_associated?(master, "pcp://#{agent}/agent"),
+             "Agent #{agent} with PCP identity pcp://#{agent}/agent should be associated with pcp-broker")
     end
   end
 

--- a/acceptance/tests/pxp-module-puppet/run_puppet_twice.rb
+++ b/acceptance/tests/pxp-module-puppet/run_puppet_twice.rb
@@ -26,10 +26,8 @@ test_name 'Run Puppet while a Puppet Agent run is in-progress, wait for completi
       on agent, puppet('resource service pxp-agent ensure=stopped')
       create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
       on agent, puppet('resource service pxp-agent ensure=running')
-      show_pcp_logs_on_failure do
-        assert(is_associated?(master, "pcp://#{agent}/agent"),
-               "Agent #{agent} with PCP identity pcp://#{agent}/agent should be associated with pcp-broker")
-      end
+      assert(is_associated?(master, "pcp://#{agent}/agent"),
+             "Agent #{agent} with PCP identity pcp://#{agent}/agent should be associated with pcp-broker")
     end
   end
 

--- a/acceptance/tests/pxp-module-puppet/run_puppet_v1.rb
+++ b/acceptance/tests/pxp-module-puppet/run_puppet_v1.rb
@@ -21,10 +21,8 @@ test_name 'pxp-module-puppet run with PCP v1' do
       pxp_config['broker-ws-uris'] = [broker_ws_uri(master, 1)]
       create_remote_file(agent, pxp_agent_config_file(agent), pxp_config.to_json.to_s)
       on agent, puppet('resource service pxp-agent ensure=running')
-      show_pcp_logs_on_failure do
-        assert(is_associated?(master, "pcp://#{agent}/agent"),
-               "Agent #{agent} with PCP identity pcp://#{agent}/agent should be associated with pcp-broker")
-      end
+      assert(is_associated?(master, "pcp://#{agent}/agent"),
+             "Agent #{agent} with PCP identity pcp://#{agent}/agent should be associated with pcp-broker")
     end
   end
 


### PR DESCRIPTION
Removes `show_pcp_logs_on_failure` from tests not present on the LTS-1.7
branch.