### PR TITLE
(PCP-729) Change default ping-interval to 2 minutes

### DIFF
--- a/lib/src/configuration.cc
+++ b/lib/src/configuration.cc
@@ -411,7 +411,7 @@ void Configuration::defineDefaultValues()
                     Types::Int,
                     2) } });
 
-    // Hidden option: interval between pings, default 15 s
+    // Hidden option: interval between pings, default 120 s
     defaults_.insert(
         Option { "ping-interval",
                  Base_ptr { new Entry<int>(
@@ -419,7 +419,7 @@ void Configuration::defineDefaultValues()
                     "",
                     "<hidden>",
                     Types::Int,
-                    15) } });
+                    120) } });
 
     // Hidden option: PCP Association timeout, default: 15 s
     defaults_.insert(


### PR DESCRIPTION
With PCP-734 fixed, pxp-agent will attempt to reconnect immediately
unless the broker disappears and the TCP connection is not closed. In
that case, it'll take 4-6 minutes to detect a failure.

This interval is chosen to minimize disconnects under reasonable loads
for pcp-broker, e.g. 10k nodes reconnecting.

Adjust the hard failover test to use a short ping-interval to minimize
test time.