### PR TITLE
(PCP-759) Enable EC2 master install

### DIFF
--- a/acceptance/setup/aio/010_Install.rb
+++ b/acceptance/setup/aio/010_Install.rb
@@ -18,30 +18,33 @@ step "Install puppet-agent..." do
   end
 end
 
-MASTER_PACKAGES = {
-  :redhat => [
-    'puppetserver',
-  ],
-  :debian => [
-    'puppetserver',
-  ],
-}
-
 step "Install puppetserver..." do
-  if ENV['SERVER_VERSION']
-    install_puppetlabs_dev_repo(master, 'puppetserver', ENV['SERVER_VERSION'])
-    install_puppetlabs_dev_repo(master, 'puppet-agent', ENV['SHA'])
-    master.install_package('puppetserver')
+  if master[:hypervisor] == 'ec2' && master[:platform].match(/(?:el|centos|oracle|redhat|scientific)/)
+    variant, version = master['platform'].to_array
+    server_num = ENV['SERVER_VERSION'].to_i
+    # nil or 'latest' will convert to 0
+    if server_num > 0 && server_num < 5
+      logger.info "EC2 master found: Installing public PC1 repo to satisfy puppetserver dependency."
+      on(master, "rpm -Uvh https://yum.puppetlabs.com/puppetlabs-release-pc1-el-#{version}.noarch.rpm")
+    else
+      logger.info "EC2 master found: Installing public puppet5 repo to satisfy puppetserver dependency."
+      on(master, "rpm -Uvh https://yum.puppetlabs.com/puppet5-release-el-#{version}.noarch.rpm")
+    end
   else
-    # beaker can't install puppetserver from nightlies (BKR-673)
-    repo_configs_dir = 'repo-configs'
-    install_repos_on(master, 'puppetserver', 'nightly', repo_configs_dir)
-    install_repos_on(master, 'puppet-agent', ENV['SHA'], repo_configs_dir)
-    install_packages_on(master, MASTER_PACKAGES)
+    if ENV['SERVER_VERSION']
+      install_puppetlabs_dev_repo(master, 'puppetserver', ENV['SERVER_VERSION'])
+      install_puppetlabs_dev_repo(master, 'puppet-agent', ENV['SHA'])
+    else
+      # beaker can't install puppetserver from nightlies (BKR-673)
+      repo_configs_dir = 'repo-configs'
+      install_repos_on(master, 'puppetserver', 'nightly', repo_configs_dir)
+      install_repos_on(master, 'puppet-agent', ENV['SHA'], repo_configs_dir)
+    end
   end
+  master.install_package('puppetserver')
 end
 
-step 'Make sure install is sane' do 
+step 'Make sure install is sane' do
   # beaker has already added puppet and ruby to PATH in ~/.ssh/environment
   agents.each do |agent|
     on agent, puppet('--version')

--- a/acceptance/setup/common/050_Setup_Broker.rb
+++ b/acceptance/setup/common/050_Setup_Broker.rb
@@ -60,7 +60,7 @@ step 'Run lein deps to download dependencies' do
   # 'lein tk' will download dependencies automatically, but downloading them will take
   # some time and will eat into the polling period we allow for the broker to start
   for i in 0..NUM_BROKERS-1
-    on master, "cd #{GIT_CLONE_FOLDER}/pcp-broker#{i}; export LEIN_ROOT=ok; lein with-profile internal-mirrors deps"
+    on master, "cd #{GIT_CLONE_FOLDER}/pcp-broker#{i}; export LEIN_ROOT=ok; lein with-profile #{LEIN_PROFILE} deps"
   end
 end
 


### PR DESCRIPTION
This commit updates the acceptance install pre-suite to allow installing
an ec2 master dynamically on a el based system without intervention.
Due to the expectations of the nightly puppetserver repo, the nightly
puppet-agent is installed first and then over-written with the
puppet-agent version under test. The specification of a SERVER_VERSION
is also supported.

A `LEIN_PROFILE` constant has been added to switch between profiles
based on whether the SUT has access to the `puppetlabs.net` network
or not to enable the installation of pcp-broker on the master.