### PR TITLE
(maint) Ensure all broker logs are unique so they can be preserved

### DIFF
--- a/acceptance/lib/pxp-agent/test_helper.rb
+++ b/acceptance/lib/pxp-agent/test_helper.rb
@@ -59,7 +59,7 @@ end
 def run_pcp_broker(host, instance=0)
   host[:pcp_broker_instance] = instance
   on(host, "cd #{GIT_CLONE_FOLDER}/pcp-broker#{instance}; export LEIN_ROOT=ok; \
-     lein with-profile internal-mirrors tk </dev/null >/var/log/puppetlabs/pcp-broker.log 2>&1 &")
+     lein with-profile internal-mirrors tk </dev/null >/var/log/puppetlabs/pcp-broker.log.#{SecureRandom.uuid} 2>&1 &")
   assert(port_open_within?(host, PCP_BROKER_PORTS[instance], 60),
          "pcp-broker port #{PCP_BROKER_PORTS[instance].to_s} not open within 1 minutes of starting the broker")
   broker_state = nil


### PR DESCRIPTION
Previously only the last broker log would be preserved, as every
re-invocation of pcp-broker would overwrite the previous log. Now use a
uuid to ensure each log is unique.