### PR TITLE
(PCP-729) Change default ping-interval to 3 minutes

### DIFF
--- a/acceptance/tests/failover/timeout_failover.rb
+++ b/acceptance/tests/failover/timeout_failover.rb
@@ -17,6 +17,7 @@ test_name 'C97964 - agent should use next broker if primary is timing out' do
       num_brokers = 2
       pxp_config = pxp_config_hash_using_puppet_certs(master, agent, num_brokers)
       pxp_config['allowed-keepalive-timeouts'] = 0
+      pxp_config['ping-interval'] = 10
       create_remote_file(agent, pxp_agent_config_file(agent), pxp_config.to_json.to_s)
       reset_logfile(agent)
       on agent, puppet('resource service pxp-agent ensure=running')

--- a/lib/src/configuration.cc
+++ b/lib/src/configuration.cc
@@ -411,7 +411,7 @@ void Configuration::defineDefaultValues()
                     Types::Int,
                     2) } });
 
-    // Hidden option: interval between pings, default 15 s
+    // Hidden option: interval between pings, default 180 s
     defaults_.insert(
         Option { "ping-interval",
                  Base_ptr { new Entry<int>(
@@ -419,7 +419,7 @@ void Configuration::defineDefaultValues()
                     "",
                     "<hidden>",
                     Types::Int,
-                    15) } });
+                    180) } });
 
     // Hidden option: PCP Association timeout, default: 15 s
     defaults_.insert(


### PR DESCRIPTION
The default ping-interval of 15 seconds, combined with
allowed-keepalive-timeouts of 2, means that if the pcp-broker is
overloaded for more than 45 seconds the agent will disconnect and
reconnect. This can happen when several thousand agents attempt to
connect at once, causing reconnection to spiral out of control.

The ping only has 2 functions: prevent the server from disconnecting the
agent (currently the server has a 15 minute timeout) and detect if the
server has become unavailable without closing the TCP connection
cleanly. This 2nd one doesn't need to happen on such a quick interval.
Change the default ping-interval to 3 minutes to reduce chances of
disconnecting under startup load.