### PR TITLE
(maint) Update task blocking response to return results directly

### DIFF
--- a/lib/tests/unit/modules/task_test.cc
+++ b/lib/tests/unit/modules/task_test.cc
@@ -186,7 +186,7 @@ TEST_CASE("Modules::Task::executeAction", "[modules][output]") {
             0 };
         ActionRequest request { RequestType::Blocking, echo_content };
 
-        auto output = e_m.executeAction(request).action_metadata.get<std::string>("results");
+        auto output = e_m.executeAction(request).action_metadata.get<std::string>({"results", "stdout"});
         boost::trim(output);
         REQUIRE(output == "{\"message\":\"hello\"}");
     }
@@ -212,7 +212,7 @@ TEST_CASE("Modules::Task::executeAction", "[modules][output]") {
             0 };
         ActionRequest request { RequestType::Blocking, echo_content };
 
-        auto output = e_m.executeAction(request).action_metadata.get<std::string>("results");
+        auto output = e_m.executeAction(request).action_metadata.get<std::string>({"results", "stdout"});
         boost::trim(output);
         REQUIRE(output == "hello");
     }
@@ -239,7 +239,7 @@ TEST_CASE("Modules::Task::executeAction", "[modules][output]") {
         ActionRequest request { RequestType::Blocking, echo_content };
         auto response = e_m.executeAction(request);
 
-        auto output = response.action_metadata.get<std::string>("results");
+        auto output = response.action_metadata.get<std::string>({"results", "stdout"});
         boost::trim(output);
         REQUIRE(output == "hello");
         REQUIRE(response.action_metadata.get<bool>("results_are_valid"));

--- a/lib/tests/unit/modules/task_test.cc
+++ b/lib/tests/unit/modules/task_test.cc
@@ -186,7 +186,7 @@ TEST_CASE("Modules::Task::executeAction", "[modules][output]") {
             0 };
         ActionRequest request { RequestType::Blocking, echo_content };
 
-        auto output = e_m.executeAction(request).action_metadata.get<std::string>({ "results", "output" });
+        auto output = e_m.executeAction(request).action_metadata.get<std::string>("results");
         boost::trim(output);
         REQUIRE(output == "{\"message\":\"hello\"}");
     }
@@ -212,7 +212,7 @@ TEST_CASE("Modules::Task::executeAction", "[modules][output]") {
             0 };
         ActionRequest request { RequestType::Blocking, echo_content };
 
-        auto output = e_m.executeAction(request).action_metadata.get<std::string>({ "results", "output" });
+        auto output = e_m.executeAction(request).action_metadata.get<std::string>("results");
         boost::trim(output);
         REQUIRE(output == "hello");
     }
@@ -239,7 +239,7 @@ TEST_CASE("Modules::Task::executeAction", "[modules][output]") {
         ActionRequest request { RequestType::Blocking, echo_content };
         auto response = e_m.executeAction(request);
 
-        auto output = response.action_metadata.get<std::string>({ "results", "output" });
+        auto output = response.action_metadata.get<std::string>("results");
         boost::trim(output);
         REQUIRE(output == "hello");
         REQUIRE(response.action_metadata.get<bool>("results_are_valid"));

--- a/locales/pxp-agent.pot
+++ b/locales/pxp-agent.pot
@@ -710,7 +710,7 @@ msgstr ""
 #: lib/src/modules/task.cc
 msgid ""
 "Obtained invalid UTF-8 on stdout for the {1}; stdout:\n"
-"{3}"
+"{2}"
 msgstr ""
 
 #: lib/src/modules/task.cc


### PR DESCRIPTION
The output from a blocking response was wrapped in a key to make it a
valid json object. That was a hack that's unnecessary, fix it by
allowing the task module to return a string, and returning the result
string directly.