### PR TITLE
(packaging) Prepare for 1.5.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.5.4
+
+This is a maintenance release.
+
+* [PCP-759](https://tickets.puppetlabs.com/browse/PCP-759) Enable acceptance pre-suite to install puppetserver on EC2
+* [PCP-755](https://tickets.puppetlabs.com/browse/PCP-755) pxp-agent service now cleanly restarts after upgrade on SLES 11
+* [PCP-750](https://tickets.puppetlabs.com/browse/PCP-750) Fix intermittent test failures due to inventory request timeouts
+* [PCP-697](https://tickets.puppetlabs.com/browse/PCP-697) Ensure logdir exists before starting service
+
 ## 1.5.3
 
 This is a maintenance release.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.2.2)
-project(pxp-agent VERSION 1.5.3)
+project(pxp-agent VERSION 1.5.4)
 
 if (NOT CMAKE_BUILD_TYPE)
     message(STATUS "Defaulting to a release build.")

--- a/locales/pxp-agent.pot
+++ b/locales/pxp-agent.pot
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: pxp-agent 1.5.3\n"
+"Project-Id-Version: pxp-agent 1.5.4\n"
 "Report-Msgid-Bugs-To: docs@puppet.com\n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"


### PR DESCRIPTION
This updates the version numbers and changelog for the 1.5.4 release, in
preparation for the puppet-agent 1.10.5 release.