### PR TITLE
(maint) Support `input_method` on tasks

### DIFF
--- a/lib/src/modules/task.cc
+++ b/lib/src/modules/task.cc
@@ -71,7 +71,7 @@ static const std::string TASK_RUN_ACTION_INPUT_SCHEMA { R"(
     "input": {
       "type": "object"
     },
-    "inputFormat": {
+    "input_method": {
       "type": "string"
     }
   },
@@ -402,25 +402,25 @@ void Task::callNonBlockingAction(
 ActionResponse Task::callAction(const ActionRequest& request)
 {
     auto task_execution_params = request.params();
-    auto task_input_format = task_execution_params.includes("inputFormat") ?
-        task_execution_params.get<std::string>("inputFormat") : std::string{""};
+    auto task_input_method = task_execution_params.includes("input_method") ?
+        task_execution_params.get<std::string>("input_method") : std::string{""};
     std::map<std::string, std::string> task_environment;
     std::string task_input;
 
     bool has_input = false;
-    if (task_input_format.empty() || task_input_format == "stdin:json") {
+    if (task_input_method.empty() || task_input_method == "stdin") {
         task_input = task_execution_params.get<lth_jc::JsonContainer>("input").toString();
         has_input = true;
     }
 
-    if (task_input_format.empty() || task_input_format == "environment") {
+    if (task_input_method.empty() || task_input_method == "environment") {
         addParametersToEnvironment(task_execution_params.get<lth_jc::JsonContainer>("input"), task_environment);
         has_input = true;
     }
 
     if (!has_input) {
         throw Module::ProcessingError {
-            lth_loc::format("unsupported task input format: {1}", task_input_format) };
+            lth_loc::format("unsupported task input method: {1}", task_input_method) };
     }
 
     auto task_command = getTaskCommand(

--- a/lib/tests/resources/tasks-cache/823c013467ce03b12dbe005757a6c842894373e8bcfb0cf879329afb5abcd543/multi
+++ b/lib/tests/resources/tasks-cache/823c013467ce03b12dbe005757a6c842894373e8bcfb0cf879329afb5abcd543/multi
@@ -1,0 +1,3 @@
+#!/bin/sh
+echo $PT_message
+cat -

--- a/lib/tests/resources/tasks-cache/88a07e5b672aa44a91aa7d63e22c91510af5d4707e12f75e0d5de2dfdbde1dec/multi.bat
+++ b/lib/tests/resources/tasks-cache/88a07e5b672aa44a91aa7d63e22c91510af5d4707e12f75e0d5de2dfdbde1dec/multi.bat
@@ -1,0 +1,2 @@
+@echo %PT_message%
+@more

--- a/locales/pxp-agent.pot
+++ b/locales/pxp-agent.pot
@@ -692,7 +692,7 @@ msgid ""
 msgstr ""
 
 #: lib/src/modules/task.cc
-msgid "unsupported task input format: {1}"
+msgid "unsupported task input method: {1}"
 msgstr ""
 
 #. debug


### PR DESCRIPTION
Support `stdin` and `environment` options for `input_method`.

Supports ORCH-1956.