### PR TITLE
(PCP-750) Ensure failed connection attempts are closed

### DIFF
--- a/acceptance/lib/pxp-agent/test_helper.rb
+++ b/acceptance/lib/pxp-agent/test_helper.rb
@@ -372,9 +372,12 @@ def connect_pcp_client(broker)
     })
     connected = client.connect(5)
     retries += 1
+
+    # If the connection was not established, close it. Otherwise we can end up with 2 successful connections
+    # and get an earlier attempt superseding later connections.
+    client.close if !connected
   end
   if !connected
-    client.close
     raise "Controller PCP client failed to connect with pcp-broker on #{broker} after #{max_retries} attempts: #{client.inspect}"
   end
   if !client.associated?


### PR DESCRIPTION
Ensure failed attemption connects are closed. If not done, we can end up
with multiple connections, and an earlier attempt can supersede a later
one. When that happens, the connection being used for testing will fail
to receive expected responses.

[skip ci]