### PR TITLE
(maint) Update task blocking response to return all results

### DIFF
--- a/lib/src/modules/task.cc
+++ b/lib/src/modules/task.cc
@@ -510,12 +510,19 @@ void Task::processOutputAndUpdateMetadata(ActionResponse& response)
     std::string &output = response.output.std_out;
 
     if (isValidUTF8(output)) {
-        lth_jc::JsonContainer stdout_result;
-        stdout_result.set("output", output);
+        // Return all relevant results: exitcode, stdout, stderr.
+        lth_jc::JsonContainer result;
+        result.set("exitcode", response.output.exitcode);
+        if (!output.empty()) {
+            result.set("stdout", output);
+        }
+        if (!response.output.std_err.empty()) {
+            result.set("stderr", response.output.std_err);
+        }
 
-        response.setValidResultsAndEnd(std::move(stdout_result));
+        response.setValidResultsAndEnd(std::move(result));
     } else {
-        LOG_DEBUG("Obtained invalid UTF-8 on stdout for the {1}; stdout:\n{3}",
+        LOG_DEBUG("Obtained invalid UTF-8 on stdout for the {1}; stdout:\n{2}",
                   response.prettyRequestLabel(), output);
         std::string execution_error {
             lth_loc::format("The task executed for the {1} returned invalid "

--- a/lib/tests/unit/modules/task_test.cc
+++ b/lib/tests/unit/modules/task_test.cc
@@ -186,7 +186,7 @@ TEST_CASE("Modules::Task::executeAction", "[modules][output]") {
             0 };
         ActionRequest request { RequestType::Blocking, echo_content };
 
-        auto output = e_m.executeAction(request).action_metadata.get<std::string>({ "results", "output" });
+        auto output = e_m.executeAction(request).action_metadata.get<std::string>({"results", "stdout"});
         boost::trim(output);
         REQUIRE(output == "{\"message\":\"hello\"}");
     }
@@ -212,7 +212,7 @@ TEST_CASE("Modules::Task::executeAction", "[modules][output]") {
             0 };
         ActionRequest request { RequestType::Blocking, echo_content };
 
-        auto output = e_m.executeAction(request).action_metadata.get<std::string>({ "results", "output" });
+        auto output = e_m.executeAction(request).action_metadata.get<std::string>({ "results", "stdout" });
         boost::trim(output);
 #ifdef _WIN32
         REQUIRE(output == "ECHO is on.\r\n{\"message\":\"hello\"}");
@@ -242,7 +242,7 @@ TEST_CASE("Modules::Task::executeAction", "[modules][output]") {
             0 };
         ActionRequest request { RequestType::Blocking, echo_content };
 
-        auto output = e_m.executeAction(request).action_metadata.get<std::string>({ "results", "output" });
+        auto output = e_m.executeAction(request).action_metadata.get<std::string>({"results", "stdout"});
         boost::trim(output);
         REQUIRE(output == "hello");
     }
@@ -268,7 +268,7 @@ TEST_CASE("Modules::Task::executeAction", "[modules][output]") {
             0 };
         ActionRequest request { RequestType::Blocking, echo_content };
 
-        auto output = e_m.executeAction(request).action_metadata.get<std::string>({ "results", "output" });
+        auto output = e_m.executeAction(request).action_metadata.get<std::string>({ "results", "stdout" });
         boost::trim(output);
         REQUIRE(output == "hello");
     }
@@ -295,7 +295,7 @@ TEST_CASE("Modules::Task::executeAction", "[modules][output]") {
         ActionRequest request { RequestType::Blocking, echo_content };
         auto response = e_m.executeAction(request);
 
-        auto output = response.action_metadata.get<std::string>({ "results", "output" });
+        auto output = response.action_metadata.get<std::string>({"results", "stdout"});
         boost::trim(output);
         REQUIRE(output == "hello");
         REQUIRE(response.action_metadata.get<bool>("results_are_valid"));

--- a/locales/pxp-agent.pot
+++ b/locales/pxp-agent.pot
@@ -710,7 +710,7 @@ msgstr ""
 #: lib/src/modules/task.cc
 msgid ""
 "Obtained invalid UTF-8 on stdout for the {1}; stdout:\n"
-"{3}"
+"{2}"
 msgstr ""
 
 #: lib/src/modules/task.cc


### PR DESCRIPTION
In the task response, return exitcode and stderr as well as stdout. This
allows a consumer to skip querying status, as all the data they need for
a task is in the response.

The status query used to retrieve task results returns stdout, stderr,
and exitcode. This makes the response to running a task - which is
returned immediately upon completion, rather than in response to a
status request - contain the same information so a controller can avoid
a follow-up request to get it.