### PR TITLE
Revert "(PCP-729) Change default ping-interval to 3 minutes"

### DIFF
--- a/acceptance/tests/failover/timeout_failover.rb
+++ b/acceptance/tests/failover/timeout_failover.rb
@@ -17,7 +17,6 @@ test_name 'C97964 - agent should use next broker if primary is timing out' do
       num_brokers = 2
       pxp_config = pxp_config_hash_using_puppet_certs(master, agent, num_brokers)
       pxp_config['allowed-keepalive-timeouts'] = 0
-      pxp_config['ping-interval'] = 10
       create_remote_file(agent, pxp_agent_config_file(agent), pxp_config.to_json.to_s)
       reset_logfile(agent)
       on agent, puppet('resource service pxp-agent ensure=running')

--- a/lib/src/configuration.cc
+++ b/lib/src/configuration.cc
@@ -411,7 +411,7 @@ void Configuration::defineDefaultValues()
                     Types::Int,
                     2) } });
 
-    // Hidden option: interval between pings, default 180 s
+    // Hidden option: interval between pings, default 15 s
     defaults_.insert(
         Option { "ping-interval",
                  Base_ptr { new Entry<int>(
@@ -419,7 +419,7 @@ void Configuration::defineDefaultValues()
                     "",
                     "<hidden>",
                     Types::Int,
-                    180) } });
+                    15) } });
 
     // Hidden option: PCP Association timeout, default: 15 s
     defaults_.insert(


### PR DESCRIPTION
Reverts puppetlabs/pxp-agent#564

This change is substantial, and affects tests more than I thought. We also need to do it in PE. I'm probably more comfortable reverting this for now and only changing it in PE in a configurable way.