### PR TITLE
(PCP-736) Don't change umask

### DIFF
--- a/lib/src/util/posix/daemonize.cc
+++ b/lib/src/util/posix/daemonize.cc
@@ -8,7 +8,6 @@
 #include <stdlib.h>         // exit()
 #include <unistd.h>         // _exit(), getpid(), fork(), setsid(), chdir()
 #include <sys/wait.h>       // waitpid()
-#include <sys/stat.h>       // umask()
 #include <signal.h>
 #include <stdio.h>
 
@@ -18,7 +17,6 @@
 namespace PXPAgent {
 namespace Util {
 
-const mode_t UMASK_FLAGS { 002 };
 const std::string DEFAULT_DAEMON_WORKING_DIR = "/";
 
 static void sigHandler(int sig) {
@@ -41,9 +39,6 @@ std::unique_ptr<PIDFile> daemonize() {
         LOG_INFO("Already a daemon with PID={1}", std::to_string(getpid()));
         return nullptr;
     }
-
-    // Set umask; child processes will inherit
-    umask(UMASK_FLAGS);
 
     // Check PID file; get read lock; ensure we can obtain write lock
 


### PR DESCRIPTION
Previosly pxp-agent set its umask to 020 but only when it was daemonizing itself. I.e. it did not do that when executed from systemd/launchd.
This made it difficult for users to configure the umask for the puppet runs executed by pxp-agent.
So in this patch we drop the setting of the umask in the pxp-agent to make it possible for users to override the umask in an init script and/or systemd/launchd service file.