### PR TITLE
(PCP-758) Support file exts on non-Windows, powershell/ruby on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,8 +26,8 @@ install:
   - git checkout master
 
     # Minimize environment polution; previously we were linking against the wrong OpenSSL DLLs.
-    # Include Ruby for unit tests.
-  - SET PATH=C:\tools\bin;C:\tools\openssl\bin;C:\tools\mingw64\bin;C:\ProgramData\chocolatey\bin;C:\Ruby22-x64\bin;C:\Windows\system32;C:\Windows
+    # Include Ruby and Powershell for unit tests.
+  - SET PATH=C:\tools\bin;C:\tools\openssl\bin;C:\tools\mingw64\bin;C:\ProgramData\chocolatey\bin;C:\Ruby22-x64\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\WindowsPowerShell\v1.0
 
   - ps: cmake -G "MinGW Makefiles" -DBOOST_ROOT="C:\tools\boost_1_58_0-x86_64_mingw-w64_4.8.3_win32_seh" -DBOOST_STATIC=ON -DCURL_STATIC=ON -DCMAKE_PREFIX_PATH="C:\tools\leatherman;C:\tools\curl-7.42.1-x86_64_mingw-w64_4.8.3_win32_seh" -Wno-dev -DCMAKE_INSTALL_PREFIX=C:\tools .
   - ps: mingw32-make install

--- a/exe/task.cc
+++ b/exe/task.cc
@@ -9,10 +9,12 @@
 
 #include <boost/nowide/iostream.hpp>
 #include <boost/filesystem.hpp>
+#include <boost/algorithm/string/join.hpp>
 
 #include <rapidjson/rapidjson.h>
 
 #include <vector>
+#include <set>
 #include <string>
 
 using namespace std;
@@ -52,6 +54,58 @@ static string system_prefix()
 #define SYSTEM_PREFIX test_prefix
 string test_prefix();
 #endif
+
+struct task_error : runtime_error
+{
+    task_error(string t, string msg) : runtime_error(move(msg)), type(move(t)) {}
+    string type;
+};
+
+static string find_task(string taskname)
+{
+    string module, task = "init";
+    if (!lth_util::re_search(taskname, boost::regex("\\A(\\w+)\\z"), &module) &&
+        !lth_util::re_search(taskname, boost::regex("\\A(\\w+)::(\\w+)\\z"), &module, &task)) {
+        throw task_error("invalid-task", _("Invalid task name '{1}'", taskname));
+    }
+
+    auto filepath = SYSTEM_PREFIX()+"/pxp-agent/tasks/"+module+"/tasks";
+
+    // Search for any executable file starting with the task name and not matching a set of reserved extensions
+    auto reserved_extensions = set<string>{".json", ".md"};
+    vector<string> filenames;
+
+    try {
+        fs::directory_iterator end;
+        for (auto f = fs::directory_iterator(filepath); f != end; ++f) {
+            if (!fs::is_directory(f->status())) {
+                auto extension = f->path().extension();
+                if (reserved_extensions.find(extension.string()) != reserved_extensions.end()) {
+                    continue;
+                }
+
+                filenames.emplace_back(f->path().string());
+            }
+        }
+    } catch (fs::filesystem_error &e) {
+        // Fall through to filenames.empty
+    }
+
+    if (filenames.empty()) {
+        throw task_error("not-found", _("Could not find task '{1}' at {2}", taskname, filepath));
+    }
+    if (filenames.size() > 1) {
+        throw task_error("multiple-files", _("Found multiple matching files for task '{1}': {2}", taskname,
+                                             boost::algorithm::join(filenames, ", ")));
+    }
+
+    auto filename = filenames.front();
+    if (lth_exec::which(filename).empty()) {
+        throw task_error("not-executable", _("Task file '{1}' is not executable", filename));
+    }
+
+    return filename;
+}
 
 static void set_error(lth_jc::JsonContainer &result, string kind, string msg)
 {
@@ -142,41 +196,32 @@ int MAIN_IMPL(int argc, char** argv)
     lth_jc::JsonContainer stdout_result;
     string stderr_str;
 
-    string module, task = "init";
-    if (!lth_util::re_search(taskname, boost::regex("\\A(\\w+)\\z"), &module) &&
-        !lth_util::re_search(taskname, boost::regex("\\A(\\w+)::(\\w+)\\z"), &module, &task)) {
-        set_error(stdout_result, "invalid-task", _("Invalid task name '{1}'", taskname));
-    } else {
-        try {
-            auto filepath = SYSTEM_PREFIX()+"/pxp-agent/tasks/"+module+"/tasks";
+    try {
+        auto filename = find_task(taskname);
+        auto environment = generate_environment_from(input);
 
-            auto filename = lth_exec::which(task, vector<string>{filepath});
-            if (filename.empty()) {
-                set_error(stdout_result, "not-found", _("Task file '{1}' is not present or not executable", filepath+"/"+task));
-            } else {
-                auto environment = generate_environment_from(input);
-                auto exec = lth_exec::execute(
-                    filename,
-                    {},  // arguments
-                    input.toString(),
-                    environment,
-                    0,  // timeout
-                    { lth_exec::execution_options::thread_safe,
-                      lth_exec::execution_options::merge_environment,
-                      lth_exec::execution_options::inherit_locale });
+        auto exec = lth_exec::execute(
+            filename,
+            {},  // arguments
+            input.toString(),
+            environment,
+            0,  // timeout
+            { lth_exec::execution_options::thread_safe,
+              lth_exec::execution_options::merge_environment,
+              lth_exec::execution_options::inherit_locale });
 
-                if (!isValidUTF8(exec.output)) {
-                    set_error(stdout_result, "output-encoding-error", _("Output cannot be represented as a JSON string"));
-                } else {
-                    stdout_result.set("output", exec.output);
-                }
-
-                stderr_str = exec.error;
-                exitcode = exec.exit_code;
-            }
-        } catch (runtime_error &e) {
-            set_error(stdout_result, "exec-failed", _("Task '{1}' failed to run: {2}", taskname, e.what()));
+        if (!isValidUTF8(exec.output)) {
+            set_error(stdout_result, "output-encoding-error", _("Output is not valid UTF-8"));
+        } else {
+            stdout_result.set("output", exec.output);
         }
+
+        stderr_str = exec.error;
+        exitcode = exec.exit_code;
+    } catch (task_error &e) {
+        set_error(stdout_result, e.type, e.what());
+    } catch (runtime_error &e) {
+        set_error(stdout_result, "exec-failed", _("Task '{1}' failed to run: {2}", taskname, e.what()));
     }
 
     lth_file::atomic_write_to_file(stdout_result.toString(), stdout_file);

--- a/exe/task.hpp
+++ b/exe/task.hpp
@@ -1,0 +1,45 @@
+#pragma once
+#include <vector>
+#include <map>
+#include <set>
+#include <string>
+#include <functional>
+#include <stdexcept>
+
+struct task_error : std::runtime_error
+{
+    task_error(std::string t, std::string msg) :
+        std::runtime_error(std::move(msg)), type(std::move(t)) {}
+    std::string type;
+};
+
+struct task
+{
+    std::string name;
+    std::vector<std::string> args;
+};
+
+struct task_runner
+{
+    task find_task(std::string taskname);
+
+private:
+    std::set<std::string> reserved_extensions_{".json", ".md"};
+    // Hard-code extensions as executable on Windows. On non-Windows, we still rely on permissions and #!
+    std::map<std::string, std::function<task(std::string)>> builtin_task_wrappers_{
+#ifdef _WIN32
+        {".rb",  [](std::string filename) { return task{"ruby", std::vector<std::string>{filename}}; }},
+        {".pp",  [](std::string filename) { return task{"puppet", std::vector<std::string>{"apply", filename}}; }},
+        {".ps1", [](std::string filename) { return task{"powershell",
+                                                           std::vector<std::string>{
+                                                               "-NoProfile",
+                                                               "-NonInteractive",
+                                                               "-NoLogo",
+                                                               "-ExecutionPolicy",
+                                                               "Bypass",
+                                                               "-File",
+                                                               filename
+                                                           }}; }}
+#endif
+    };
+};

--- a/exe/tests/fixtures.hpp
+++ b/exe/tests/fixtures.hpp
@@ -119,9 +119,7 @@ struct temp_task {
 
     void make_powershell(vector<string> keys, string task = "init") {
         ofstream foo(module_path+"/"+task);
-#ifndef _WIN32
         foo << "#!/usr/bin/env powershell" << endl;
-#endif
         foo << "foreach ($i in $input) { Write-Output $i }" << endl;
         for (auto& k : keys) {
             foo << "Write-Output $env:PT_" << k << endl;
@@ -130,9 +128,7 @@ struct temp_task {
 
     void make_ruby(vector<string> keys, string task = "init") {
         ofstream foo(module_path+"/"+task);
-#ifndef _WIN32
         foo << "#!/usr/bin/env ruby" << endl;
-#endif
         foo << "puts STDIN.gets" << endl;
         for (auto& k : keys) {
             foo << "puts ENV['PT_" << k << "']" << endl;

--- a/exe/tests/fixtures.hpp
+++ b/exe/tests/fixtures.hpp
@@ -106,7 +106,7 @@ struct temp_task {
     }
 
     void make_error(string task = "init") {
-        ofstream foo(module_path+"/"+task, ios_base::binary);
+        ofstream foo(module_path+"/"+task);
 #ifdef _WIN32
         foo << "@echo off" << endl;
 #else
@@ -117,19 +117,39 @@ struct temp_task {
         foo << "exit 1" << endl;
     }
 
-    void make_executable(string task = "init") {
+    void make_powershell(vector<string> keys, string task = "init") {
+        ofstream foo(module_path+"/"+task);
+#ifndef _WIN32
+        foo << "#!/usr/bin/env powershell" << endl;
+#endif
+        foo << "foreach ($i in $input) { Write-Output $i }" << endl;
+        for (auto& k : keys) {
+            foo << "Write-Output $env:PT_" << k << endl;
+        }
+    }
+
+    void make_ruby(vector<string> keys, string task = "init") {
+        ofstream foo(module_path+"/"+task);
+#ifndef _WIN32
+        foo << "#!/usr/bin/env ruby" << endl;
+#endif
+        foo << "puts STDIN.gets" << endl;
+        for (auto& k : keys) {
+            foo << "puts ENV['PT_" << k << "']" << endl;
+        }
+    }
+
+    void make_executable(string task = "init", string ext = "") {
 #ifdef _WIN32
-        fs::rename(module_path+"/"+task, module_path+"/"+task+".bat");
+        if (ext.empty()) {
+            ext = ".bat";
+        }
 #else
         fs::permissions(module_path+"/"+task, fs::owner_read|fs::owner_write|fs::owner_exe);
 #endif
-    }
-
-    void make_exec_extension(string task = "init") {
-#ifndef _WIN32
-        fs::permissions(module_path+"/"+task, fs::owner_read|fs::owner_write|fs::owner_exe);
-#endif
-        fs::rename(module_path+"/"+task, module_path+"/"+task+".bat");
+        if (!ext.empty()) {
+            fs::rename(module_path+"/"+task, module_path+"/"+task+ext);
+        }
     }
 
 private:

--- a/exe/tests/fixtures.hpp
+++ b/exe/tests/fixtures.hpp
@@ -148,7 +148,6 @@ struct temp_task {
         }
     }
 
-private:
     string module_path;
 };
 
@@ -173,11 +172,4 @@ static string output_files(string const& dir)
 static string basic_task(string task, string const& dir)
 {
     return "{\"input\": {\"task\": \""+task+"\", \"input\": {}}, "+output_files(dir)+"}";
-}
-
-static bool validate_failure(string const& dir)
-{
-    auto err = read(dir+"/err");
-    auto exi = read(dir+"/exit");
-    return err.empty() && exi == lines{"255"};
 }

--- a/exe/tests/fixtures.hpp
+++ b/exe/tests/fixtures.hpp
@@ -125,6 +125,13 @@ struct temp_task {
 #endif
     }
 
+    void make_exec_extension(string task = "init") {
+#ifndef _WIN32
+        fs::permissions(module_path+"/"+task, fs::owner_read|fs::owner_write|fs::owner_exe);
+#endif
+        fs::rename(module_path+"/"+task, module_path+"/"+task+".bat");
+    }
+
 private:
     string module_path;
 };

--- a/exe/tests/main.cc
+++ b/exe/tests/main.cc
@@ -232,6 +232,19 @@ TEST_CASE("returns an error if the task can't be run") {
                 +test_prefix()+R"(/pxp-agent/tasks/foo/tasks"}})"});
             REQUIRE(validate_failure(dir));
         }
+
+        SECTION("other task exists") {
+            temp_task bar("foo");
+            bar.make_echo("bar");
+
+            stream_fixture fix(basic_task("foo", dir));
+            MAIN_IMPL(args.size(), args.data());
+
+            auto output = read(dir+"/out");
+            REQUIRE(output == lines{R"({"_error":{"kind":"puppetlabs.tasks/not-found","msg":"Could not find task 'foo' at )"
+                +test_prefix()+R"(/pxp-agent/tasks/foo/tasks"}})"});
+            REQUIRE(validate_failure(dir));
+        }
     }
 
     SECTION("task not executable") {

--- a/locales/pxp-agent.pot
+++ b/locales/pxp-agent.pot
@@ -100,11 +100,19 @@ msgid "Invalid task name '{1}'"
 msgstr ""
 
 #: exe/task.cc
-msgid "Task file '{1}' is not present or not executable"
+msgid "Could not find task '{1}' at {2}"
 msgstr ""
 
 #: exe/task.cc
-msgid "Output cannot be represented as a JSON string"
+msgid "Found multiple matching files for task '{1}': {2}"
+msgstr ""
+
+#: exe/task.cc
+msgid "Task file '{1}' is not executable"
+msgstr ""
+
+#: exe/task.cc
+msgid "Output is not valid UTF-8"
 msgstr ""
 
 #: exe/task.cc


### PR DESCRIPTION
Accepts file extensions on non-Windows platforms, except the reserved extensions `.json` or `.md`. That allows writing cross-platform tasks in scripting languages.

Adds support for cross-platform scripts via powershell and ruby.