### PR TITLE
(PCP-699) Accept and pass job-id in pxp-module-puppet

### DIFF
--- a/modules/pxp-module-puppet
+++ b/modules/pxp-module-puppet
@@ -27,11 +27,19 @@ module Pxp
       end
     end
 
+    attr_reader :config, :action_input
+
     def self.handle_action(action)
       if action == 'metadata'
         puts metadata.to_json
       else
-        action_results = new().action_run($stdin.read.chomp)
+        result = create_runner($stdin.read.chomp)
+        if result.is_a?(self)
+          action_results = result.run(config, action_input)
+        else
+          action_results = result
+        end
+
         print action_results.to_json
 
         unless action_results["error"].nil?
@@ -75,7 +83,7 @@ module Pxp
       end
     end
 
-    def last_run_result(exitcode)
+    def self.last_run_result(exitcode)
       return {"kind"             => "unknown",
               "time"             => "unknown",
               "transaction_uuid" => "unknown",
@@ -124,7 +132,7 @@ module Pxp
       return cmd_array
     end
 
-    def make_error_result(exitcode, error_type, error_message)
+    def self.make_error_result(exitcode, error_type, error_message)
       result = last_run_result(exitcode)
       result["error_type"] = error_type
       result["error"] = error_message
@@ -153,12 +161,12 @@ module Pxp
 
     def get_result_from_report(last_run_report, exitcode, config, start_time)
       if !File.exist?(last_run_report)
-        return make_error_result(exitcode, Errors::NoLastRunReport,
+        return self.class.make_error_result(exitcode, Errors::NoLastRunReport,
                                  "#{last_run_report} doesn't exist")
       end
 
       if start_time && File.mtime(last_run_report) == start_time
-        return make_error_result(exitcode, Errors::NoLastRunReport,
+        return self.class.make_error_result(exitcode, Errors::NoLastRunReport,
                                  "#{last_run_report} was not written")
       end
 
@@ -167,14 +175,14 @@ module Pxp
       begin
         last_run_report_yaml = parse_report(last_run_report)
       rescue => e
-        return make_error_result(exitcode, Errors::InvalidLastRunReport,
+        return self.class.make_error_result(exitcode, Errors::InvalidLastRunReport,
                                  "#{last_run_report} could not be loaded: #{e}")
       end
 
       if exitcode == 0
-        run_result = last_run_result(exitcode)
+        run_result = self.class.last_run_result(exitcode)
       else
-        run_result = make_error_result(exitcode, Errors::NonZeroExit,
+        run_result = self.class.make_error_result(exitcode, Errors::NonZeroExit,
                                        "Puppet agent exited with a non 0 exitcode")
       end
 
@@ -205,7 +213,7 @@ module Pxp
 
       last_run_report = check_config_print("lastrunreport", config)
       if last_run_report.empty?
-        return make_error_result(exitcode, Errors::NoLastRunReport,
+        return self.class.make_error_result(exitcode, Errors::NoLastRunReport,
                                  "could not find the location of the last run report")
       end
 
@@ -222,7 +230,7 @@ module Pxp
                                                            :override_locale => false})
 
         if !run_result
-          return make_error_result(exitcode, Errors::FailedToStart,
+          return self.class.make_error_result(exitcode, Errors::FailedToStart,
                                    "Failed to start Puppet agent")
         end
 
@@ -230,14 +238,14 @@ module Pxp
         puppet_output = force_unicode(run_result.to_s)
 
         if disabled?(puppet_output)
-          return make_error_result(exitcode, Errors::Disabled,
+          return self.class.make_error_result(exitcode, Errors::Disabled,
                                    "Puppet agent is disabled")
         elsif running?(puppet_output)
           # Puppet is already running, attempt to wait until it finishes and retry.
           lockfile = check_config_print('agent_catalog_run_lockfile', config)
           if lockfile.empty?
             # Can't identify lockfile, just report an error.
-            return make_error_result(exitcode, Errors::AlreadyRunning,
+            return self.class.make_error_result(exitcode, Errors::AlreadyRunning,
                                      "Puppet agent is already performing a run; it also appears to be" +
                                      " misconfigured, agent_catalog_run_lockfile is an empty string")
           end
@@ -323,16 +331,16 @@ module Pxp
       }
     end
 
-    def run(config, action_input)
+    def run
       if !File.exist?(config["puppet_bin"])
-        return make_error_result(DEFAULT_EXITCODE, Errors::NoPuppetBin,
+        return self.class.make_error_result(DEFAULT_EXITCODE, Errors::NoPuppetBin,
                                  "Puppet executable '#{config["puppet_bin"]}' does not exist")
       end
 
       return start_run(config, action_input)
     end
 
-    def get_configuration(args)
+    def self.get_configuration(args)
       config = args["configuration"] || {}
 
       if config["puppet_bin"].nil? || config["puppet_bin"].empty?
@@ -377,7 +385,7 @@ module Pxp
     VALID_FLAG_REGEX = /\A[a-zA-Z0-9_:,\.\-]+\Z/
 
     # This asserts that the flag has a valid prefix
-    def get_flag_name(flag)
+    def self.get_flag_name(flag)
       if flag.start_with?("--no-")
         flag[5..-1]
       elsif flag.start_with?("--")
@@ -387,7 +395,7 @@ module Pxp
       end
     end
 
-    def get_action_input(args)
+    def self.get_action_input(args)
       action_input = args["input"]
       unless action_input.is_a?(Hash)
         raise ProcessingError.new(Errors::InvalidJson, "The json received on STDIN did not contain a valid 'input' key: #{args.to_s}")
@@ -426,7 +434,7 @@ module Pxp
       action_input
     end
 
-    def action_run(input)
+    def self.create_runner(input)
       begin
         args = JSON.parse(input)
       rescue
@@ -483,7 +491,12 @@ module Pxp
         return make_error_result(DEFAULT_EXITCODE, e.error_type, e.message)
       end
 
-      run(config, action_input)
+      new(config, action_input)
+    end
+
+    def initialize(config, action_input)
+      @config = config
+      @action_input = action_input
     end
 
   end

--- a/modules/pxp-module-puppet
+++ b/modules/pxp-module-puppet
@@ -5,487 +5,491 @@ require 'json'
 require 'yaml'
 require 'puppet'
 
-module Errors
-  InvalidJson = "invalid_json"
-  NoPuppetBin = "no_puppet_bin"
-  NoLastRunReport = "no_last_run_report"
-  InvalidLastRunReport = "invalid_last_run_report"
-  AlreadyRunning = "agent_already_running"
-  Disabled = "agent_disabled"
-  FailedToStart = "agent_failed_to_start"
-  NonZeroExit = "agent_exit_non_zero"
-end
-
-class ProcessingError < StandardError
-  attr_reader :error_type
-
-  def initialize(error_type, message = nil)
-    super(message)
-    @error_type = error_type
-  end
-end
-
-DEFAULT_EXITCODE = -1
-
-env_fix_up = nil
-
-# use this way of defining the `get_env_fix_up` method so that it can "see"
-# the `env_fix_up` variable
-self.class.send(:define_method, :get_env_fix_up) do
-  # If running in a C or POSIX locale, ask Puppet to use UTF-8
-  base_env = {}
-  if Encoding.default_external == Encoding::US_ASCII
-    base_env = {"RUBYOPT" => "#{ENV['RUBYOPT']} -EUTF-8"}
-  end
-
-  # Prepare an environment fix-up to make up for its cleansing performed
-  # by the Puppet::Util::Execution.execute function.
-  # This fix-up is meant for running puppet under a non-root user;
-  # puppet cannot find the user's HOME directory otherwise.
-  env_fix_up ||= if Puppet.features.microsoft_windows? || Process.euid == 0
-    # no environment fix-up is needed on windows or for root
-    base_env
-  else
-    begin
-      require 'etc'
-
-      pwentry = Etc.getpwuid(Process.euid)
-
-      {"USER"    => pwentry.name,
-       "LOGNAME" => pwentry.name,
-       "HOME"    => pwentry.dir}.merge base_env
-    rescue => e
-      # oh well ..., let's give it a try without the environment fix-up
-      myname = File.basename($0)
-      $stderr.puts "#{myname}: Could not fix environment for effective UID #{Process.euid}: #{e.message}"
-      $stderr.puts "#{myname}: Expect puppet run problems"
-      base_env
-    end
-  end
-end
-
-def last_run_result(exitcode)
-  return {"kind"             => "unknown",
-          "time"             => "unknown",
-          "transaction_uuid" => "unknown",
-          "environment"      => "unknown",
-          "status"           => "unknown",
-          "metrics"          => {},
-          "exitcode"         => exitcode,
-          "version"          => 1}
-end
-
-def force_unicode(s)
-  begin
-    # Later comparisons assume UTF-8. Convert to that encoding now.
-    s.encode(Encoding::UTF_8)
-  rescue Encoding::InvalidByteSequenceError
-    # Found non-native characters, hope it's a UTF-8 string. Since this is Puppet, and
-    # incorrect characters probably means we're in a C or POSIX locale, this is usually safe.
-    s.force_encoding(Encoding::UTF_8)
-  end
-end
-
-def check_config_print(cli_arg, config)
-  command_array = [config["puppet_bin"], "agent", "--configprint", cli_arg]
-  process_output = Puppet::Util::Execution.execute(command_array,
-                                                   {:custom_environment => get_env_fix_up(),
-                                                    :override_locale => false})
-  return force_unicode(process_output.to_s).chomp
-end
-
-def running?(run_result)
-  !!(run_result =~ /Run of Puppet configuration client already in progress/)
-end
-
-def disabled?(run_result)
-  !!(run_result =~ /disabled(.*?)Use 'puppet agent --enable' to re-enable/m)
-end
-
-def make_environment_hash()
-  # NB: we're ignoring the `env` array for setting the environment
-  return get_env_fix_up()
-end
-
-def make_command_array(config, action_input)
-  cmd_array = [config["puppet_bin"], "agent"]
-  cmd_array +=  action_input["flags"]
-  return cmd_array
-end
-
-def make_error_result(exitcode, error_type, error_message)
-  result = last_run_result(exitcode)
-  result["error_type"] = error_type
-  result["error"] = error_message
-  return result
-end
-
-def parse_report(filename)
-  # Read the report and drop Ruby objects first. We can't parse the Ruby objects
-  # (because we don't have Puppet loaded) and don't need that data.
-  # Psych::Nodes::Node#each iterates over each node in the parsed document tree.
-  # YAML.parse_file returns a Psych::Nodes::Document, and #root returns the
-  # root-level Node.
-  data = YAML.parse_file(filename)
-  data.root.each do |o|
-    o.tag = nil if o.respond_to?(:tag=)
-  end
-
-  data.to_ruby
-end
-
-def nest_metrics(metrics)
-  metrics.fetch('resources', {}).fetch('values', {}).inject({}) do |result, (name,human_name,value)|
-    result.merge(name => value)
-  end
-end
-
-def get_result_from_report(last_run_report, exitcode, config, start_time)
-  if !File.exist?(last_run_report)
-    return make_error_result(exitcode, Errors::NoLastRunReport,
-                             "#{last_run_report} doesn't exist")
-  end
-
-  if start_time && File.mtime(last_run_report) == start_time
-    return make_error_result(exitcode, Errors::NoLastRunReport,
-                             "#{last_run_report} was not written")
-  end
-
-  last_run_report_yaml = {}
-
-  begin
-    last_run_report_yaml = parse_report(last_run_report)
-  rescue => e
-    return make_error_result(exitcode, Errors::InvalidLastRunReport,
-                             "#{last_run_report} could not be loaded: #{e}")
-  end
-
-  if exitcode == 0
-    run_result = last_run_result(exitcode)
-  else
-    run_result = make_error_result(exitcode, Errors::NonZeroExit,
-                                   "Puppet agent exited with a non 0 exitcode")
-  end
-
-  run_result["kind"] = last_run_report_yaml['kind']
-  run_result["time"] = last_run_report_yaml['time']
-  run_result["transaction_uuid"] = last_run_report_yaml['transaction_uuid']
-  run_result["environment"] = last_run_report_yaml['environment']
-  run_result["status"] = last_run_report_yaml['status']
-  run_result["metrics"] = nest_metrics(last_run_report_yaml['metrics'])
-
-  return run_result
-end
-
-# Wait for the lockfile to be removed. If it hasn't after 30 seconds, give up.
-def wait_for_lockfile(lockfile = '', check_interval = 0.1, give_up_after = 30)
-  number_of_tries = give_up_after / check_interval
-  count = 0
-  while File.exist?(lockfile) && count < number_of_tries
-    sleep check_interval
-    count += 1
-  end
-end
-
-def start_run(config, action_input)
-  exitcode = DEFAULT_EXITCODE
-  cmd = make_command_array(config, action_input)
-  env = make_environment_hash()
-
-  last_run_report = check_config_print("lastrunreport", config)
-  if last_run_report.empty?
-    return make_error_result(exitcode, Errors::NoLastRunReport,
-                             "could not find the location of the last run report")
-  end
-
-  # Initially ignore the lockfile. It might be out-dated, so we give Puppet a chance
-  # to clean it up and run.
-  lockfile = ''
-  while true
-    wait_for_lockfile(lockfile)
-
-    start_time = File.mtime(last_run_report) if File.exist?(last_run_report)
-
-    run_result = Puppet::Util::Execution.execute(cmd, {:failonfail => false,
-                                                       :custom_environment => env,
-                                                       :override_locale => false})
-
-    if !run_result
-      return make_error_result(exitcode, Errors::FailedToStart,
-                               "Failed to start Puppet agent")
+module Pxp
+  class ModulePuppet
+    module Errors
+      InvalidJson = "invalid_json"
+      NoPuppetBin = "no_puppet_bin"
+      NoLastRunReport = "no_last_run_report"
+      InvalidLastRunReport = "invalid_last_run_report"
+      AlreadyRunning = "agent_already_running"
+      Disabled = "agent_disabled"
+      FailedToStart = "agent_failed_to_start"
+      NonZeroExit = "agent_exit_non_zero"
     end
 
-    exitcode = run_result.exitstatus
-    puppet_output = force_unicode(run_result.to_s)
+    class ProcessingError < StandardError
+      attr_reader :error_type
 
-    if disabled?(puppet_output)
-      return make_error_result(exitcode, Errors::Disabled,
-                               "Puppet agent is disabled")
-    elsif running?(puppet_output)
-      # Puppet is already running, attempt to wait until it finishes and retry.
-      lockfile = check_config_print('agent_catalog_run_lockfile', config)
-      if lockfile.empty?
-        # Can't identify lockfile, just report an error.
-        return make_error_result(exitcode, Errors::AlreadyRunning,
-                                 "Puppet agent is already performing a run; it also appears to be" +
-                                 " misconfigured, agent_catalog_run_lockfile is an empty string")
+      def initialize(error_type, message = nil)
+        super(message)
+        @error_type = error_type
       end
-      next
     end
 
-    return get_result_from_report(last_run_report, exitcode, config, start_time)
-  end
-end
+    def self.handle_action(action)
+      if action == 'metadata'
+        puts metadata.to_json
+      else
+        action_results = new().action_run($stdin.read.chomp)
+        print action_results.to_json
 
-# TODO(ale): remove `env` from input before bumping to the next version
-def metadata()
-  return {
-    :description => "PXP Puppet module",
-    :actions => [
-      { :name        => "run",
-        :description => "Start a Puppet run",
-        :input       => {
-          :type      => "object",
-          :properties => {
-            :env => {
-              :type => "array",
-            },
-            :flags => {
-              :type => "array",
-              :items => {
-                :type => "string"
-              }
-            },
-            :job => {
-              :type => "string"
-            }
-          },
-          :required => [:flags]
-        },
-        :results => {
-          :type => "object",
-          :properties => {
-            :kind => {
-              :type => "string"
-            },
-            :time => {
-              :type => "string"
-            },
-            :transaction_uuid => {
-              :type => "string"
-            },
-            :metrics => {
-              :type => "object"
-            },
-            :environment => {
-              :type => "string"
-            },
-            :status => {
-              :type => "string"
-            },
-            :error_type => {
-              :type => "string"
-            },
-            :error => {
-              :type => "string"
-            },
-            :exitcode => {
-              :type => "number"
-            },
-            :version => {
-              :type => "number"
-            }
-          },
-          :required => [:kind, :time, :transaction_uuid, :environment, :status,
-                        :exitcode, :version]
-        }
-      }
-    ],
-    :configuration => {
-      :type => "object",
-      :properties => {
-        :puppet_bin => {
-          :type => "string"
-        }
-      }
-    }
-  }
-end
-
-def run(config, action_input)
-  if !File.exist?(config["puppet_bin"])
-    return make_error_result(DEFAULT_EXITCODE, Errors::NoPuppetBin,
-                             "Puppet executable '#{config["puppet_bin"]}' does not exist")
-  end
-
-  return start_run(config, action_input)
-end
-
-def get_configuration(args)
-  config = args["configuration"] || {}
-
-  if config["puppet_bin"].nil? || config["puppet_bin"].empty?
-    if !Puppet.features.microsoft_windows?
-      config["puppet_bin"] = "/opt/puppetlabs/bin/puppet"
-    else
-      module_path = File.expand_path(File.dirname(__FILE__))
-      puppet_bin = File.join(module_path, '..', '..', 'bin', 'puppet.bat')
-      config["puppet_bin"] = File.expand_path(puppet_bin)
+        unless action_results["error"].nil?
+          exit 1
+        end
+      end
     end
-  end
 
-  config
-end
+    DEFAULT_EXITCODE = -1
 
-DEFAULT_FLAGS = ["--onetime", "--no-daemonize", "--verbose"]
-
-DEFAULT_FLAGS_NAMES = ["onetime", "daemonize", "verbose"]
-
-WHITELISTED_FLAGS_NAMES = [
-  "color", "configtimeout",
-  "debug","disable_warnings",
-  "environment", "evaltrace",
-  "filetimeout",
-  "graph",
-  "http_connect_timeout", "http_debug", "http_keepalive_timeout", "http_read_timeout",
-  "log_level",
-  "noop",
-  "ordering",
-  "pluginsync",
-  "show_diff", "skip_tags", "splay", "strict_environment_mode",
-  "tags", "trace",
-  "use_cached_catalog", "usecacheonfailure",
-  "waitforcert"]
-
-# All flags and valid arguments to them should be caught by this.
-#  It was constructed for the following argument types:
-#  "timeout": /\A\d+[mhdy]?\Z/,
-#  "environment": /\A[a-z0-9_]+\Z/,
-#  "tag": /\A[a-z0-9_][a-z0-9_:\.\-]*\Z/,
-#  "ordering": /\Atitle-hash|manifest|random\Z/
-VALID_FLAG_REGEX = /\A[a-zA-Z0-9_:,\.\-]+\Z/
-
-# This asserts that the flag has a valid prefix
-def get_flag_name(flag)
-  if flag.start_with?("--no-")
-    flag[5..-1]
-  elsif flag.start_with?("--")
-    flag[2..-1]
-  else
-    raise "Assertion error: we're here by mistake"
-  end
-end
-
-def get_action_input(args)
-  action_input = args["input"]
-  unless action_input.is_a?(Hash)
-    raise ProcessingError.new(Errors::InvalidJson, "The json received on STDIN did not contain a valid 'input' key: #{args.to_s}")
-  end
-
-  if action_input.has_key?("flags")
-    action_input["flags"].each do |flag|
-      flag = flag.strip
-      unless flag =~ VALID_FLAG_REGEX
-        raise ProcessingError.new(Errors::InvalidJson, "The json received on STDIN contained characters not present in valid flags: #{flag}")
+    def get_env_fix_up
+      # If running in a C or POSIX locale, ask Puppet to use UTF-8
+      base_env = {}
+      if Encoding.default_external == Encoding::US_ASCII
+        base_env = {"RUBYOPT" => "#{ENV['RUBYOPT']} -EUTF-8"}
       end
 
-      if flag.start_with?("--")
-        flag_name = get_flag_name(flag)
+      # Prepare an environment fix-up to make up for its cleansing performed
+      # by the Puppet::Util::Execution.execute function.
+      # This fix-up is meant for running puppet under a non-root user;
+      # puppet cannot find the user's HOME directory otherwise.
+      @env_fix_up ||= if Puppet.features.microsoft_windows? || Process.euid == 0
+        # no environment fix-up is needed on windows or for root
+        base_env
+      else
+        begin
+          require 'etc'
 
-        if DEFAULT_FLAGS_NAMES.include?(flag_name)
-          unless DEFAULT_FLAGS.include?(flag)
-            raise ProcessingError.new(Errors::InvalidJson, "The json received on STDIN overrides a default setting with: #{flag}")
+          pwentry = Etc.getpwuid(Process.euid)
+
+          {"USER"    => pwentry.name,
+           "LOGNAME" => pwentry.name,
+           "HOME"    => pwentry.dir}.merge base_env
+        rescue => e
+          # oh well ..., let's give it a try without the environment fix-up
+          myname = File.basename($0)
+          $stderr.puts "#{myname}: Could not fix environment for effective UID #{Process.euid}: #{e.message}"
+          $stderr.puts "#{myname}: Expect puppet run problems"
+          base_env
+        end
+      end
+    end
+
+    def last_run_result(exitcode)
+      return {"kind"             => "unknown",
+              "time"             => "unknown",
+              "transaction_uuid" => "unknown",
+              "environment"      => "unknown",
+              "status"           => "unknown",
+              "metrics"          => {},
+              "exitcode"         => exitcode,
+              "version"          => 1}
+    end
+
+    def force_unicode(s)
+      begin
+        # Later comparisons assume UTF-8. Convert to that encoding now.
+        s.encode(Encoding::UTF_8)
+      rescue Encoding::InvalidByteSequenceError
+        # Found non-native characters, hope it's a UTF-8 string. Since this is Puppet, and
+        # incorrect characters probably means we're in a C or POSIX locale, this is usually safe.
+        s.force_encoding(Encoding::UTF_8)
+      end
+    end
+
+    def check_config_print(cli_arg, config)
+      command_array = [config["puppet_bin"], "agent", "--configprint", cli_arg]
+      process_output = Puppet::Util::Execution.execute(command_array,
+                                                       {:custom_environment => get_env_fix_up(),
+                                                        :override_locale => false})
+      return force_unicode(process_output.to_s).chomp
+    end
+
+    def running?(run_result)
+      !!(run_result =~ /Run of Puppet configuration client already in progress/)
+    end
+
+    def disabled?(run_result)
+      !!(run_result =~ /disabled(.*?)Use 'puppet agent --enable' to re-enable/m)
+    end
+
+    def make_environment_hash()
+      # NB: we're ignoring the `env` array for setting the environment
+      return get_env_fix_up()
+    end
+
+    def make_command_array(config, action_input)
+      cmd_array = [config["puppet_bin"], "agent"]
+      cmd_array +=  action_input["flags"]
+      return cmd_array
+    end
+
+    def make_error_result(exitcode, error_type, error_message)
+      result = last_run_result(exitcode)
+      result["error_type"] = error_type
+      result["error"] = error_message
+      return result
+    end
+
+    def parse_report(filename)
+      # Read the report and drop Ruby objects first. We can't parse the Ruby objects
+      # (because we don't have Puppet loaded) and don't need that data.
+      # Psych::Nodes::Node#each iterates over each node in the parsed document tree.
+      # YAML.parse_file returns a Psych::Nodes::Document, and #root returns the
+      # root-level Node.
+      data = YAML.parse_file(filename)
+      data.root.each do |o|
+        o.tag = nil if o.respond_to?(:tag=)
+      end
+
+      data.to_ruby
+    end
+
+    def nest_metrics(metrics)
+      metrics.fetch('resources', {}).fetch('values', {}).inject({}) do |result, (name,human_name,value)|
+        result.merge(name => value)
+      end
+    end
+
+    def get_result_from_report(last_run_report, exitcode, config, start_time)
+      if !File.exist?(last_run_report)
+        return make_error_result(exitcode, Errors::NoLastRunReport,
+                                 "#{last_run_report} doesn't exist")
+      end
+
+      if start_time && File.mtime(last_run_report) == start_time
+        return make_error_result(exitcode, Errors::NoLastRunReport,
+                                 "#{last_run_report} was not written")
+      end
+
+      last_run_report_yaml = {}
+
+      begin
+        last_run_report_yaml = parse_report(last_run_report)
+      rescue => e
+        return make_error_result(exitcode, Errors::InvalidLastRunReport,
+                                 "#{last_run_report} could not be loaded: #{e}")
+      end
+
+      if exitcode == 0
+        run_result = last_run_result(exitcode)
+      else
+        run_result = make_error_result(exitcode, Errors::NonZeroExit,
+                                       "Puppet agent exited with a non 0 exitcode")
+      end
+
+      run_result["kind"] = last_run_report_yaml['kind']
+      run_result["time"] = last_run_report_yaml['time']
+      run_result["transaction_uuid"] = last_run_report_yaml['transaction_uuid']
+      run_result["environment"] = last_run_report_yaml['environment']
+      run_result["status"] = last_run_report_yaml['status']
+      run_result["metrics"] = nest_metrics(last_run_report_yaml['metrics'])
+
+      return run_result
+    end
+
+    # Wait for the lockfile to be removed. If it hasn't after 30 seconds, give up.
+    def wait_for_lockfile(lockfile = '', check_interval = 0.1, give_up_after = 30)
+      number_of_tries = give_up_after / check_interval
+      count = 0
+      while File.exist?(lockfile) && count < number_of_tries
+        sleep check_interval
+        count += 1
+      end
+    end
+
+    def start_run(config, action_input)
+      exitcode = DEFAULT_EXITCODE
+      cmd = make_command_array(config, action_input)
+      env = make_environment_hash()
+
+      last_run_report = check_config_print("lastrunreport", config)
+      if last_run_report.empty?
+        return make_error_result(exitcode, Errors::NoLastRunReport,
+                                 "could not find the location of the last run report")
+      end
+
+      # Initially ignore the lockfile. It might be out-dated, so we give Puppet a chance
+      # to clean it up and run.
+      lockfile = ''
+      while true
+        wait_for_lockfile(lockfile)
+
+        start_time = File.mtime(last_run_report) if File.exist?(last_run_report)
+
+        run_result = Puppet::Util::Execution.execute(cmd, {:failonfail => false,
+                                                           :custom_environment => env,
+                                                           :override_locale => false})
+
+        if !run_result
+          return make_error_result(exitcode, Errors::FailedToStart,
+                                   "Failed to start Puppet agent")
+        end
+
+        exitcode = run_result.exitstatus
+        puppet_output = force_unicode(run_result.to_s)
+
+        if disabled?(puppet_output)
+          return make_error_result(exitcode, Errors::Disabled,
+                                   "Puppet agent is disabled")
+        elsif running?(puppet_output)
+          # Puppet is already running, attempt to wait until it finishes and retry.
+          lockfile = check_config_print('agent_catalog_run_lockfile', config)
+          if lockfile.empty?
+            # Can't identify lockfile, just report an error.
+            return make_error_result(exitcode, Errors::AlreadyRunning,
+                                     "Puppet agent is already performing a run; it also appears to be" +
+                                     " misconfigured, agent_catalog_run_lockfile is an empty string")
           end
           next
         end
 
-        unless WHITELISTED_FLAGS_NAMES.include?(flag_name)
-          raise ProcessingError.new(Errors::InvalidJson, "The json received on STDIN included a non-permitted flag: #{flag}")
-        end
+        return get_result_from_report(last_run_report, exitcode, config, start_time)
       end
     end
-  end
 
-  action_input["flags"] = action_input["flags"] | DEFAULT_FLAGS
-
-  if action_input.has_key?("job")
-    action_input["flags"] += ["--job-id", action_input["job"]]
-  end
-
-  action_input
-end
-
-def action_run(input)
-  begin
-    args = JSON.parse(input)
-  rescue
-    return make_error_result(DEFAULT_EXITCODE, Errors::InvalidJson,
-                             "Invalid json received on STDIN: #{input}")
-  end
-  unless args.is_a?(Hash)
-    return make_error_result(DEFAULT_EXITCODE, Errors::InvalidJson,
-                             "The json received on STDIN was not a hash: #{args.to_s}")
-  end
-
-  output_files = args["output_files"]
-  if output_files
-    begin
-      $stdout.reopen(File.open(output_files["stdout"], 'w'))
-      $stderr.reopen(File.open(output_files["stderr"], 'w'))
-    rescue => e
-      print make_error_result(DEFAULT_EXITCODE, Errors::InvalidJson,
-                              "Could not open output files: #{e.message}").to_json
-      exit 5 # this exit code is reserved for problems with opening
-             # of the output_files
+    # TODO(ale): remove `env` from input before bumping to the next version
+    def self.metadata()
+      return {
+        :description => "PXP Puppet module",
+        :actions => [
+          { :name        => "run",
+            :description => "Start a Puppet run",
+            :input       => {
+              :type      => "object",
+              :properties => {
+                :env => {
+                  :type => "array",
+                },
+                :flags => {
+                  :type => "array",
+                  :items => {
+                    :type => "string"
+                  }
+                },
+                :job => {
+                  :type => "string"
+                }
+              },
+              :required => [:flags]
+            },
+            :results => {
+              :type => "object",
+              :properties => {
+                :kind => {
+                  :type => "string"
+                },
+                :time => {
+                  :type => "string"
+                },
+                :transaction_uuid => {
+                  :type => "string"
+                },
+                :metrics => {
+                  :type => "object"
+                },
+                :environment => {
+                  :type => "string"
+                },
+                :status => {
+                  :type => "string"
+                },
+                :error_type => {
+                  :type => "string"
+                },
+                :error => {
+                  :type => "string"
+                },
+                :exitcode => {
+                  :type => "number"
+                },
+                :version => {
+                  :type => "number"
+                }
+              },
+              :required => [:kind, :time, :transaction_uuid, :environment, :status,
+                            :exitcode, :version]
+            }
+          }
+        ],
+        :configuration => {
+          :type => "object",
+          :properties => {
+            :puppet_bin => {
+              :type => "string"
+            }
+          }
+        }
+      }
     end
 
-    at_exit do
-      status = if $!.nil?
-        0
-      elsif $!.is_a?(SystemExit)
-        $!.status
+    def run(config, action_input)
+      if !File.exist?(config["puppet_bin"])
+        return make_error_result(DEFAULT_EXITCODE, Errors::NoPuppetBin,
+                                 "Puppet executable '#{config["puppet_bin"]}' does not exist")
+      end
+
+      return start_run(config, action_input)
+    end
+
+    def get_configuration(args)
+      config = args["configuration"] || {}
+
+      if config["puppet_bin"].nil? || config["puppet_bin"].empty?
+        if !Puppet.features.microsoft_windows?
+          config["puppet_bin"] = "/opt/puppetlabs/bin/puppet"
+        else
+          module_path = File.expand_path(File.dirname(__FILE__))
+          puppet_bin = File.join(module_path, '..', '..', 'bin', 'puppet.bat')
+          config["puppet_bin"] = File.expand_path(puppet_bin)
+        end
+      end
+
+      config
+    end
+
+    DEFAULT_FLAGS = ["--onetime", "--no-daemonize", "--verbose"]
+
+    DEFAULT_FLAGS_NAMES = ["onetime", "daemonize", "verbose"]
+
+    WHITELISTED_FLAGS_NAMES = [
+      "color", "configtimeout",
+      "debug","disable_warnings",
+      "environment", "evaltrace",
+      "filetimeout",
+      "graph",
+      "http_connect_timeout", "http_debug", "http_keepalive_timeout", "http_read_timeout",
+      "log_level",
+      "noop",
+      "ordering",
+      "pluginsync",
+      "show_diff", "skip_tags", "splay", "strict_environment_mode",
+      "tags", "trace",
+      "use_cached_catalog", "usecacheonfailure",
+      "waitforcert"]
+
+    # All flags and valid arguments to them should be caught by this.
+    #  It was constructed for the following argument types:
+    #  "timeout": /\A\d+[mhdy]?\Z/,
+    #  "environment": /\A[a-z0-9_]+\Z/,
+    #  "tag": /\A[a-z0-9_][a-z0-9_:\.\-]*\Z/,
+    #  "ordering": /\Atitle-hash|manifest|random\Z/
+    VALID_FLAG_REGEX = /\A[a-zA-Z0-9_:,\.\-]+\Z/
+
+    # This asserts that the flag has a valid prefix
+    def get_flag_name(flag)
+      if flag.start_with?("--no-")
+        flag[5..-1]
+      elsif flag.start_with?("--")
+        flag[2..-1]
       else
-        1
-      end
-
-      # flush the stdout/stderr before writing the exitcode
-      # file to avoid pxp-agent reading incomplete output
-      $stdout.fsync
-      $stderr.fsync
-      begin
-        File.open(output_files["exitcode"], 'w') do |f|
-          f.puts(status)
-        end
-      rescue => e
-        print make_error_result(DEFAULT_EXITCODE, Errors::InvalidJson,
-                                "Could not open exit code file: #{e.message}").to_json
-        exit 5 # this exit code is reserved for problems with opening
-               # of the output_files
+        raise "Assertion error: we're here by mistake"
       end
     end
-  end
 
-  begin
-    config = get_configuration(args)
-    action_input = get_action_input(args)
-  rescue ProcessingError => e
-    return make_error_result(DEFAULT_EXITCODE, e.error_type, e.message)
-  end
+    def get_action_input(args)
+      action_input = args["input"]
+      unless action_input.is_a?(Hash)
+        raise ProcessingError.new(Errors::InvalidJson, "The json received on STDIN did not contain a valid 'input' key: #{args.to_s}")
+      end
 
-  run(config, action_input)
+      if action_input.has_key?("flags")
+        action_input["flags"].each do |flag|
+          flag = flag.strip
+          unless flag =~ VALID_FLAG_REGEX
+            raise ProcessingError.new(Errors::InvalidJson, "The json received on STDIN contained characters not present in valid flags: #{flag}")
+          end
+
+          if flag.start_with?("--")
+            flag_name = get_flag_name(flag)
+
+            if DEFAULT_FLAGS_NAMES.include?(flag_name)
+              unless DEFAULT_FLAGS.include?(flag)
+                raise ProcessingError.new(Errors::InvalidJson, "The json received on STDIN overrides a default setting with: #{flag}")
+              end
+              next
+            end
+
+            unless WHITELISTED_FLAGS_NAMES.include?(flag_name)
+              raise ProcessingError.new(Errors::InvalidJson, "The json received on STDIN included a non-permitted flag: #{flag}")
+            end
+          end
+        end
+      end
+
+      action_input["flags"] = action_input["flags"] | DEFAULT_FLAGS
+
+      if action_input.has_key?("job")
+        action_input["flags"] += ["--job-id", action_input["job"]]
+      end
+
+      action_input
+    end
+
+    def action_run(input)
+      begin
+        args = JSON.parse(input)
+      rescue
+        return make_error_result(DEFAULT_EXITCODE, Errors::InvalidJson,
+                                 "Invalid json received on STDIN: #{input}")
+      end
+      unless args.is_a?(Hash)
+        return make_error_result(DEFAULT_EXITCODE, Errors::InvalidJson,
+                                 "The json received on STDIN was not a hash: #{args.to_s}")
+      end
+
+      output_files = args["output_files"]
+      if output_files
+        begin
+          $stdout.reopen(File.open(output_files["stdout"], 'w'))
+          $stderr.reopen(File.open(output_files["stderr"], 'w'))
+        rescue => e
+          print make_error_result(DEFAULT_EXITCODE, Errors::InvalidJson,
+                                  "Could not open output files: #{e.message}").to_json
+          exit 5 # this exit code is reserved for problems with opening
+                 # of the output_files
+        end
+
+        at_exit do
+          status = if $!.nil?
+            0
+          elsif $!.is_a?(SystemExit)
+            $!.status
+          else
+            1
+          end
+
+          # flush the stdout/stderr before writing the exitcode
+          # file to avoid pxp-agent reading incomplete output
+          $stdout.fsync
+          $stderr.fsync
+          begin
+            File.open(output_files["exitcode"], 'w') do |f|
+              f.puts(status)
+            end
+          rescue => e
+            print make_error_result(DEFAULT_EXITCODE, Errors::InvalidJson,
+                                    "Could not open exit code file: #{e.message}").to_json
+            exit 5 # this exit code is reserved for problems with opening
+                   # of the output_files
+          end
+        end
+      end
+
+      begin
+        config = get_configuration(args)
+        action_input = get_action_input(args)
+      rescue ProcessingError => e
+        return make_error_result(DEFAULT_EXITCODE, e.error_type, e.message)
+      end
+
+      run(config, action_input)
+    end
+
+  end
 end
 
 if __FILE__ == $0
   action = ARGV.shift || 'metadata'
-
-  if action == 'metadata'
-    puts metadata.to_json
-  else
-    action_results = action_run($stdin.read.chomp)
-    print action_results.to_json
-
-    unless action_results["error"].nil?
-      exit 1
-    end
-  end
+  Pxp::ModulePuppet.handle_action(action)
 end

--- a/modules/pxp-module-puppet
+++ b/modules/pxp-module-puppet
@@ -340,9 +340,7 @@ module Pxp
       return start_run(config, action_input)
     end
 
-    def self.get_configuration(args)
-      config = args["configuration"] || {}
-
+    def get_configuration(config)
       if config["puppet_bin"].nil? || config["puppet_bin"].empty?
         if !Puppet.features.microsoft_windows?
           config["puppet_bin"] = "/opt/puppetlabs/bin/puppet"
@@ -385,7 +383,7 @@ module Pxp
     VALID_FLAG_REGEX = /\A[a-zA-Z0-9_:,\.\-]+\Z/
 
     # This asserts that the flag has a valid prefix
-    def self.get_flag_name(flag)
+    def get_flag_name(flag)
       if flag.start_with?("--no-")
         flag[5..-1]
       elsif flag.start_with?("--")
@@ -395,12 +393,7 @@ module Pxp
       end
     end
 
-    def self.get_action_input(args)
-      action_input = args["input"]
-      unless action_input.is_a?(Hash)
-        raise ProcessingError.new(Errors::InvalidJson, "The json received on STDIN did not contain a valid 'input' key: #{args.to_s}")
-      end
-
+    def get_action_input(action_input)
       if action_input.has_key?("flags")
         action_input["flags"].each do |flag|
           flag = flag.strip
@@ -485,18 +478,22 @@ module Pxp
       end
 
       begin
-        config = get_configuration(args)
-        action_input = get_action_input(args)
+        config = args["configuration"] || {}
+
+        action_input = args["input"]
+        unless action_input.is_a?(Hash)
+          raise ProcessingError.new(Errors::InvalidJson, "The json received on STDIN did not contain a valid 'input' key: #{args.to_s}")
+        end
+
+        new(config, action_input)
       rescue ProcessingError => e
         return make_error_result(DEFAULT_EXITCODE, e.error_type, e.message)
       end
-
-      new(config, action_input)
     end
 
     def initialize(config, action_input)
-      @config = config
-      @action_input = action_input
+      @config = get_configuration(config.dup)
+      @action_input = get_action_input(action_input.dup)
     end
 
   end

--- a/modules/pxp-module-puppet
+++ b/modules/pxp-module-puppet
@@ -206,7 +206,18 @@ module Pxp
       end
     end
 
-    def start_run
+    # Determine whether the configured puppet bin exists. This method mostly
+    # exists for testing.
+    def puppet_bin_present?
+      File.exist?(config["puppet_bin"])
+    end
+
+    def run
+      if !puppet_bin_present?
+        return self.class.make_error_result(DEFAULT_EXITCODE, Errors::NoPuppetBin,
+                                 "Puppet executable '#{config["puppet_bin"]}' does not exist")
+      end
+
       exitcode = DEFAULT_EXITCODE
       env = make_environment_hash()
 
@@ -328,15 +339,6 @@ module Pxp
           }
         }
       }
-    end
-
-    def run
-      if !File.exist?(config["puppet_bin"])
-        return self.class.make_error_result(DEFAULT_EXITCODE, Errors::NoPuppetBin,
-                                 "Puppet executable '#{config["puppet_bin"]}' does not exist")
-      end
-
-      start_run
     end
 
     def self.add_config_defaults(config)

--- a/modules/pxp-module-puppet
+++ b/modules/pxp-module-puppet
@@ -105,7 +105,7 @@ module Pxp
       end
     end
 
-    def check_config_print(cli_arg, config)
+    def config_print(cli_arg)
       command_array = [config["puppet_bin"], "agent", "--configprint", cli_arg]
       process_output = Puppet::Util::Execution.execute(command_array,
                                                        {:custom_environment => get_env_fix_up(),
@@ -210,7 +210,7 @@ module Pxp
       exitcode = DEFAULT_EXITCODE
       env = make_environment_hash()
 
-      last_run_report = check_config_print("lastrunreport", config)
+      last_run_report = config_print("lastrunreport")
       if last_run_report.empty?
         return self.class.make_error_result(exitcode, Errors::NoLastRunReport,
                                  "could not find the location of the last run report")
@@ -241,7 +241,7 @@ module Pxp
                                    "Puppet agent is disabled")
         elsif running?(puppet_output)
           # Puppet is already running, attempt to wait until it finishes and retry.
-          lockfile = check_config_print('agent_catalog_run_lockfile', config)
+          lockfile = config_print('agent_catalog_run_lockfile')
           if lockfile.empty?
             # Can't identify lockfile, just report an error.
             return self.class.make_error_result(exitcode, Errors::AlreadyRunning,

--- a/modules/pxp-module-puppet
+++ b/modules/pxp-module-puppet
@@ -255,6 +255,9 @@ def metadata()
               :items => {
                 :type => "string"
               }
+            },
+            :job => {
+              :type => "string"
             }
           },
           :required => [:flags]
@@ -404,6 +407,11 @@ def get_action_input(args)
   end
 
   action_input["flags"] = action_input["flags"] | DEFAULT_FLAGS
+
+  if action_input.has_key?("job")
+    action_input["flags"] += ["--job-id", action_input["job"]]
+  end
+
   action_input
 end
 

--- a/modules/pxp-module-puppet
+++ b/modules/pxp-module-puppet
@@ -126,7 +126,7 @@ module Pxp
       return get_env_fix_up()
     end
 
-    def make_command_array(config, flags)
+    def puppet_agent_command
       cmd_array = [config["puppet_bin"], "agent"]
       cmd_array += flags
       return cmd_array
@@ -208,7 +208,6 @@ module Pxp
 
     def start_run
       exitcode = DEFAULT_EXITCODE
-      cmd = make_command_array(config, flags)
       env = make_environment_hash()
 
       last_run_report = check_config_print("lastrunreport", config)
@@ -225,9 +224,9 @@ module Pxp
 
         start_time = File.mtime(last_run_report) if File.exist?(last_run_report)
 
-        run_result = Puppet::Util::Execution.execute(cmd, {:failonfail => false,
-                                                           :custom_environment => env,
-                                                           :override_locale => false})
+        run_result = Puppet::Util::Execution.execute(puppet_agent_command, {:failonfail => false,
+                                                                            :custom_environment => env,
+                                                                            :override_locale => false})
 
         if !run_result
           return self.class.make_error_result(exitcode, Errors::FailedToStart,

--- a/modules/pxp-module-puppet
+++ b/modules/pxp-module-puppet
@@ -27,7 +27,7 @@ module Pxp
       end
     end
 
-    attr_reader :config, :action_input
+    attr_reader :config, :flags
 
     def self.handle_action(action)
       if action == 'metadata'
@@ -126,9 +126,9 @@ module Pxp
       return get_env_fix_up()
     end
 
-    def make_command_array(config, action_input)
+    def make_command_array(config, flags)
       cmd_array = [config["puppet_bin"], "agent"]
-      cmd_array +=  action_input["flags"]
+      cmd_array += flags
       return cmd_array
     end
 
@@ -206,9 +206,9 @@ module Pxp
       end
     end
 
-    def start_run(config, action_input)
+    def start_run
       exitcode = DEFAULT_EXITCODE
-      cmd = make_command_array(config, action_input)
+      cmd = make_command_array(config, flags)
       env = make_environment_hash()
 
       last_run_report = check_config_print("lastrunreport", config)
@@ -337,10 +337,11 @@ module Pxp
                                  "Puppet executable '#{config["puppet_bin"]}' does not exist")
       end
 
-      return start_run(config, action_input)
+      return start_run(config)
     end
 
-    def get_configuration(config)
+    def self.add_config_defaults(config)
+      config = config.dup
       if config["puppet_bin"].nil? || config["puppet_bin"].empty?
         if !Puppet.features.microsoft_windows?
           config["puppet_bin"] = "/opt/puppetlabs/bin/puppet"
@@ -383,7 +384,7 @@ module Pxp
     VALID_FLAG_REGEX = /\A[a-zA-Z0-9_:,\.\-]+\Z/
 
     # This asserts that the flag has a valid prefix
-    def get_flag_name(flag)
+    def self.get_flag_name(flag)
       if flag.start_with?("--no-")
         flag[5..-1]
       elsif flag.start_with?("--")
@@ -393,38 +394,38 @@ module Pxp
       end
     end
 
-    def get_action_input(action_input)
-      if action_input.has_key?("flags")
-        action_input["flags"].each do |flag|
-          flag = flag.strip
-          unless flag =~ VALID_FLAG_REGEX
-            raise ProcessingError.new(Errors::InvalidJson, "The json received on STDIN contained characters not present in valid flags: #{flag}")
+    def self.process_flags(action_input)
+      flags = action_input['flags'] || []
+
+      flags.each do |flag|
+        flag = flag.strip
+        unless flag =~ VALID_FLAG_REGEX
+          raise ProcessingError.new(Errors::InvalidJson, "The json received on STDIN contained characters not present in valid flags: #{flag}")
+        end
+
+        if flag.start_with?("--")
+          flag_name = get_flag_name(flag)
+
+          if DEFAULT_FLAGS_NAMES.include?(flag_name)
+            unless DEFAULT_FLAGS.include?(flag)
+              raise ProcessingError.new(Errors::InvalidJson, "The json received on STDIN overrides a default setting with: #{flag}")
+            end
+            next
           end
 
-          if flag.start_with?("--")
-            flag_name = get_flag_name(flag)
-
-            if DEFAULT_FLAGS_NAMES.include?(flag_name)
-              unless DEFAULT_FLAGS.include?(flag)
-                raise ProcessingError.new(Errors::InvalidJson, "The json received on STDIN overrides a default setting with: #{flag}")
-              end
-              next
-            end
-
-            unless WHITELISTED_FLAGS_NAMES.include?(flag_name)
-              raise ProcessingError.new(Errors::InvalidJson, "The json received on STDIN included a non-permitted flag: #{flag}")
-            end
+          unless WHITELISTED_FLAGS_NAMES.include?(flag_name)
+            raise ProcessingError.new(Errors::InvalidJson, "The json received on STDIN included a non-permitted flag: #{flag}")
           end
         end
       end
 
-      action_input["flags"] = action_input["flags"] | DEFAULT_FLAGS
+      flags |= DEFAULT_FLAGS
 
       if action_input.has_key?("job")
-        action_input["flags"] += ["--job-id", action_input["job"]]
+        flags += ["--job-id", action_input["job"]]
       end
 
-      action_input
+      flags
     end
 
     def self.create_runner(input)
@@ -478,12 +479,14 @@ module Pxp
       end
 
       begin
-        config = args["configuration"] || {}
+        config = add_config_defaults(args["configuration"] || {})
 
         action_input = args["input"]
         unless action_input.is_a?(Hash)
           raise ProcessingError.new(Errors::InvalidJson, "The json received on STDIN did not contain a valid 'input' key: #{args.to_s}")
         end
+
+        flags = process_flags(action_input)
 
         new(config, action_input)
       rescue ProcessingError => e
@@ -491,9 +494,9 @@ module Pxp
       end
     end
 
-    def initialize(config, action_input)
-      @config = get_configuration(config.dup)
-      @action_input = get_action_input(action_input.dup)
+    def initialize(config, flags)
+      @config = config
+      @flags = flags
     end
 
   end

--- a/modules/pxp-module-puppet
+++ b/modules/pxp-module-puppet
@@ -212,6 +212,10 @@ module Pxp
       File.exist?(config["puppet_bin"])
     end
 
+    def get_start_time(last_run_report)
+      File.mtime(last_run_report) if File.exist?(last_run_report)
+    end
+
     def run
       if !puppet_bin_present?
         return self.class.make_error_result(DEFAULT_EXITCODE, Errors::NoPuppetBin,
@@ -233,7 +237,7 @@ module Pxp
       while true
         wait_for_lockfile(lockfile)
 
-        start_time = File.mtime(last_run_report) if File.exist?(last_run_report)
+        start_time = get_start_time(last_run_report)
 
         run_result = Puppet::Util::Execution.execute(puppet_agent_command, {:failonfail => false,
                                                                             :custom_environment => env,

--- a/modules/pxp-module-puppet
+++ b/modules/pxp-module-puppet
@@ -159,7 +159,7 @@ module Pxp
       end
     end
 
-    def get_result_from_report(last_run_report, exitcode, config, start_time)
+    def get_result_from_report(last_run_report, exitcode, start_time)
       if !File.exist?(last_run_report)
         return self.class.make_error_result(exitcode, Errors::NoLastRunReport,
                                  "#{last_run_report} doesn't exist")
@@ -251,7 +251,7 @@ module Pxp
           next
         end
 
-        return get_result_from_report(last_run_report, exitcode, config, start_time)
+        return get_result_from_report(last_run_report, exitcode, start_time)
       end
     end
 
@@ -336,7 +336,7 @@ module Pxp
                                  "Puppet executable '#{config["puppet_bin"]}' does not exist")
       end
 
-      return start_run(config)
+      start_run
     end
 
     def self.add_config_defaults(config)

--- a/modules/spec/unit/modules/puppet_spec.rb
+++ b/modules/spec/unit/modules/puppet_spec.rb
@@ -31,14 +31,14 @@ describe Pxp::ModulePuppet do
     end
   end
 
-  describe "check_config_print" do
+  describe "config_print" do
     it "returns the result of configprint" do
       cli_vec = ["puppet", "agent", "--configprint", "value"]
       expect(subject).to receive(:get_env_fix_up).and_return({"FIXVAR" => "fixvalue"})
       expect(Puppet::Util::Execution).to receive(:execute).with(cli_vec,
                                                                 {:custom_environment => {"FIXVAR" => "fixvalue"},
                                                                  :override_locale => false}).and_return("value\n")
-      expect(subject.check_config_print("value", default_configuration)).to be == "value"
+      expect(subject.config_print("value")).to be == "value"
     end
 
     it "returns the result of configprint with UTF-8 even though locale is POSIX" do
@@ -48,7 +48,7 @@ describe Pxp::ModulePuppet do
                                                                 {:custom_environment => {"FIXVAR" => "fixvalue"},
                                                                  :override_locale => false}).
                                                                  and_return("value☃".force_encoding(Encoding::US_ASCII))
-      expect(subject.check_config_print("value", default_configuration)).to be == "value☃"
+      expect(subject.config_print("value")).to be == "value☃"
     end
   end
 
@@ -257,8 +257,8 @@ describe Pxp::ModulePuppet do
     }
 
     before :each do
-      allow(subject).to receive(:check_config_print).with('lastrunreport', anything).and_return(last_run_report)
-      allow(subject).to receive(:check_config_print).with('agent_catalog_run_lockfile', anything).and_return(lockfile)
+      allow(subject).to receive(:config_print).with('lastrunreport').and_return(last_run_report)
+      allow(subject).to receive(:config_print).with('agent_catalog_run_lockfile').and_return(lockfile)
     end
 
     it "populates output when it terminated normally" do
@@ -324,7 +324,7 @@ describe Pxp::ModulePuppet do
       allow(subject).to receive(:disabled?).and_return(false)
       expect(subject).to receive(:running?).and_return(true)
 
-      allow(subject).to receive(:check_config_print).with('agent_catalog_run_lockfile', anything).and_return('')
+      allow(subject).to receive(:config_print).with('agent_catalog_run_lockfile').and_return('')
       expect(described_class).to receive(:make_error_result).with(1, Pxp::ModulePuppet::Errors::AlreadyRunning, anything)
       subject.start_run
     end

--- a/modules/spec/unit/modules/puppet_spec.rb
+++ b/modules/spec/unit/modules/puppet_spec.rb
@@ -125,7 +125,7 @@ describe Pxp::ModulePuppet do
 
     it "doesn't process the last_run_report if the file doesn't exist" do
       allow(File).to receive(:exist?).and_return(false)
-      expect(subject.get_result_from_report(last_run_report_path, 0, default_configuration, Time.now)).to be ==
+      expect(subject.get_result_from_report(last_run_report_path, 0, Time.now)).to be ==
           {"kind"             => "unknown",
            "time"             => "unknown",
            "transaction_uuid" => "unknown",
@@ -143,7 +143,7 @@ describe Pxp::ModulePuppet do
       allow(File).to receive(:mtime).and_return(start_time+1)
       allow(File).to receive(:exist?).and_return(true)
       allow(subject).to receive(:parse_report).and_raise("error")
-      expect(subject.get_result_from_report(last_run_report_path, 0, default_configuration, start_time)).to be ==
+      expect(subject.get_result_from_report(last_run_report_path, 0, start_time)).to be ==
           {"kind"             => "unknown",
            "time"             => "unknown",
            "transaction_uuid" => "unknown",
@@ -171,7 +171,7 @@ describe Pxp::ModulePuppet do
       allow(File).to receive(:exist?).and_return(true)
       allow(subject).to receive(:parse_report).with(last_run_report_path).and_return(last_run_report)
 
-      expect(subject.get_result_from_report(last_run_report_path, -1, default_configuration, start_time)).to be ==
+      expect(subject.get_result_from_report(last_run_report_path, -1, start_time)).to be ==
           {"kind"             => "unknown",
            "time"             => "unknown",
            "transaction_uuid" => "unknown",
@@ -200,7 +200,7 @@ describe Pxp::ModulePuppet do
       allow(File).to receive(:exist?).and_return(true)
       allow(subject).to receive(:parse_report).with(last_run_report_path).and_return(last_run_report)
 
-      expect(subject.get_result_from_report(last_run_report_path, -1, default_configuration, start_time)).to be ==
+      expect(subject.get_result_from_report(last_run_report_path, -1, start_time)).to be ==
           {"kind"             => "apply",
            "time"             => run_time,
            "transaction_uuid" => "ac59acbe-6a0f-49c9-8ece-f781a689fda9",
@@ -215,7 +215,7 @@ describe Pxp::ModulePuppet do
 
     it "correctly processes the last_run_report" do
       start_time = Time.parse('2016-01-01')
-      result = subject.get_result_from_report(last_run_report_path, 0, default_configuration, start_time)
+      result = subject.get_result_from_report(last_run_report_path, 0, start_time)
       result.delete('metrics')
       expect(result).to be ==
         {'kind'             => 'apply',
@@ -229,7 +229,7 @@ describe Pxp::ModulePuppet do
 
     it "includes metrics in the report" do
       start_time = Time.parse('2016-01-01')
-      result = subject.get_result_from_report(last_run_report_path, 0, default_configuration, start_time)
+      result = subject.get_result_from_report(last_run_report_path, 0, start_time)
       expect(result['metrics']).to be ==
         {'total' => 183,
          'skipped' => 0,
@@ -264,14 +264,14 @@ describe Pxp::ModulePuppet do
     it "populates output when it terminated normally" do
       allow(Puppet::Util::Execution).to receive(:execute).and_return(runoutcome)
       allow(runoutcome).to receive(:exitstatus).and_return(0)
-      expect(subject).to receive(:get_result_from_report).with(last_run_report, 0, default_configuration, anything)
+      expect(subject).to receive(:get_result_from_report).with(last_run_report, 0, anything)
       subject.start_run
     end
 
     it "populates output when it terminated with a non 0 code" do
       allow(Puppet::Util::Execution).to receive(:execute).and_return(runoutcome)
       allow(runoutcome).to receive(:exitstatus).and_return(1)
-      expect(subject).to receive(:get_result_from_report).with(last_run_report, 1, default_configuration, anything)
+      expect(subject).to receive(:get_result_from_report).with(last_run_report, 1, anything)
       subject.start_run
     end
 
@@ -299,7 +299,7 @@ describe Pxp::ModulePuppet do
       expect(File).to receive(:exist?).with('').and_return(false)
       expect(File).to receive(:exist?).with(lockfile).and_return(true, false)
 
-      expect(subject).to receive(:get_result_from_report).with(last_run_report, 0, default_configuration, anything)
+      expect(subject).to receive(:get_result_from_report).with(last_run_report, 0, anything)
       subject.start_run
     end
 
@@ -314,7 +314,7 @@ describe Pxp::ModulePuppet do
       expect(File).to receive(:exist?).with(lockfile).exactly(301).times.and_return(true)
       expect(subject).to receive(:sleep).with(0.1).exactly(300).times
 
-      expect(subject).to receive(:get_result_from_report).with(last_run_report, 0, default_configuration, anything)
+      expect(subject).to receive(:get_result_from_report).with(last_run_report, 0, anything)
       subject.start_run
     end
 
@@ -334,7 +334,7 @@ describe Pxp::ModulePuppet do
       allow(Puppet::Util::Execution).to receive(:execute).and_return(output)
       allow(output).to receive(:exitstatus).and_return(0)
       allow(output).to receive(:to_s).and_return(output)
-      expect(subject).to receive(:get_result_from_report).with(last_run_report, 0, default_configuration, anything)
+      expect(subject).to receive(:get_result_from_report).with(last_run_report, 0, anything)
       subject.start_run
     end
 
@@ -343,7 +343,7 @@ describe Pxp::ModulePuppet do
       allow(Puppet::Util::Execution).to receive(:execute).and_return(output)
       allow(output).to receive(:exitstatus).and_return(0)
       allow(output).to receive(:to_s).and_return(output)
-      expect(subject).to receive(:get_result_from_report).with(last_run_report, 0, default_configuration, anything)
+      expect(subject).to receive(:get_result_from_report).with(last_run_report, 0, anything)
       subject.start_run
     end
   end

--- a/modules/spec/unit/modules/puppet_spec.rb
+++ b/modules/spec/unit/modules/puppet_spec.rb
@@ -99,6 +99,7 @@ describe Pxp::ModulePuppet do
     it "should correctly append any flags" do
       input = default_input
       input["flags"] = ["--noop", "--verbose"]
+      subject = described_class.new(default_configuration, input)
       expect(subject.make_command_array(default_configuration, input)).to be ==
         ["puppet", "agent", "--noop", "--verbose"]
     end
@@ -352,27 +353,27 @@ describe Pxp::ModulePuppet do
 
   describe "get_flag_name" do
     it "returns the flag name" do
-      expect(described_class.get_flag_name("--spam")).to be == "spam"
+      expect(subject.get_flag_name("--spam")).to be == "spam"
     end
 
     it "returns the flag name in case it's negative" do
-      expect(described_class.get_flag_name("--no-spam")).to be == "spam"
+      expect(subject.get_flag_name("--no-spam")).to be == "spam"
     end
 
     it "returns an empty string in case the flag has only a suffix" do
-      expect(described_class.get_flag_name("--")).to be == ""
-      expect(described_class.get_flag_name("--no-")).to be == ""
+      expect(subject.get_flag_name("--")).to be == ""
+      expect(subject.get_flag_name("--no-")).to be == ""
     end
 
     it "raises an error in case of invalid suffix" do
       expect do
-        described_class.get_flag_name("-spam")
+        subject.get_flag_name("-spam")
       end.to raise_error(RuntimeError, /Assertion error: we're here by mistake/)
     end
 
     it "raises an error in case the flag has no suffix" do
       expect do
-        described_class.get_flag_name("eggs")
+        subject.get_flag_name("eggs")
       end.to raise_error(RuntimeError, /Assertion error: we're here by mistake/)
     end
   end
@@ -523,7 +524,7 @@ describe Pxp::ModulePuppet do
       input = default_input.merge('job' => 'foobar')
       expected_input = {"flags" => ["--onetime", "--no-daemonize", "--verbose", "--job-id", "foobar"],
                         "job" => "foobar"}
-      subject = described_class.new(default_configuration, expected_input)
+      subject = described_class.new(default_configuration, input)
 
       allow(File).to receive(:exist?).and_return(true)
       allow(subject).to receive(:running?).and_return(false)

--- a/modules/spec/unit/modules/puppet_spec.rb
+++ b/modules/spec/unit/modules/puppet_spec.rb
@@ -391,6 +391,9 @@ describe "pxp-module-puppet" do
                   :items => {
                     :type => "string"
                   }
+                },
+                :job => {
+                  :type => "string"
                 }
               },
               :required => [:flags]
@@ -498,6 +501,18 @@ describe "pxp-module-puppet" do
       expect_any_instance_of(Object).to receive(:start_run).with(default_configuration,
                                                                  expected_input)
       action_run({"configuration" => default_configuration, "input" => default_input}.to_json)
+    end
+
+    it "passes --job-id flag if a job id is set" do
+      input = default_input.merge('job' => 'foobar')
+      expected_input = {"flags" => ["--onetime", "--no-daemonize", "--verbose", "--job-id", "foobar"],
+                        "job" => "foobar"}
+      allow(File).to receive(:exist?).and_return(true)
+      allow_any_instance_of(Object).to receive(:running?).and_return(false)
+      allow_any_instance_of(Object).to receive(:disabled?).and_return(false)
+      expect_any_instance_of(Object).to receive(:start_run).with(default_configuration,
+                                                                 expected_input)
+      action_run({"configuration" => default_configuration, "input" => input}.to_json)
     end
 
     it "does not allow changing settings of default flags" do

--- a/modules/spec/unit/modules/puppet_spec.rb
+++ b/modules/spec/unit/modules/puppet_spec.rb
@@ -10,10 +10,8 @@ describe Pxp::ModulePuppet do
     {"flags" => []}
   }
 
-  let(:default_flags) { described_class.process_flags(default_input) }
-
   let(:subject) {
-    described_class.new(default_configuration, default_flags)
+    described_class.new(default_configuration, described_class.process_flags(default_input))
   }
 
   let(:default_configuration) {
@@ -91,18 +89,16 @@ describe Pxp::ModulePuppet do
     end
   end
 
-  describe "make_command_array" do
+  describe "puppet_agent_command" do
     it "should correctly append the executable and action" do
-      expect(subject.make_command_array(default_configuration, default_input['flags'])).to be ==
-        ["puppet", "agent"]
+      runner = described_class.new(default_configuration, [])
+      expect(runner.puppet_agent_command).to be == ["puppet", "agent"]
     end
 
     it "should correctly append any flags" do
-      input = default_input
-      input["flags"] = ["--noop", "--verbose"]
-      subject = described_class.new(default_configuration, input)
-      expect(subject.make_command_array(default_configuration, input['flags'])).to be ==
-        ["puppet", "agent", "--noop", "--verbose"]
+      default_input["flags"] = ["--noop", "--verbose"]
+      expect(subject.puppet_agent_command).to be ==
+        ["puppet", "agent", "--noop", "--verbose", "--onetime", "--no-daemonize"]
     end
   end
 

--- a/modules/spec/unit/modules/puppet_spec.rb
+++ b/modules/spec/unit/modules/puppet_spec.rb
@@ -159,13 +159,13 @@ describe Pxp::ModulePuppet do
     it "doesn't process the last_run_report if it hasn't been updated after the run was kicked" do
       start_time = Time.now
       run_time = Time.now - 10
-      last_run_report = double(:last_run_report)
-
-      allow(last_run_report).to receive(:[]).with('kind').and_return("apply")
-      allow(last_run_report).to receive(:[]).with('time').and_return(run_time)
-      allow(last_run_report).to receive(:[]).with('transaction_uuid').and_return("ac59acbe-6a0f-49c9-8ece-f781a689fda9")
-      allow(last_run_report).to receive(:[]).with('environment').and_return("production")
-      allow(last_run_report).to receive(:[]).with('status').and_return("changed")
+      last_run_report = {
+        'kind' => "apply",
+        'time' => run_time,
+        'transaction_uuid' => "ac59acbe-6a0f-49c9-8ece-f781a689fda9",
+        'environment' => "production",
+        'status' => "changed"
+      }
 
       allow(File).to receive(:mtime).and_return(start_time)
       allow(File).to receive(:exist?).and_return(true)
@@ -187,14 +187,14 @@ describe Pxp::ModulePuppet do
     it "processes the last_run_report if it has been updated after the run was kicked" do
       start_time = Time.now
       run_time = Time.now + 10
-      last_run_report = double(:last_run_report)
-
-      allow(last_run_report).to receive(:[]).with('kind').and_return("apply")
-      allow(last_run_report).to receive(:[]).with('time').and_return(run_time)
-      allow(last_run_report).to receive(:[]).with('transaction_uuid').and_return("ac59acbe-6a0f-49c9-8ece-f781a689fda9")
-      allow(last_run_report).to receive(:[]).with('environment').and_return("production")
-      allow(last_run_report).to receive(:[]).with('status').and_return("changed")
-      allow(last_run_report).to receive(:[]).with('metrics').and_return({})
+      last_run_report = {
+        'kind' => "apply",
+        'time' => run_time,
+        'transaction_uuid' => "ac59acbe-6a0f-49c9-8ece-f781a689fda9",
+        'environment' => "production",
+        'status' => "changed",
+        'metrics' => {},
+      }
 
       allow(File).to receive(:mtime).and_return(start_time+1)
       allow(File).to receive(:exist?).and_return(true)


### PR DESCRIPTION
In order to track the execution of a job all the way through the agent to
PuppetDB, we now have a --job-id flag that can be passed to `puppet agent`.
That flag will cause the provided job id to be added to the report that
gets stored in PuppetDB, making it easy to determine whether a report was
associated with a job.

We now optionally accept a "job-id" input to pxp-module-puppet and will
pass that along to the agent. This is provided as a top-level input rather
than a flag for backward compatibility (so old agents will ignore the
option rather than fail), and because it properly represents metadata about
the run rather than being an ordinary flag.

This PR also includes a substantial refactor of pxp-module-puppet and its
tests, turning the code into a class rather than leaving everything in the
`main` class. This improves testability by dramatically reducing the amount of
stubbing needed. It also helps separate the steps of parsing/transforming the
input from actually performing the action.