### PR TITLE
(maint) Unblock acceptance tests on Japanese locale instances

### DIFF
--- a/acceptance/tests/pxp-module-puppet/run_puppet_agent_disabled.rb
+++ b/acceptance/tests/pxp-module-puppet/run_puppet_agent_disabled.rb
@@ -2,12 +2,17 @@ require 'pxp-agent/test_helper.rb'
 
 test_name 'C93065 - Run puppet and expect puppet agent disabled' do
 
+  applicable_agents = agents.select { |agent| agent['locale'] != 'ja' }
+  if applicable_agents.empty? then
+    skip_test 'Testing for disabled agent is broken with translated Puppet (PCP-776)'
+  end
+
   teardown do
-    on agents, puppet('agent --enable')
+    on applicable_agents, puppet('agent --enable')
   end
 
   step 'Ensure each agent host has pxp-agent running and associated' do
-    agents.each do |agent|
+    applicable_agents.each do |agent|
       on agent, puppet('resource service pxp-agent ensure=stopped')
       create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
       on agent, puppet('resource service pxp-agent ensure=running')
@@ -18,12 +23,12 @@ test_name 'C93065 - Run puppet and expect puppet agent disabled' do
   end
 
   step 'Set puppet agent on agent hosts to disabled' do
-    on agents, puppet('agent --disable')
+    on applicable_agents, puppet('agent --disable')
   end
 
   step "Send an rpc_blocking_request to all agents" do
     target_identities = []
-    agents.each do |agent|
+    applicable_agents.each do |agent|
       target_identities << "pcp://#{agent}/agent"
     end
     responses = nil # Declare here so not local to begin/rescue below
@@ -35,7 +40,7 @@ test_name 'C93065 - Run puppet and expect puppet agent disabled' do
     rescue => exception
       fail("Exception occurred when trying to run Puppet on all agents: #{exception.message}")
     end
-    agents.each_with_index do |agent|
+    applicable_agents.each_with_index do |agent|
       step "Check Run Puppet response for #{agent}" do
         identity = "pcp://#{agent}/agent"
         action_result = responses[identity][:data]["results"]

--- a/acceptance/tests/pxp-module-puppet/run_puppet_twice.rb
+++ b/acceptance/tests/pxp-module-puppet/run_puppet_twice.rb
@@ -7,13 +7,18 @@ STATUS_QUERY_INTERVAL_SECONDS = 1
 
 test_name 'Run Puppet while a Puppet Agent run is in-progress, wait for completion' do
 
+  applicable_agents = agents.select { |agent| agent['locale'] != 'ja' }
+  if applicable_agents.empty? then
+    skip_test 'Testing for running agent is broken with translated Puppet (PCP-776)'
+  end
+
   extend Puppet::Acceptance::EnvironmentUtils
 
   env_name = test_file_name = File.basename(__FILE__, '.*')
   environment_name = mk_tmp_environment(env_name)
 
   teardown do
-    stop_sleep_process(agents, true)
+    stop_sleep_process(applicable_agents, true)
   end
 
   step 'On master, create a new environment that will result in a slow run' do
@@ -22,7 +27,7 @@ test_name 'Run Puppet while a Puppet Agent run is in-progress, wait for completi
   end
 
   step 'Ensure each agent host has pxp-agent running and associated' do
-    agents.each do |agent|
+    applicable_agents.each do |agent|
       on agent, puppet('resource service pxp-agent ensure=stopped')
       create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
       on agent, puppet('resource service pxp-agent ensure=running')
@@ -32,11 +37,11 @@ test_name 'Run Puppet while a Puppet Agent run is in-progress, wait for completi
   end
 
   step 'Ensure puppet is not currently running as a service (PCP-632)' do
-    on(agents, puppet('resource service puppet ensure=stopped enable=false'))
+    on(applicable_agents, puppet('resource service puppet ensure=stopped enable=false'))
   end
 
   target_identities = []
-  agents.each do |agent|
+  applicable_agents.each do |agent|
     target_identities << "pcp://#{agent}/agent"
   end
 
@@ -46,7 +51,7 @@ test_name 'Run Puppet while a Puppet Agent run is in-progress, wait for completi
   end
 
   step 'Wait until Puppet starts executing' do
-    agents.each do |agent|
+    applicable_agents.each do |agent|
       wait_for_sleep_process(agent)
     end
   end
@@ -71,7 +76,7 @@ test_name 'Run Puppet while a Puppet Agent run is in-progress, wait for completi
   #   b. It observes 1 PID for at least 10 concurrent samples
   #
   step 'Wait for only one puppet agent PID to exist' do
-    agents.each do |agent|
+    applicable_agents.each do |agent|
 
       satisfied = false
       pid_counting_attempts = 0
@@ -113,7 +118,7 @@ test_name 'Run Puppet while a Puppet Agent run is in-progress, wait for completi
   end
 
   step 'Signal sleep process to end so 1st Puppet run will complete' do
-    stop_sleep_process(agents)
+    stop_sleep_process(applicable_agents)
   end
 
   target_identities.zip(transaction_ids).each do |identity, transaction_id|

--- a/modules/pxp-module-puppet
+++ b/modules/pxp-module-puppet
@@ -97,7 +97,7 @@ module Pxp
       begin
         # Later comparisons assume UTF-8. Convert to that encoding now.
         s.encode(Encoding::UTF_8)
-      rescue Encoding::InvalidByteSequenceError
+      rescue Encoding::InvalidByteSequenceError, Encoding::UndefinedConversionError
         # Found non-native characters, hope it's a UTF-8 string. Since this is Puppet, and
         # incorrect characters probably means we're in a C or POSIX locale, this is usually safe.
         s.force_encoding(Encoding::UTF_8)


### PR DESCRIPTION
When output is UTF-8, but running on a Japanese-configured system with
Windows-31J, we get UndefinedConversionError trying to convert the
encoding to UTF-8. Handle this error.

Disable tests that fail with Japanese locales now that Puppet is
translated into Japanese. This should be reverted once PCP-776 is fixed.