### PR TITLE
(maint) Fix unnecessary use of each_with_index

### DIFF
--- a/acceptance/tests/pxp-module-puppet/run_puppet_nonASCII.rb
+++ b/acceptance/tests/pxp-module-puppet/run_puppet_nonASCII.rb
@@ -49,7 +49,7 @@ SITEPP
     rescue => exception
       fail("Exception occurred when trying to run Puppet on all agents: #{exception.message}")
     end
-    applicable_agents.each_with_index do |agent|
+    applicable_agents.each do |agent|
       step "Check Run Puppet response for #{agent}" do
         identity = "pcp://#{agent}/agent"
         assert(responses[identity][:data].has_key?("results"),


### PR DESCRIPTION
We incorrectly pass a block that accepts a single argument to
`each_with_index`. This somehow works, but I wouldn't necessarily expect
it to work in a future version of Ruby. Fix to use `each`.