### PR TITLE
(packaging) Do not use versioned executable

### DIFF
--- a/exe/CMakeLists.txt
+++ b/exe/CMakeLists.txt
@@ -12,7 +12,6 @@ include_directories(
 )
 
 add_executable(pxp-agent ${PXP-AGENT_SOURCES})
-set_target_properties(pxp-agent PROPERTIES VERSION ${PROJECT_VERSION})
 target_link_libraries(pxp-agent ${CPP_PCP_CLIENT_LIB} libpxp-agent)
 
 install(TARGETS pxp-agent DESTINATION bin)


### PR DESCRIPTION
Versioning the executable files clutters the filesystem and,
more importantly, totally breaks service management on SLES.
Since we don't have any use for symlinks to versioned binaries,
we should just get rid of them.