### PR TITLE
(PCP-755) Support restarting service when the binary path changes

### DIFF
--- a/ext/suse/pxp-agent.init
+++ b/ext/suse/pxp-agent.init
@@ -85,8 +85,24 @@ case "$1" in
         ## Stop daemon with killproc(8) and if this fails
         ## set echo the echo return value.
 
-        killproc -QUIT -p "${pidfile}" "${exec}" && rm -f "${lockfile}" "${pidfile}"
+        ## This accounts for the behavior of killproc on sles 11:
+        ## if the binary we're attempting to halt is a symlink to
+        ## a versioned binary, then it won't be halted if that
+        ## symlink is changed to point to a different file name.
+        ## Check to see if a running process matches the contents
+        ## of the pidfile, and if so kill it. This could fail if
+        ## multiple pxp-agent processes are running, in which case
+        ## killproc may succeed or manual intervention is required.
+        if [ -f "${pidfile}" ]; then
+            PID=$(cat "$pidfile")
+            if [ "$PID" -eq $(pgrep -f "$exec") ] ; then
+                kill -QUIT "${PID}" && rm -f "${lockfile}" "${pidfile}"
+                rc_status -v
+                rc_exit
+            fi
+        fi
 
+        killproc -QUIT -p "${pidfile}" "${exec}" && rm -f "${lockfile}" "${pidfile}"
         # Remember status and be verbose
         rc_status -v
         ;;
@@ -138,6 +154,24 @@ case "$1" in
         # 3 - service not running
 
         # NOTE: checkproc returns LSB compliant status values.
+
+        ## This accounts for the behavior of checkproc on sles 11:
+        ## if the binary we're attempting to check is a symlink to
+        ## a versioned binary, then it won't be halted if that
+        ## symlink is changed to point to a different file name.
+        ## Check to see if a running process matches the contents
+        ## of the pidfile, and if so return running. This could fail
+        ## if multiple pxp-agent processes are running, in which case
+        ## checkproc may succeed or manual intervention is required.
+        if [ -f "${pidfile}" ]; then
+            PID=$(cat "$pidfile")
+            if [ "$PID" -eq $(pgrep -f "$exec") ] ; then
+                rc_reset
+                rc_status -v
+                rc_exit
+            fi
+        fi
+
         if [ -f "${pidfile}" ]; then
             checkproc -p "${pidfile}" "${exec}"
             rc_status -v


### PR DESCRIPTION
From pxp-agent 1.5.3 to 1.6.0, pxp-agent used a versioned binary with
pxp-agent symlinked to it. When upgrading, the binary used to start the
pxp-agent service would change. On SUSE, this prevented restarting the
service after upgrade because checkproc would not detect the existing
process (needed by condrestart) and killproc would not kill the process
started with the previous binary. Use pgrep/kill instead - with
appropriate guards to check it was the expected service process - to
ensure we can restart the service after upgrading from one of those
versions.

[skip ci]