### PR TITLE
(maint) IDE suggested fixes

### DIFF
--- a/lib/inc/pxp-agent/configuration.hpp
+++ b/lib/inc/pxp-agent/configuration.hpp
@@ -232,9 +232,9 @@ class Configuration
 
         try {
             HorseWhisperer::SetFlag<T>(flagname, std::move(value));
-        } catch (HorseWhisperer::flag_validation_error) {
+        } catch (HorseWhisperer::flag_validation_error&) {
             throw Configuration::Error { getInvalidFlagError(flagname) };
-        } catch (HorseWhisperer::undefined_flag_error) {
+        } catch (HorseWhisperer::undefined_flag_error&) {
             throw Configuration::Error { getUnknownFlagError(flagname) };
         }
     }

--- a/lib/inc/pxp-agent/module.hpp
+++ b/lib/inc/pxp-agent/module.hpp
@@ -36,6 +36,8 @@ class Module {
 
     Module();
 
+    virtual ~Module() = default;
+
     /// Whether or not the module has the specified action.
     bool hasAction(const std::string& action_name);
 

--- a/lib/inc/pxp-agent/pxp_connector.hpp
+++ b/lib/inc/pxp-agent/pxp_connector.hpp
@@ -20,6 +20,8 @@ using MessageCallback = std::function<void(const PCPClient::ParsedChunks& parsed
 // no exception will be propagated.
 class PXPConnector {
   public:
+    virtual ~PXPConnector() = default;
+
     virtual void sendPCPError(const std::string& request_id,
                               const std::string& description,
                               const std::vector<std::string>& endpoints) = 0;

--- a/lib/src/module.cc
+++ b/lib/src/module.cc
@@ -45,7 +45,7 @@ void Module::validateOutputAndUpdateMetadata(ActionResponse& response)
             response.action_metadata.get<std::string>("action"));
         LOG_TRACE("Successfully validated the results for the {1}",
                   response.prettyRequestLabel());
-    } catch (PCPClient::validation_error) {
+    } catch (PCPClient::validation_error&) {
         // Modify the response metadata to indicate the failure
         if (type() == ModuleType::Internal) {
             // This is unexpected

--- a/lib/src/modules/task.cc
+++ b/lib/src/modules/task.cc
@@ -33,7 +33,7 @@ namespace lth_curl = leatherman::curl;
 
 static const std::string TASK_RUN_ACTION { "run" };
 
-static const lth_jc::JsonContainer TASK_RUN_ACTION_INPUT_SCHEMA { R"(
+static const std::string TASK_RUN_ACTION_INPUT_SCHEMA { R"(
 {
   "type": "object",
   "properties": {
@@ -117,7 +117,7 @@ Task::Task(const fs::path& exec_prefix,
     module_name = "task";
     actions.push_back(TASK_RUN_ACTION);
 
-    PCPClient::Schema input_schema { TASK_RUN_ACTION, TASK_RUN_ACTION_INPUT_SCHEMA };
+    PCPClient::Schema input_schema { TASK_RUN_ACTION, lth_jc::JsonContainer { TASK_RUN_ACTION_INPUT_SCHEMA } };
     PCPClient::Schema output_schema { TASK_RUN_ACTION };
 
     input_validator_.registerSchema(input_schema);

--- a/lib/tests/component/external_modules_interface_test.cc
+++ b/lib/tests/component/external_modules_interface_test.cc
@@ -131,7 +131,7 @@ TEST_CASE("Process correctly requests for external modules", "[component]") {
             const PCPClient::ParsedChunks p_c { envelope, data, debug, 0 };
 
             REQUIRE_THROWS_AS(r_p.processRequest(RequestType::Blocking, p_c),
-                              MockConnector::pxpError_msg);
+                              MockConnector::pxpError_msg&);
         }
     }
 

--- a/lib/tests/unit/agent_test.cc
+++ b/lib/tests/unit/agent_test.cc
@@ -42,7 +42,7 @@ TEST_CASE("Agent::Agent", "[agent]") {
     SECTION("should throw an Agent::Error if client cert path is invalid") {
         agent_configuration.crt = "spam";
 
-        REQUIRE_THROWS_AS(Agent { agent_configuration }, Agent::Error);
+        REQUIRE_THROWS_AS(Agent { agent_configuration }, Agent::Error&);
     }
 
     SECTION("successfully instantiates with valid arguments") {

--- a/lib/tests/unit/modules/ping_test.cc
+++ b/lib/tests/unit/modules/ping_test.cc
@@ -17,8 +17,6 @@ namespace PXPAgent {
 
 namespace lth_jc = leatherman::json_container;
 
-static const std::string PING_ACTION { "ping" };
-
 static const std::string PING_TXT {
     (DATA_FORMAT % "\"0563\""
                  % "\"ping\""

--- a/lib/tests/unit/modules/task_test.cc
+++ b/lib/tests/unit/modules/task_test.cc
@@ -154,7 +154,7 @@ TEST_CASE("Modules::Task::callAction - non blocking", "[modules]") {
         try {
             auto pid_txt = lth_file::read(pid_path.string());
             auto pid = std::stoi(pid_txt);
-        } catch (std::exception) {
+        } catch (std::exception&) {
             FAIL("fail to get pid");
         }
     }


### PR DESCRIPTION
Apply fixes suggested by the Eclipse CDT IDE:
* define virtual destructors for classes which are deleted through base class typed pointers
* catch exceptions by reference
* remove unused variables