### PR TITLE
(PCP-699) Avoid undefined variables when running puppet

### DIFF
--- a/modules/pxp-module-puppet
+++ b/modules/pxp-module-puppet
@@ -493,7 +493,7 @@ module Pxp
 
         flags = process_flags(action_input)
 
-        new(config, action_input)
+        new(config, flags)
       rescue ProcessingError => e
         return make_error_result(DEFAULT_EXITCODE, e.error_type, e.message)
       end

--- a/modules/pxp-module-puppet
+++ b/modules/pxp-module-puppet
@@ -35,7 +35,7 @@ module Pxp
       else
         result = create_runner($stdin.read.chomp)
         if result.is_a?(self)
-          action_results = result.run(config, action_input)
+          action_results = result.run
         else
           action_results = result
         end

--- a/modules/spec/unit/modules/puppet_spec.rb
+++ b/modules/spec/unit/modules/puppet_spec.rb
@@ -31,6 +31,33 @@ describe Pxp::ModulePuppet do
     end
   end
 
+  describe "handle_action" do
+    describe "when the action is 'metadata'" do
+      it "prints the metadata" do
+        described_class.handle_action('metadata')
+      end
+    end
+
+    describe "for other actions" do
+      it "builds and runs the action" do
+        original_stdin = $stdin
+        original_stdout = $stdout
+        allow_any_instance_of(described_class).to receive(:run).and_return({})
+        begin
+          $stdin = StringIO.new({"config" => {}, "input" => {}}.to_json)
+          $stdout = StringIO.new
+          described_class.handle_action('run')
+          $stdout.rewind
+          result = JSON.parse($stdout.read)
+          expect(result).to be == {}
+        ensure
+          $stdin = original_stdin
+          $stdout = original_stdout
+        end
+      end
+    end
+  end
+
   describe "config_print" do
     it "returns the result of configprint" do
       cli_vec = ["puppet", "agent", "--configprint", "value"]

--- a/modules/spec/unit/modules/puppet_spec.rb
+++ b/modules/spec/unit/modules/puppet_spec.rb
@@ -526,6 +526,12 @@ describe Pxp::ModulePuppet do
           "The json received on STDIN contained characters not present in valid flags: \\t--prerun_command"
     end
 
+    it "builds a runner with the provided config and flags" do
+      runner = described_class.create_runner({:configuration => default_configuration, :input => default_input}.to_json)
+
+      expect(runner.config).to be == {'puppet_bin' => 'puppet'}
+      expect(runner.flags).to be == ['--onetime', '--no-daemonize', '--verbose']
+    end
   end
 
   describe "process_flags" do


### PR DESCRIPTION
Because of the circuitous route to which the final version of this code was
arrived, as well as unit test coverage lacking at the outer levels, there are a
couple of places where arguments aren't properly set/used on the ModulePuppet
instance. This PR fixes those and improves the test coverage to exercise as
much of the module as possible.