### PR TITLE
(PCP-729) Shorten timeout for failover in tests

### DIFF
--- a/acceptance/tests/failover/intentional_shutdown_failover.rb
+++ b/acceptance/tests/failover/intentional_shutdown_failover.rb
@@ -15,6 +15,7 @@ test_name 'C97934 - agent should use next broker if primary is intentionally shu
       on agent, puppet('resource service pxp-agent ensure=stopped')
       num_brokers = 2
       pxp_config = pxp_config_hash_using_puppet_certs(master, agent, num_brokers)
+      pxp_config['ping-interval'] = 10
       create_remote_file(agent, pxp_agent_config_file(agent), pxp_config.to_json.to_s)
       reset_logfile(agent)
       on agent, puppet('resource service pxp-agent ensure=running')

--- a/acceptance/tests/reconnect_after_broker_unavailable.rb
+++ b/acceptance/tests/reconnect_after_broker_unavailable.rb
@@ -6,7 +6,9 @@ test_name 'C94789 - An associated agent should automatically reconnect when the 
 step 'Ensure each agent host has pxp-agent running and associated' do
   agents.each do |agent|
     on agent, puppet('resource service pxp-agent ensure=stopped')
-    create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
+    pxp_config = pxp_config_hash_using_puppet_certs(master, agent)
+    pxp_config['ping-interval'] = 10
+    create_remote_file(agent, pxp_agent_config_file(agent), pxp_config.to_json.to_s)
     reset_logfile(agent)
     on agent, puppet('resource service pxp-agent ensure=running')
 


### PR DESCRIPTION
After changing the default ping interval, failover tests need to reset
it to run in a reasonable time.