### PR TITLE
(PCP-775) Enable DEP support in Windows version of PCP/PXP binaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,10 @@ leatherman_logging_line_numbers()
 set(CMAKE_CXX_FLAGS "${LEATHERMAN_CXX_FLAGS}")
 add_definitions(${LEATHERMAN_DEFINITIONS})
 
+if (WIN32)
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--nxcompat -Wl,--dynamicbase")
+endif()
+
 # TODO(ale): enable i18n with add_definitions(-DLEATHERMAN_I18N) - PCP-257
 # TODO(ale): enable translation with set(LEATHERMAN_LOCALES "...;...") and
 # gettext_compile(${CMAKE_CURRENT_SOURCE_DIR}/locales share/locale)


### PR DESCRIPTION
Enable nxcompat and dynamicbase flags in Windows builds of pxp-agent.
Being done to meet some customer's security audit requirements.