### PR TITLE
(PCP-758) Add tests for shell, powershell, ruby, and puppet tasks

### DIFF
--- a/acceptance/lib/pxp-agent/task_helper.rb
+++ b/acceptance/lib/pxp-agent/task_helper.rb
@@ -1,0 +1,46 @@
+require 'pxp-agent/test_helper.rb'
+require 'json'
+
+# Runs a task on targets, and passes the output to the block for validation
+# Block should expect a map parsed from the JSON output
+def run_task(broker, targets, task, input = {}, max_retries = 30, query_interval = 1, &block)
+  target_identities = targets.map {|agent| "pcp://#{agent}/agent"}
+
+  provisional_responses =
+    begin
+      rpc_non_blocking_request(broker, target_identities,
+                               'task', 'run',
+                               {:task => task, :input => input})
+    rescue => exception
+      fail("Exception occurred when trying to run task '#{task}' on all agents: #{exception.message}")
+    end
+
+  transaction_ids = target_identities.map do |identity|
+    assert_equal("http://puppetlabs.com/rpc_provisional_response",
+                 provisional_responses[identity][:envelope][:message_type],
+                 "Did not receive expected rpc_provisional_response in reply to non-blocking request")
+    provisional_responses[identity][:data]["transaction_id"]
+  end
+
+  target_identities.zip(transaction_ids).map do |identity, transaction_id|
+    check_non_blocking_response(broker, identity, transaction_id, max_retries, query_interval, &block)
+  end
+end
+
+def create_task_on(agent, mod, task, body)
+  if agent['platform'] =~ /win/
+    tasks_path = 'C:/ProgramData/PuppetLabs/pxp-agent/tasks'
+  else
+    tasks_path = '/opt/puppetlabs/pxp-agent/tasks'
+  end
+
+  task_path = "#{tasks_path}/#{mod}/tasks"
+  on agent, "mkdir -p #{task_path}"
+
+  create_remote_file(agent, "#{task_path}/#{task}", body)
+  on agent, "chmod +x #{task_path}/#{task}"
+
+  teardown do
+    on agent, "rm -rf #{task_path}"
+  end
+end

--- a/acceptance/tests/tasks/run_echo.rb
+++ b/acceptance/tests/tasks/run_echo.rb
@@ -1,0 +1,35 @@
+require 'pxp-agent/task_helper.rb'
+
+test_name 'run echo task' do
+
+  step 'Ensure each agent host has pxp-agent running and associated' do
+    agents.each do |agent|
+      on agent, puppet('resource service pxp-agent ensure=stopped')
+      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
+      on agent, puppet('resource service pxp-agent ensure=running')
+
+      assert(is_associated?(master, "pcp://#{agent}/agent"),
+             "Agent #{agent} with PCP identity pcp://#{agent}/agent should be associated with pcp-broker")
+    end
+  end
+
+  step 'Create echo task on agent hosts' do
+    agents.each do |agent|
+      if agent['platform'] =~ /win/
+        task_name = 'init.bat'
+        task_body = '@echo %PT_message%'
+      else
+        task_name = 'init'
+        task_body = "#!/bin/sh\necho $PT_message"
+      end
+
+      create_task_on(agent, 'echo', task_name, task_body)
+    end
+  end
+
+  step 'Run echo task on agent hosts' do
+    run_task(master, agents, 'echo', {:message => 'hello'}) do |stdout|
+      assert_equal('hello', stdout['output'].chomp, "Output did not contain 'hello'")
+    end
+  end # test step
+end # test

--- a/acceptance/tests/tasks/run_ps1.rb
+++ b/acceptance/tests/tasks/run_ps1.rb
@@ -1,0 +1,37 @@
+require 'pxp-agent/task_helper.rb'
+
+test_name 'run powershell task' do
+
+  windows_hosts = hosts.select {|h| /windows/ =~ h[:platform]}
+  if windows_hosts.empty?
+    skip_test "No windows hosts to test powershell on"
+  end
+
+  step 'Ensure each agent host has pxp-agent running and associated' do
+    windows_hosts.each do |agent|
+      on agent, puppet('resource service pxp-agent ensure=stopped')
+      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
+      on agent, puppet('resource service pxp-agent ensure=running')
+
+      assert(is_associated?(master, "pcp://#{agent}/agent"),
+             "Agent #{agent} with PCP identity pcp://#{agent}/agent should be associated with pcp-broker")
+    end
+  end
+
+  step 'Create powershell task on agent hosts' do
+    windows_hosts.each do |agent|
+      create_task_on(agent, 'echo', 'init.ps1', <<-EOF)
+foreach ($i in $input) { Write-Output $i }
+Write-Output $env:PT_data
+EOF
+    end
+  end
+
+  step 'Run powershell task on Windows agent hosts' do
+    run_task(master, windows_hosts, 'echo', {:data => [1, 2, 3]}) do |stdout|
+      json, data = stdout['output'].delete("\r").split("\n")
+      assert_equal('{"data":[1,2,3]}', json, "Output did not contain 'data'")
+      assert_equal('[1,2,3]', data, "Output did not contain 'data'")
+    end
+  end # test step
+end # test

--- a/acceptance/tests/tasks/run_puppet.rb
+++ b/acceptance/tests/tasks/run_puppet.rb
@@ -1,0 +1,30 @@
+require 'pxp-agent/task_helper.rb'
+
+test_name 'run puppet task' do
+
+  step 'Ensure each agent host has pxp-agent running and associated' do
+    agents.each do |agent|
+      on agent, puppet('resource service pxp-agent ensure=stopped')
+      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
+      on agent, puppet('resource service pxp-agent ensure=running')
+
+      assert(is_associated?(master, "pcp://#{agent}/agent"),
+             "Agent #{agent} with PCP identity pcp://#{agent}/agent should be associated with pcp-broker")
+    end
+  end
+
+  step 'Create puppet task on agent hosts' do
+    agents.each do |agent|
+      create_task_on(agent, 'hello', 'init.pp', <<-EOF)
+#!/opt/puppetlabs/bin/puppet apply
+notify { 'hello': }
+EOF
+    end
+  end
+
+  step 'Run puppet task on agent hosts' do
+    run_task(master, agents, 'hello', {:data => [1, 2, 3]}) do |stdout|
+      assert_match(/Notify\[hello\]\/message: defined 'message' as 'hello'/, stdout['output'], "Output did not contain 'hello'")
+    end
+  end # test step
+end # test

--- a/acceptance/tests/tasks/run_ruby.rb
+++ b/acceptance/tests/tasks/run_ruby.rb
@@ -1,0 +1,33 @@
+require 'pxp-agent/task_helper.rb'
+
+test_name 'run ruby task' do
+
+  step 'Ensure each agent host has pxp-agent running and associated' do
+    agents.each do |agent|
+      on agent, puppet('resource service pxp-agent ensure=stopped')
+      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
+      on agent, puppet('resource service pxp-agent ensure=running')
+
+      assert(is_associated?(master, "pcp://#{agent}/agent"),
+             "Agent #{agent} with PCP identity pcp://#{agent}/agent should be associated with pcp-broker")
+    end
+  end
+
+  step 'Create ruby task on agent hosts' do
+    agents.each do |agent|
+      create_task_on(agent, 'echo', 'init.rb', <<-EOF)
+#!/usr/bin/env ruby
+puts STDIN.gets
+puts ENV['PT_data']
+EOF
+    end
+  end
+
+  step 'Run ruby task on agent hosts' do
+    run_task(master, agents, 'echo', {:data => [1, 2, 3]}) do |stdout|
+      json, data = stdout['output'].delete("\r").split("\n")
+      assert_equal('{"data":[1,2,3]}', json, "Output did not contain 'data'")
+      assert_equal('[1,2,3]', data, "Output did not contain 'data'")
+    end
+  end # test step
+end # test

--- a/exe/task.cc
+++ b/exe/task.cc
@@ -177,7 +177,11 @@ int MAIN_IMPL(int argc, char** argv)
     }
 
     lth_log::setup_logging(boost::nowide::cerr);
-    lth_log::set_level(lth_log::log_level::error);
+    if (argc > 1 && argv[1] == string("trace")) {
+        lth_log::set_level(lth_log::log_level::trace);
+    } else {
+        lth_log::set_level(lth_log::log_level::error);
+    }
 
     boost::nowide::cin >> std::noskipws;
     istream_iterator<char> it(boost::nowide::cin), end;


### PR DESCRIPTION
Adds acceptance tests that exercise a basic shell task, a powershell
task on Windows, and ruby and puppet tasks.

Refactors code to check puppet results for re-use in run_task.

Task runner now accepts a `trace` argument to aid in debugging. Passing
it will cause logging to be configured to the `trace` level, so issues
can be dubugged locally using `cat input.json | task trace`.