### PR TITLE
(maint) Log version and level at startup

### DIFF
--- a/exe/main.cc
+++ b/exe/main.cc
@@ -3,6 +3,8 @@
 
 #include <pxp-agent/util/daemonize.hpp>
 
+#include "version-inl.hpp"
+
 #include <cpp-pcp-client/util/thread.hpp>
 #include <cpp-pcp-client/util/chrono.hpp>
 
@@ -182,8 +184,8 @@ int main(int argc, char *argv[]) {
     // Set up logging
 
     try {
-        Configuration::Instance().setupLogging();
-        LOG_DEBUG("pxp-agent logging has been initialized");
+        auto loglevel = Configuration::Instance().setupLogging();
+        LOG_INFO("pxp-agent {1} started at {2} level", PXP_AGENT_VERSION, loglevel);
     } catch (const Configuration::Error& e) {
         boost::nowide::cout << lth_loc::format("Failed to configure logging: {1}\n"
                                                "Cannot start pxp-agent", e.what());

--- a/lib/inc/pxp-agent/configuration.hpp
+++ b/lib/inc/pxp-agent/configuration.hpp
@@ -164,7 +164,8 @@ class Configuration
     /// Throw a Configuration::Error: in case of invalid the specified
     /// log file is in a non-esixtent directory.
     /// Other execeptions are propagated.
-    void setupLogging();
+    /// Returns the log level.
+    std::string setupLogging();
 
     /// Ensure all required values are valid. If necessary, expand
     /// file paths to the expected format.

--- a/lib/src/configuration.cc
+++ b/lib/src/configuration.cc
@@ -189,7 +189,7 @@ static void validateLogDirPath(const std::string& logfile)
     }
 }
 
-void Configuration::setupLogging()
+std::string Configuration::setupLogging()
 {
     logfile_ = HW::GetFlag<std::string>("logfile");
     pcp_access_logfile_ = HW::GetFlag<std::string>("pcp-access-logfile");
@@ -268,14 +268,14 @@ void Configuration::setupLogging()
                                   loglevel,
                                   pcp_access_fstream_ptr_);
 
-    LOG_DEBUG("Logging configured");
-
     if (!log_on_stdout) {
         // Configure platform-specific things for file logging
         // NB: we do that after setting up lth_log in order to log in
         //     case of failure
         configure_platform_file_logging();
     }
+
+    return loglevel;
 }
 
 void Configuration::validate()

--- a/locales/pxp-agent.pot
+++ b/locales/pxp-agent.pot
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: pxp-agent 1.5.3\n"
+"Project-Id-Version: pxp-agent 1.6.0\n"
 "Report-Msgid-Bugs-To: docs@puppet.com\n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
@@ -69,9 +69,9 @@ msgid ""
 "Cannot start pxp-agent"
 msgstr ""
 
-#. debug
+#. info
 #: exe/main.cc
-msgid "pxp-agent logging has been initialized"
+msgid "pxp-agent {1} started at {2} level"
 msgstr ""
 
 #: exe/main.cc
@@ -170,11 +170,6 @@ msgstr ""
 
 #: lib/src/configuration.cc
 msgid "invalid log level: '{1}'"
-msgstr ""
-
-#. debug
-#: lib/src/configuration.cc
-msgid "Logging configured"
 msgstr ""
 
 #. info


### PR DESCRIPTION
Logs pxp-agent version and configured log level as soon as logging is
configured. Clarifies when versions change in logging, which makes
debugging issues easier.