### PR TITLE
(PCP-745) Add manpage name to Solaris SMF manifest

### DIFF
--- a/ext/solaris/smf/pxp-agent.xml
+++ b/ext/solaris/smf/pxp-agent.xml
@@ -30,7 +30,7 @@
         <loctext xml:lang="C">PCP Execution Protocol (PXP) Agent</loctext>
       </common_name>
       <documentation>
-        <manpage title="" section="1"/>
+        <manpage title="pxp-agent" section="1"/>
         <doc_link name="puppetlabs.com" uri="http://puppetlabs.com/puppet/introduction"/>
       </documentation>
     </template>


### PR DESCRIPTION
Prior to this commit, the svcs -xv command would
return a libscf error when encountering the unset
name field in the manpage property for pxp-agent.
This commit adds a string to that setting to bring
it into alignment with other Puppet services.