### PR TITLE
(PCP-769) Fix permissions hacks

### DIFF
--- a/lib/inc/pxp-agent/configuration.hpp
+++ b/lib/inc/pxp-agent/configuration.hpp
@@ -24,11 +24,9 @@ namespace PXPAgent {
 
 extern const std::string DEFAULT_SPOOL_DIR;     // used by unit tests
 
-#ifndef _WIN32
-// Not used on Windows. We instead rely on inherited directory ACLs.
+// Note that on Windows we rely on inherited directory ACLs.
 extern const boost::filesystem::perms NIX_FILE_PERMS;
 extern const boost::filesystem::perms NIX_DIR_PERMS;
-#endif
 
 //
 // Types

--- a/lib/src/configuration.cc
+++ b/lib/src/configuration.cc
@@ -104,10 +104,8 @@ static const std::string DEFAULT_SPOOL_DIR_PURGE_TTL { "14d" };
 
 static const std::string AGENT_CLIENT_TYPE { "agent" };
 
-#ifndef _WIN32
 const fs::perms NIX_FILE_PERMS { fs::owner_read | fs::owner_write | fs::group_read };
 const fs::perms NIX_DIR_PERMS  { NIX_FILE_PERMS | fs::owner_exe | fs::group_exe };
-#endif
 
 //
 // Public interface
@@ -228,9 +226,7 @@ std::string Configuration::setupLogging()
         // up logging before calling validateAndNormalizeConfiguration
         validateLogDirPath(logfile_);
         logfile_fstream_.open(logfile_.c_str(), std::ios_base::app);
-#ifndef _WIN32
         fs::permissions(logfile_, NIX_FILE_PERMS);
-#endif
 
         log_stream = &logfile_fstream_;
     } else {
@@ -243,9 +239,7 @@ std::string Configuration::setupLogging()
         pcp_access_fstream_ptr_.reset(
             new boost::nowide::ofstream(pcp_access_logfile_.c_str(),
                                         std::ios_base::app));
-#ifndef _WIN32
         fs::permissions(pcp_access_logfile_, NIX_FILE_PERMS);
-#endif
     }
 
 #ifndef _WIN32
@@ -936,7 +930,6 @@ void Configuration::validateAndNormalizeOtherSettings()
 
     fs::path task_cache_dir_path { lth_file::tilde_expand(task_cache_dir) };
     check_and_create_dir(task_cache_dir_path, "task-cache-dir", true);
-#ifndef _WIN32
     try {
         fs::permissions(task_cache_dir_path, NIX_DIR_PERMS);
     } catch (const fs::filesystem_error& e) {
@@ -944,7 +937,6 @@ void Configuration::validateAndNormalizeOtherSettings()
                 lth_loc::format("Failed to make the task-cache-dir '{1}' user/group readable and executable, and user writable during configuration validation: {2}",
                             task_cache_dir_path.string(), e.what()) };
     }
-#endif
 
     HW::SetFlag<std::string>("task-cache-dir", task_cache_dir_path.string());
 

--- a/lib/src/external_module.cc
+++ b/lib/src/external_module.cc
@@ -362,12 +362,8 @@ ActionResponse ExternalModule::callNonBlockingAction(const ActionRequest& reques
         std::map<std::string, std::string>(),  // environment
         [results_dir_path](size_t pid) {
             auto pid_file = (results_dir_path / "pid").string();
-#ifdef _WIN32
-            lth_file::atomic_write_to_file(std::to_string(pid) + "\n", pid_file);
-#else
             lth_file::atomic_write_to_file(std::to_string(pid) + "\n", pid_file,
                                            NIX_FILE_PERMS, std::ios::binary);
-#endif
         },          // pid callback
         0,          // timeout
         { lth_exec::execution_options::thread_safe,

--- a/lib/src/results_storage.cc
+++ b/lib/src/results_storage.cc
@@ -42,11 +42,7 @@ bool ResultsStorage::find(const std::string& transaction_id)
 
 static void writeMetadata(const std::string& txt, const std::string& file_path) {
     try {
-#ifdef _WIN32
-        lth_file::atomic_write_to_file(txt, file_path);
-#else
         lth_file::atomic_write_to_file(txt, file_path, NIX_FILE_PERMS, std::ios::binary);
-#endif
     } catch (const std::exception& e) {
         throw ResultsStorage::Error {
             lth_loc::format("failed to write metadata: {1}", e.what()) };
@@ -63,9 +59,7 @@ void ResultsStorage::initializeMetadataFile(const std::string& transaction_id,
                   transaction_id, results_path.string());
         try {
             fs::create_directories(results_path);
-#ifndef _WIN32
             fs::permissions(results_path, NIX_DIR_PERMS);
-#endif
         } catch (const fs::filesystem_error& e) {
             throw ResultsStorage::Error {
                 lth_loc::format("failed to create results directory '{1}'",

--- a/lib/tests/unit/configuration_test.cc
+++ b/lib/tests/unit/configuration_test.cc
@@ -341,6 +341,8 @@ TEST_CASE("Configuration::validate", "[configuration]") {
         REQUIRE(fs::exists(test_task_cache_dir));
 #ifndef _WIN32
         REQUIRE(fs::status(test_task_cache_dir).permissions() == 0750);
+#else
+        REQUIRE(fs::status(test_task_cache_dir).permissions() == 0666);
 #endif
 
         fs::remove_all(test_task_cache_dir);

--- a/lib/tests/unit/modules/task_test.cc
+++ b/lib/tests/unit/modules/task_test.cc
@@ -409,6 +409,8 @@ TEST_CASE("Modules::Task::executeAction", "[modules][output]") {
         REQUIRE(fs::is_directory(cache));
 #ifndef _WIN32
         REQUIRE(fs::status(cache).permissions() == 0750);
+#else
+        REQUIRE(fs::status(cache).permissions() == 0666);
 #endif
     }
 }


### PR DESCRIPTION
Applying permissions on Windows and using fs::permissions on Solaris
were both hacked around due to a faulty assumption that they were broken
on those platforms. The root cause of both issues was a static
initialization ordering issue.

Fix it by using a macro to alias the variable name, rather than
assigning from a global variable in another object. Unwind Windows and
Solaris hacks.