### PR TITLE
(PCP-740) Check for default umask on AIX service

### DIFF
--- a/acceptance/tests/pxp-module-puppet/run_puppet_umask.rb
+++ b/acceptance/tests/pxp-module-puppet/run_puppet_umask.rb
@@ -116,6 +116,10 @@ SITEPP
           when /solaris/
             # Solaris has no identifiable way to modify umask for smf services
             '644'
+          when /aix/
+            # TODO: set a umask for an AIX service
+            # Doing so appears non-trivial, so for now asserts default.
+            '644'
           else
             '444'
           end


### PR DESCRIPTION
Ideally we'd set umask on the service and verify it had changed, but
doing that on AIX looks non-trivial if its even possible. It also
wouldn't bring much extra testing, so for now just verify that the
default umask is used.

[skip ci]