### PR TITLE
(PCP-750) Add inventory retries to flaky tests

### DIFF
--- a/acceptance/tests/invalid_ssl_config.rb
+++ b/acceptance/tests/invalid_ssl_config.rb
@@ -36,7 +36,8 @@ agents.each do |agent|
     create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
     on agent, puppet('resource service pxp-agent ensure=running')
 
-    assert(is_associated?(master, "pcp://#{agent}/agent"),
+    inventory_retries = 60
+    assert(is_associated?(master, "pcp://#{agent}/agent", inventory_retries),
            "Agent #{agent} with PCP identity pcp://#{agent}/agent should be associated with pcp-broker")
   end
 

--- a/acceptance/tests/pxp_agent_associate.rb
+++ b/acceptance/tests/pxp_agent_associate.rb
@@ -21,7 +21,8 @@ agents.each do |agent|
   end
 
   step 'Assert that agent is listed in pcp-broker inventory' do
-    assert(is_associated?(master, "pcp://#{agent}/agent"),
+    inventory_retries = 60
+    assert(is_associated?(master, "pcp://#{agent}/agent", inventory_retries),
            "Agent identity pcp://#{agent}/agent for agent host #{agent} does not appear in pcp-broker's client inventory")
   end
 end


### PR DESCRIPTION
This commit adds inventory retries to tests that have been intermittently
failing to get responses to inventory requests.

These test failures have not been consistent between runs or platforms. They
appear to be sensitive to starting or restarting the service.