### PR TITLE
(maint) Avoid setting permissions on Windows

### DIFF
--- a/lib/inc/pxp-agent/configuration.hpp
+++ b/lib/inc/pxp-agent/configuration.hpp
@@ -24,9 +24,11 @@ namespace PXPAgent {
 
 extern const std::string DEFAULT_SPOOL_DIR;     // used by unit tests
 
-// Has no effect on Windows. We instead rely on inherited directory ACLs.
+#ifndef _WIN32
+// Not used on Windows. We instead rely on inherited directory ACLs.
 extern const boost::filesystem::perms NIX_FILE_PERMS;
 extern const boost::filesystem::perms NIX_DIR_PERMS;
+#endif
 
 //
 // Types

--- a/lib/src/configuration.cc
+++ b/lib/src/configuration.cc
@@ -104,8 +104,10 @@ static const std::string DEFAULT_SPOOL_DIR_PURGE_TTL { "14d" };
 
 static const std::string AGENT_CLIENT_TYPE { "agent" };
 
+#ifndef _WIN32
 const fs::perms NIX_FILE_PERMS { fs::owner_read | fs::owner_write | fs::group_read };
 const fs::perms NIX_DIR_PERMS  { NIX_FILE_PERMS | fs::owner_exe | fs::group_exe };
+#endif
 
 //
 // Public interface
@@ -226,7 +228,9 @@ std::string Configuration::setupLogging()
         // up logging before calling validateAndNormalizeConfiguration
         validateLogDirPath(logfile_);
         logfile_fstream_.open(logfile_.c_str(), std::ios_base::app);
+#ifndef _WIN32
         fs::permissions(logfile_, NIX_FILE_PERMS);
+#endif
 
         log_stream = &logfile_fstream_;
     } else {
@@ -239,7 +243,9 @@ std::string Configuration::setupLogging()
         pcp_access_fstream_ptr_.reset(
             new boost::nowide::ofstream(pcp_access_logfile_.c_str(),
                                         std::ios_base::app));
+#ifndef _WIN32
         fs::permissions(pcp_access_logfile_, NIX_FILE_PERMS);
+#endif
     }
 
 #ifndef _WIN32

--- a/lib/src/external_module.cc
+++ b/lib/src/external_module.cc
@@ -362,8 +362,12 @@ ActionResponse ExternalModule::callNonBlockingAction(const ActionRequest& reques
         std::map<std::string, std::string>(),  // environment
         [results_dir_path](size_t pid) {
             auto pid_file = (results_dir_path / "pid").string();
+#ifdef _WIN32
+            lth_file::atomic_write_to_file(std::to_string(pid) + "\n", pid_file);
+#else
             lth_file::atomic_write_to_file(std::to_string(pid) + "\n", pid_file,
                                            NIX_FILE_PERMS, std::ios::binary);
+#endif
         },          // pid callback
         0,          // timeout
         { lth_exec::execution_options::thread_safe,

--- a/lib/src/modules/task.cc
+++ b/lib/src/modules/task.cc
@@ -366,8 +366,12 @@ void Task::callNonBlockingAction(
         environment,
         [results_dir](size_t pid) {
             auto pid_file = (results_dir / "pid").string();
+#ifdef _WIN32
+            lth_file::atomic_write_to_file(std::to_string(pid) + "\n", pid_file);
+#else
             lth_file::atomic_write_to_file(std::to_string(pid) + "\n", pid_file,
                                            NIX_FILE_PERMS, std::ios::binary);
+#endif
         },  // pid callback
         0,  // timeout
         leatherman::util::option_set<lth_exec::execution_options> {

--- a/lib/src/results_storage.cc
+++ b/lib/src/results_storage.cc
@@ -42,7 +42,11 @@ bool ResultsStorage::find(const std::string& transaction_id)
 
 static void writeMetadata(const std::string& txt, const std::string& file_path) {
     try {
+#ifdef _WIN32
+        lth_file::atomic_write_to_file(txt, file_path);
+#else
         lth_file::atomic_write_to_file(txt, file_path, NIX_FILE_PERMS, std::ios::binary);
+#endif
     } catch (const std::exception& e) {
         throw ResultsStorage::Error {
             lth_loc::format("failed to write metadata: {1}", e.what()) };
@@ -59,7 +63,9 @@ void ResultsStorage::initializeMetadataFile(const std::string& transaction_id,
                   transaction_id, results_path.string());
         try {
             fs::create_directories(results_path);
+#ifndef _WIN32
             fs::permissions(results_path, NIX_DIR_PERMS);
+#endif
         } catch (const fs::filesystem_error& e) {
             throw ResultsStorage::Error {
                 lth_loc::format("failed to create results directory '{1}'",

--- a/lib/tests/unit/configuration_test.cc
+++ b/lib/tests/unit/configuration_test.cc
@@ -339,9 +339,9 @@ TEST_CASE("Configuration::validate", "[configuration]") {
         REQUIRE_FALSE(fs::exists(test_task_cache_dir));
         REQUIRE_NOTHROW(Configuration::Instance().validate());
         REQUIRE(fs::exists(test_task_cache_dir));
-        #ifndef _WIN32
+#ifndef _WIN32
         REQUIRE(fs::status(test_task_cache_dir).permissions() == 0750);
-        #endif
+#endif
 
         fs::remove_all(test_task_cache_dir);
     }


### PR DESCRIPTION
Boost.Filesystem's permission behaves strangely on Windows. It seems to
set read-only when it shouldn't (according to documentation). Avoid
using it to set permissions on Windows; we want it to be a noop anyway.