### PR TITLE
(PCP-783) Specify required sleep process more thoroughly

### DIFF
--- a/acceptance/lib/pxp-agent/test_helper.rb
+++ b/acceptance/lib/pxp-agent/test_helper.rb
@@ -440,17 +440,17 @@ def get_process_pids(host, process)
   pids
 end
 
-def wait_for_sleep_process(target)
+def wait_for_sleep_process(target, seconds_to_sleep)
   begin
     ps_cmd = target['platform'] =~ /win/ ? 'ps -efW' : 'ps -ef'
-    sleep_process = target['platform'] =~ /win/ ? 'PING' : '/bin/sleep'
+    sleep_process = target['platform'] =~ /win/ ? 'PING' : " /bin/sleep #{seconds_to_sleep}"
     retry_on(target, "#{ps_cmd} | grep '#{sleep_process}' | grep -v 'grep'", {:max_retries => 120, :retry_interval => 1})
   rescue
     raise("After triggering a puppet run on #{target} the expected sleep process did not appear in process list")
   end
 end
 
-def stop_sleep_process(targets, accept_no_pid_found = false)
+def stop_sleep_process(targets, seconds_to_sleep, accept_no_pid_found = false)
   targets = [targets].flatten
 
   targets.each do |target|
@@ -460,7 +460,7 @@ def stop_sleep_process(targets, accept_no_pid_found = false)
     when /win/
       command = "ps -efW | grep PING | sed 's/^[^0-9]*[0-9]*[^0-9]*//g' | cut -d ' ' -f1"
     else
-      command = "ps -ef | grep 'bin/sleep ' | grep -v 'grep' | grep -v 'true' | sed 's/^[^0-9]*//g' | cut -d\\  -f1"
+      command = "ps -ef | grep ' /bin/sleep #{seconds_to_sleep}' | grep -v 'grep' | grep -v 'true' | sed 's/^[^0-9]*//g' | cut -d\\  -f1"
     end
 
     # A failed test may leave an orphaned sleep process, handle multiple matches.

--- a/acceptance/tests/pxp-module-puppet/restart_pxp_agent_during_non_blocking_run.rb
+++ b/acceptance/tests/pxp-module-puppet/restart_pxp_agent_during_non_blocking_run.rb
@@ -14,7 +14,7 @@ test_name 'C94705 - Run Puppet (non-blocking request) and restart pxp-agent serv
 
   teardown do
     unless applicable_agents.empty? then
-      stop_sleep_process(applicable_agents, true)
+      stop_sleep_process(applicable_agents, SECONDS_TO_SLEEP, true)
     end
   end
 
@@ -64,7 +64,7 @@ test_name 'C94705 - Run Puppet (non-blocking request) and restart pxp-agent serv
     end
 
     step 'Wait to ensure that Puppet has time to execute manifest' do
-      wait_for_sleep_process(agent)
+      wait_for_sleep_process(agent, SECONDS_TO_SLEEP)
     end
 
     step "Restart pxp-agent service on #{agent}" do
@@ -77,7 +77,7 @@ test_name 'C94705 - Run Puppet (non-blocking request) and restart pxp-agent serv
     end
 
     step 'Signal sleep process to end so Puppet run will complete' do
-      stop_sleep_process(agent)
+      stop_sleep_process(agent, SECONDS_TO_SLEEP)
     end
 
     step 'Check response of puppet run' do

--- a/acceptance/tests/pxp-module-puppet/run_puppet_during_puppet.rb
+++ b/acceptance/tests/pxp-module-puppet/run_puppet_during_puppet.rb
@@ -36,7 +36,7 @@ test_name 'Run Puppet while a Puppet Agent run is in-progress, wait for completi
 
   step 'Wait until Puppet starts executing' do
     agents.each do |agent|
-      wait_for_sleep_process(agent)
+      wait_for_sleep_process(agent, SECONDS_TO_SLEEP)
     end
   end
 
@@ -51,7 +51,7 @@ test_name 'Run Puppet while a Puppet Agent run is in-progress, wait for completi
   end
 
   step 'Signal sleep process to end so 1st Puppet run will complete' do
-    stop_sleep_process(agents)
+    stop_sleep_process(agents, SECONDS_TO_SLEEP)
   end
 
   target_identities.zip(transaction_ids).each do |identity, transaction_id|

--- a/acceptance/tests/pxp-module-puppet/run_puppet_killed_puppet.rb
+++ b/acceptance/tests/pxp-module-puppet/run_puppet_killed_puppet.rb
@@ -38,7 +38,7 @@ test_name 'Run Puppet while a Puppet Agent run is in-progress, wait for it to be
 
   step 'Wait until Puppet starts executing' do
     agents.each do |agent|
-      wait_for_sleep_process(agent)
+      wait_for_sleep_process(agent, SECONDS_TO_SLEEP)
     end
   end
 
@@ -54,7 +54,7 @@ test_name 'Run Puppet while a Puppet Agent run is in-progress, wait for it to be
 
   teardown do
     # Make sure we stop sleep processes when the test finishes, to avoid leaving stranded processes running.
-    stop_sleep_process(agents)
+    stop_sleep_process(agents, SECONDS_TO_SLEEP)
   end
 
   agents.each do |agent|

--- a/acceptance/tests/pxp-module-puppet/run_puppet_twice.rb
+++ b/acceptance/tests/pxp-module-puppet/run_puppet_twice.rb
@@ -13,7 +13,7 @@ test_name 'Run Puppet while a Puppet Agent run is in-progress, wait for completi
   environment_name = mk_tmp_environment(env_name)
 
   teardown do
-    stop_sleep_process(agents, true)
+    stop_sleep_process(agents, SECONDS_TO_SLEEP, true)
   end
 
   step 'On master, create a new environment that will result in a slow run' do
@@ -47,7 +47,7 @@ test_name 'Run Puppet while a Puppet Agent run is in-progress, wait for completi
 
   step 'Wait until Puppet starts executing' do
     agents.each do |agent|
-      wait_for_sleep_process(agent)
+      wait_for_sleep_process(agent, SECONDS_TO_SLEEP)
     end
   end
 
@@ -113,7 +113,7 @@ test_name 'Run Puppet while a Puppet Agent run is in-progress, wait for completi
   end
 
   step 'Signal sleep process to end so 1st Puppet run will complete' do
-    stop_sleep_process(agents)
+    stop_sleep_process(agents, SECONDS_TO_SLEEP)
   end
 
   target_identities.zip(transaction_ids).each do |identity, transaction_id|


### PR DESCRIPTION
On our AIX 7.1 machines, there's a pre-existing sleep process that's
constantly renewed. Make the check for the sleep process we expect from
Puppet more specific, so we don't falsely identify the wrong one.

[skip ci]