### PR TITLE
(maint) Drop ifdefs for linting, fix finding task_wrapper via PATH

### DIFF
--- a/exe/task_wrapper.cc
+++ b/exe/task_wrapper.cc
@@ -33,10 +33,8 @@ int main(int argc, char *argv[])
             {},       // environment
             nullptr,  // PID callback
             0,        // timeout
-#ifndef _WIN32
-            // Only override on non-Windows. On Windows we inherit directory ACLs.
+            // Has no effect on Windows. We instead rely on inherited directory ACLs.
             FILE_PERMS,
-#endif
             lth_util::option_set<lth_exec::execution_options> {
                 lth_exec::execution_options::thread_safe,
                 lth_exec::execution_options::merge_environment,
@@ -46,18 +44,13 @@ int main(int argc, char *argv[])
         // Avoid atomic update to allow testing against /dev/stderr. There should never be
         // multiple processes trying to write this output.
         boost::nowide::ofstream ofs { params.get<std::string>("stderr"), std::ios::binary };
-#ifndef _WIN32
         fs::permissions(params.get<std::string>("stderr"), FILE_PERMS);
-#endif
         ofs << lth_loc::format("Task '{1}' failed to run: {2}", task_executable, e.what());
         exitcode = 127;
     }
 
-    lth_file::atomic_write_to_file(std::to_string(exitcode), params.get<std::string>("exitcode")
-#ifndef _WIN32
-                                   , FILE_PERMS, std::ios::binary
-#endif
-                                   );
+    lth_file::atomic_write_to_file(std::to_string(exitcode), params.get<std::string>("exitcode"),
+                                   FILE_PERMS, std::ios::binary);
 
     return exitcode;
 }

--- a/lib/inc/pxp-agent/configuration.hpp
+++ b/lib/inc/pxp-agent/configuration.hpp
@@ -24,7 +24,7 @@ namespace PXPAgent {
 
 extern const std::string DEFAULT_SPOOL_DIR;     // used by unit tests
 
-// Only set on non-Windows. On Windows we inherit directory ACLs.
+// Has no effect on Windows. We instead rely on inherited directory ACLs.
 extern const boost::filesystem::perms NIX_FILE_PERMS;
 extern const boost::filesystem::perms NIX_DIR_PERMS;
 

--- a/lib/src/configuration.cc
+++ b/lib/src/configuration.cc
@@ -223,9 +223,7 @@ std::string Configuration::setupLogging()
         // up logging before calling validateAndNormalizeConfiguration
         validateLogDirPath(logfile_);
         logfile_fstream_.open(logfile_.c_str(), std::ios_base::app);
-#ifndef _WIN32
         fs::permissions(logfile_, NIX_FILE_PERMS);
-#endif
 
         log_stream = &logfile_fstream_;
     } else {
@@ -238,9 +236,7 @@ std::string Configuration::setupLogging()
         pcp_access_fstream_ptr_.reset(
             new boost::nowide::ofstream(pcp_access_logfile_.c_str(),
                                         std::ios_base::app));
-#ifndef _WIN32
         fs::permissions(logfile_, NIX_FILE_PERMS);
-#endif
     }
 
 #ifndef _WIN32

--- a/lib/src/configuration.cc
+++ b/lib/src/configuration.cc
@@ -164,10 +164,15 @@ HW::ParseResult Configuration::parseOptions(int argc, char *argv[])
     // This is primarily for testing.
     master_uris_.clear();
 
-    // remember the path to the pxp-agent executable used to start
+    // Remember the path to the pxp-agent executable used to start
     // this process, it is supposed to be used to start executables
-    // which are installed alongside the pxp-agent executable
-    exec_prefix_ = fs::absolute(fs::path(argv[0]).parent_path());
+    // which are installed alongside the pxp-agent executable.
+    exec_prefix_ = fs::path(argv[0]).parent_path();
+    // If a relative or absolute path was specified, convert to absolute.
+    // Otherwise, we'll depend on using PATH to find the task_wrapper.
+    if (!exec_prefix_.empty()) {
+        exec_prefix_ = fs::absolute(exec_prefix_);
+    }
 
     auto parse_result = parseArguments(argc, argv);
 

--- a/lib/src/external_module.cc
+++ b/lib/src/external_module.cc
@@ -362,11 +362,8 @@ ActionResponse ExternalModule::callNonBlockingAction(const ActionRequest& reques
         std::map<std::string, std::string>(),  // environment
         [results_dir_path](size_t pid) {
             auto pid_file = (results_dir_path / "pid").string();
-            lth_file::atomic_write_to_file(std::to_string(pid) + "\n", pid_file
-#ifndef _WIN32
-                                           , NIX_FILE_PERMS, std::ios::binary
-#endif
-                                           );
+            lth_file::atomic_write_to_file(std::to_string(pid) + "\n", pid_file,
+                                           NIX_FILE_PERMS, std::ios::binary);
         },          // pid callback
         0,          // timeout
         { lth_exec::execution_options::thread_safe,

--- a/lib/src/modules/task.cc
+++ b/lib/src/modules/task.cc
@@ -192,11 +192,8 @@ void Task::callNonBlockingAction(
         environment,
         [results_dir](size_t pid) {
             auto pid_file = (results_dir / "pid").string();
-            lth_file::atomic_write_to_file(std::to_string(pid) + "\n", pid_file
-#ifndef _WIN32
-                                           , NIX_FILE_PERMS, std::ios::binary
-#endif
-                                          );
+            lth_file::atomic_write_to_file(std::to_string(pid) + "\n", pid_file,
+                                           NIX_FILE_PERMS, std::ios::binary);
         },  // pid callback
         0,  // timeout
         leatherman::util::option_set<lth_exec::execution_options> {

--- a/lib/src/results_storage.cc
+++ b/lib/src/results_storage.cc
@@ -42,11 +42,7 @@ bool ResultsStorage::find(const std::string& transaction_id)
 
 static void writeMetadata(const std::string& txt, const std::string& file_path) {
     try {
-        lth_file::atomic_write_to_file(txt, file_path
-#ifndef _WIN32
-                                       , NIX_FILE_PERMS, std::ios::binary
-#endif
-                                      );
+        lth_file::atomic_write_to_file(txt, file_path, NIX_FILE_PERMS, std::ios::binary);
     } catch (const std::exception& e) {
         throw ResultsStorage::Error {
             lth_loc::format("failed to write metadata: {1}", e.what()) };
@@ -63,9 +59,7 @@ void ResultsStorage::initializeMetadataFile(const std::string& transaction_id,
                   transaction_id, results_path.string());
         try {
             fs::create_directories(results_path);
-#ifndef _WIN32
             fs::permissions(results_path, NIX_DIR_PERMS);
-#endif
         } catch (const fs::filesystem_error& e) {
             throw ResultsStorage::Error {
                 lth_loc::format("failed to create results directory '{1}'",


### PR DESCRIPTION
The code looks bad, linting doesn't like it, and it should have no effect.

If pxp-agent is invoked by finding it on PATH, finding the task_wrapper would search on the current working directory and likely fail. Fix so if pxp-agent was found via PATH, task_wrapper will also be searched via PATH.