### PR TITLE
(PCP-767) Create internal "task" module

### DIFF
--- a/exe/task.cc
+++ b/exe/task.cc
@@ -188,9 +188,12 @@ int MAIN_IMPL(int argc, char** argv)
     string STDIN(it, end);
     auto args = lth_jc::JsonContainer(STDIN);
 
+    // TODO: expect this to be a file name and args when find_task is moved to the internal module.
     auto taskname = args.get<string>({"input", "task"});
     auto input = args.get<lth_jc::JsonContainer>({"input", "input"});
 
+    // TODO: if these aren't set, write to stdout/stderr and return exitcode instead.
+    //       For use with blocking request.
     auto stdout_file = args.get<string>({"output_files", "stdout"});
     auto stderr_file = args.get<string>({"output_files", "stderr"});
     auto exitcode_file = args.get<string>({"output_files", "exitcode"});

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -28,6 +28,7 @@ set(LIBRARY_COMMON_SOURCES
     src/time.cc
     src/modules/echo.cc
     src/modules/ping.cc
+    src/modules/task.cc
 )
 
 if (UNIX)

--- a/lib/inc/pxp-agent/external_module.hpp
+++ b/lib/inc/pxp-agent/external_module.hpp
@@ -56,10 +56,23 @@ class ExternalModule : public Module {
     /// in the response object's metadata.
     static void processOutputAndUpdateMetadata(ActionResponse& response);
 
-  private:
+  protected:
+    struct execArgs {
+        std::string path;
+        std::vector<std::string> params;
+    };
+
+    /// Returns the path and command-line parameters used to invoke an action.
+    virtual execArgs getExecArgs(std::string action);
+
+    /// A no-op that can be overridden by a subclass to prepare the action
+    /// to run before it's invoked externally.
+    virtual void prepareAction(const ActionRequest& request);
+
     /// The path of the module file
     const std::string path_;
 
+  private:
     /// Module configuration data
     leatherman::json_container::JsonContainer config_;
 

--- a/lib/inc/pxp-agent/external_module.hpp
+++ b/lib/inc/pxp-agent/external_module.hpp
@@ -38,7 +38,7 @@ class ExternalModule : public Module {
         const std::string& spool_dir);
 
     /// The type of the module.
-    ModuleType type() { return ModuleType::External; }
+    ModuleType type() override { return ModuleType::External; }
 
     /// If a configuration schema has been registered for this module,
     /// validate configuration data. In that case, throw a
@@ -96,7 +96,7 @@ class ExternalModule : public Module {
     /// the action output to file.
     ActionResponse callNonBlockingAction(const ActionRequest& request);
 
-    ActionResponse callAction(const ActionRequest& request);
+    ActionResponse callAction(const ActionRequest& request) override;
 };
 
 }  // namespace PXPAgent

--- a/lib/inc/pxp-agent/modules/echo.hpp
+++ b/lib/inc/pxp-agent/modules/echo.hpp
@@ -12,7 +12,7 @@ class Echo : public PXPAgent::Module {
     Echo();
 
   private:
-    ActionResponse callAction(const ActionRequest& request);
+    ActionResponse callAction(const ActionRequest& request) override;
 };
 
 }  // namespace Modules

--- a/lib/inc/pxp-agent/modules/ping.hpp
+++ b/lib/inc/pxp-agent/modules/ping.hpp
@@ -18,7 +18,7 @@ class Ping : public PXPAgent::Module {
     leatherman::json_container::JsonContainer ping(const ActionRequest& request);
 
   private:
-    ActionResponse callAction(const ActionRequest& request);
+    ActionResponse callAction(const ActionRequest& request) override;
 };
 
 }  // namespace Modules

--- a/lib/inc/pxp-agent/modules/task.hpp
+++ b/lib/inc/pxp-agent/modules/task.hpp
@@ -1,0 +1,21 @@
+#pragma once
+#include <pxp-agent/external_module.hpp>
+#include <pxp-agent/action_response.hpp>
+#include <boost/filesystem/path.hpp>
+
+namespace PXPAgent {
+namespace Modules {
+
+class Task : public PXPAgent::ExternalModule {
+  public:
+    // exec_path will be the install location for pxp-agent
+    Task(const boost::filesystem::path& modules_dir,
+         const boost::filesystem::path& spool_dir);
+
+  protected:
+    void prepareAction(const ActionRequest& request) override;
+    execArgs getExecArgs(std::string action) override;
+};
+
+}  // namespace Modules
+}  // namespace PXPAgent

--- a/lib/src/modules/task.cc
+++ b/lib/src/modules/task.cc
@@ -8,6 +8,8 @@ namespace Modules {
 
 namespace fs = boost::filesystem;
 
+// TODO: construct and pass metadata to a new ExternalModule constructor, rather than calling `task metadata`
+// TODO: how do we get the path to task.exe if it's co-located with pxp-agent, rather than in modules dir?
 Task::Task(const fs::path& modules_dir, const fs::path& spool_dir)
         : ExternalModule { (modules_dir/"task").string(), spool_dir.string() }
 {
@@ -18,6 +20,10 @@ ExternalModule::execArgs Task::getExecArgs(std::string action)
     return { path_, { action } };
 }
 
+// TODO: move environment generation for input to a new virtual method?
+
+// TODO: move local task lookup from task.cc to here
+//       handle returning an error if no module is found
 void Task::prepareAction(const ActionRequest& request)
 {
 }

--- a/lib/src/modules/task.cc
+++ b/lib/src/modules/task.cc
@@ -1,0 +1,26 @@
+#include <pxp-agent/modules/task.hpp>
+
+#define LEATHERMAN_LOGGING_NAMESPACE "puppetlabs.pxp_agent.modules.task"
+#include <leatherman/logging/logging.hpp>
+
+namespace PXPAgent {
+namespace Modules {
+
+namespace fs = boost::filesystem;
+
+Task::Task(const fs::path& modules_dir, const fs::path& spool_dir)
+        : ExternalModule { (modules_dir/"task").string(), spool_dir.string() }
+{
+}
+
+ExternalModule::execArgs Task::getExecArgs(std::string action)
+{
+    return { path_, { action } };
+}
+
+void Task::prepareAction(const ActionRequest& request)
+{
+}
+
+}  // namespace Modules
+}  // namespace PXPAgent

--- a/lib/src/request_processor.cc
+++ b/lib/src/request_processor.cc
@@ -9,6 +9,7 @@
 #include <pxp-agent/time.hpp>
 #include <pxp-agent/modules/echo.hpp>
 #include <pxp-agent/modules/ping.hpp>
+#include <pxp-agent/modules/task.hpp>
 #include <pxp-agent/util/process.hpp>
 
 #include <leatherman/json_container/json_container.hpp>
@@ -184,6 +185,8 @@ RequestProcessor::RequestProcessor(std::shared_ptr<PXPConnector> connector_ptr,
     loadInternalModules();
 
     if (!agent_configuration.modules_dir.empty()) {
+        // Tasks currently uses the modules_dir to avoid having to know pxp-agent's install location.
+        modules_["task"] = std::make_shared<Modules::Task>(agent_configuration.modules_dir, spool_dir_path_);
         loadExternalModulesFrom(agent_configuration.modules_dir);
     } else {
         LOG_WARNING("The modules directory was not provided; no external "
@@ -803,8 +806,8 @@ void RequestProcessor::loadModulesConfiguration()
 void RequestProcessor::loadInternalModules()
 {
     // HERE(ale): no external configuration for internal modules
-    modules_["echo"] = std::shared_ptr<Module>(new Modules::Echo);
-    modules_["ping"] = std::shared_ptr<Module>(new Modules::Ping);
+    modules_["echo"] = std::make_shared<Modules::Echo>();
+    modules_["ping"] = std::make_shared<Modules::Ping>();
 }
 
 void RequestProcessor::loadExternalModulesFrom(fs::path dir_path)


### PR DESCRIPTION
Subclasses external_module to create an internal task module. It
currently treats `task` as an external module, with the ability to run
code before running the external module.