### PR TITLE
(PCP-697) Ensure default log location exists on startup

### DIFF
--- a/ext/debian/pxp-agent.init
+++ b/ext/debian/pxp-agent.init
@@ -14,6 +14,7 @@ desc="PXP agent"
 
 piddir=/var/run/puppetlabs
 pidfile="${piddir}/${prog}.pid"
+logdir=/var/log/puppetlabs
 
 [ -x $exec ] || exit 5
 
@@ -26,7 +27,7 @@ reload_pxp_agent() {
 }
 
 start_pxp_agent() {
-    mkdir -p $piddir
+    mkdir -p $piddir $logdir
     start-stop-daemon --start --quiet --pidfile $pidfile --startas $exec -- $PXP_AGENT_OPTIONS
 }
 

--- a/ext/redhat/pxp-agent.init
+++ b/ext/redhat/pxp-agent.init
@@ -20,6 +20,7 @@ desc="PXP agent"
 lockfile=/var/lock/subsys/$prog
 piddir=/var/run/puppetlabs
 pidfile="${piddir}/${prog}.pid"
+logdir=/var/log/puppetlabs
 pid=$(cat $pidfile 2> /dev/null)
 RETVAL=0
 
@@ -35,7 +36,7 @@ fi
 
 start() {
     echo -n $"Starting PXP agent: "
-    mkdir -p $piddir
+    mkdir -p $piddir $logdir
     daemon $daemonopts $exec ${PXP_AGENT_OPTIONS}
     RETVAL=$?
     echo

--- a/ext/suse/pxp-agent.init
+++ b/ext/suse/pxp-agent.init
@@ -38,6 +38,7 @@ desc="PXP agent"
 lockfile=/var/lock/subsys/pxp-agent
 piddir=/var/run/puppetlabs
 pidfile="${piddir}/${prog}.pid"
+logdir=/var/run/puppetlabs
 
 [ -x $exec ] || exit 5
 
@@ -75,7 +76,7 @@ case "$1" in
                 rc_exit
             fi
         fi
-        mkdir -p $piddir
+        mkdir -p $piddir $logdir
         startproc -f -w -p "${pidfile}" "${exec}" ${PXP_AGENT_OPTIONS} && touch "${lockfile}"
         # Remember status and be verbose
         rc_status -v


### PR DESCRIPTION
The init scripts used to run pxp-agent as a service currently ensure the
rundir exists before starting. Update them to also ensure the logdir
location exists, in case it's volatile.