### PR TITLE
(PCP-789) Add input_method: powershell for .ps1 files

### DIFF
--- a/acceptance/files/complex-args.json
+++ b/acceptance/files/complex-args.json
@@ -1,0 +1,28 @@
+{
+  "argstring": "hello all",
+  "argint32": 5,
+  "argfloat": 42.42,
+  "arghashtable": {
+    "key": "value",
+    "key2": 2,
+    "key3": true
+  },
+  "argarray": [0, "foo", true, { "key": "value" }],
+  "argarrayofhashes": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 3.7.0 < 6.0.0"
+    },
+    {
+      "name": "pe",
+      "version_requirement": ">= 5.0.0"
+    }
+  ],
+  "argfileinfo": "/Users/foo/source/puppet/Gemfile",
+  "argbool": false,
+  "argtimespan": "12:34:56",
+  "argdatetime": "9/8/2017 2:23:59 PM",
+  "argguid": "74be6039-e777-45fe-aa56-3d356443e096",
+  "argregex": "^http:\\/\\/",
+  "argswitch": true
+}

--- a/acceptance/files/complex-output
+++ b/acceptance/files/complex-output
@@ -1,0 +1,50 @@
+Defined with arguments:
+* ArgArray of type array
+* ArgArrayOfHashes of type hashtable[]
+* ArgBool of type bool
+* ArgDateTime of type datetime
+* ArgFileInfo of type System.IO.FileInfo
+* ArgFloat of type float
+* ArgGuid of type guid
+* ArgHashtable of type hashtable
+* ArgInt32 of type int
+* ArgRegex of type regex
+* ArgString of type string
+* ArgSwitch of type switch
+* ArgTimeSpan of type timespan
+
+Received arguments:
+* ArgArray (System.Object[]):
+0
+foo
+True
+key: value
+* ArgArrayOfHashes (hashtable[]):
+name: puppet
+version_requirement: >= 3.7.0 < 6.0.0
+name: pe
+version_requirement: >= 5.0.0
+* ArgBool (bool):
+False
+* ArgDateTime (datetime):
+9/8/2017 2:23:59 PM
+* ArgFileInfo (System.IO.FileInfo):
+/Users/foo/source/puppet/Gemfile
+* ArgFloat (float):
+42.42
+* ArgGuid (guid):
+74be6039-e777-45fe-aa56-3d356443e096
+* ArgHashtable (hashtable):
+key: value
+key2: 2
+key3: True
+* ArgInt32 (int):
+5
+* ArgRegex (regex):
+^http:\/\/
+* ArgString (string):
+hello all
+* ArgSwitch (switch):
+True
+* ArgTimeSpan (timespan):
+12:34:56

--- a/acceptance/files/complex-task.ps1
+++ b/acceptance/files/complex-task.ps1
@@ -1,0 +1,107 @@
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $True)]
+  [string]
+  $ArgString,
+
+  [Parameter(Mandatory = $False)]
+  [Int32] # aka [Int]
+  $ArgInt32,
+
+  [Parameter(Mandatory = $False)]
+  [Float] # aka [Single]
+  $ArgFloat,
+
+  [Parameter(Mandatory = $False)]
+  [Hashtable]
+  $ArgHashtable,
+
+  [Parameter(Mandatory = $False)]
+  [Array]
+  $ArgArray,
+
+  [Parameter(Mandatory = $False)]
+  [Hashtable[]] # any array of type[] should work
+  $ArgArrayOfHashes,
+
+  [Parameter(Mandatory = $False)]
+  [IO.FileInfo] # aka a file path
+  $ArgFileInfo,
+
+  [Parameter(Mandatory = $False)]
+  [Bool]
+  $ArgBool,
+
+  [Parameter(Mandatory = $False)]
+  [TimeSpan]
+  $ArgTimeSpan,
+
+  [Parameter(Mandatory = $False)]
+  [DateTime]
+  $ArgDateTime,
+
+  [Parameter(Mandatory = $False)]
+  [Guid]
+  $ArgGuid,
+
+  [Parameter(Mandatory = $False)]
+  [Regex]
+  $ArgRegex,
+
+  [Parameter(Mandatory = $False)]
+  [Switch]
+  $ArgSwitch
+)
+
+function ConvertTo-String
+{
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $True, ValueFromPipeline = $True)]
+    $Object
+  )
+
+  begin
+  {
+    $outputs = @()
+  }
+  process
+  {
+    if ($Object -is [Hashtable])
+    {
+      $outputs += (HashtableTo-String $Object)
+    }
+    else
+    {
+      $outputs += $Object
+    }
+  }
+  end
+  {
+    $outputs -join "`n"
+  }
+}
+
+function HashtableTo-String
+{
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $True, ValueFromPipeline = $True)]
+    [Hashtable]
+    $Hashtable
+  )
+
+  ($Hashtable.GetEnumerator() | Sort-Object -Property Key | % { "$($_.Key): $($_.Value)" }) -join "`n"
+}
+
+Write-Output "Defined with arguments:"
+
+$PSCmdlet.MyInvocation.MyCommand.Parameters.GetEnumerator() | Sort-Object -Property Key | Where-Object { $_.Key -match "Arg.+" } | % {
+  Write-Output "* $($_.Key) of type $($_.Value.ParameterType)"
+}
+
+Write-Output "`nReceived arguments:"
+
+$PSBoundParameters.GetEnumerator() | Sort-Object -Property Key | % {
+  Write-Output "* $($_.Key) ($($_.Value.GetType())):`n$($_.Value | ConvertTo-String)"
+}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,7 @@ install:
   - choco install -y pl-openssl-x64 -Version 1.0.24.1 -source https://www.myget.org/F/puppetlabs
   - choco install -y pl-curl-x64 -Version 7.46.0.1 -source https://www.myget.org/F/puppetlabs
   - choco install -y pl-zlib-x64 -Version 1.2.8.1 -source https://www.myget.org/F/puppetlabs
+  - choco install -y pester --pre
 
     # Minimize environment polution; previously we were linking against the wrong OpenSSL DLLs.
     # Include Ruby and Powershell for unit tests.
@@ -32,3 +33,5 @@ test_script:
   - ps: cp C:\Tools\pl-build-tools\bin\libeay32.dll .\bin
   - ps: cp C:\Tools\pl-build-tools\bin\ssleay32.dll .\bin
   - ps: ctest -V 2>&1 | %{ if ($_ -is [System.Management.Automation.ErrorRecord]) { $_ | c++filt } else { $_ } }
+  - ps: type ./acceptance/files/complex-args.json | ./exe/PowershellShim.ps1 ./acceptance/files/complex-task.ps1
+  - ps: Invoke-Pester -EnableExit

--- a/exe/CMakeLists.txt
+++ b/exe/CMakeLists.txt
@@ -23,14 +23,16 @@ add_executable(task_wrapper-tests tests/main.cc)
 target_link_libraries(task_wrapper-tests ${TASK_WRAPPER_LIBS})
 
 # Copy powershell shim to bin so we can use with local testing.
-set(POWERSHELL_SHIM ${CMAKE_BINARY_DIR}/bin/powershell_shim.ps1)
-add_custom_command(
-    OUTPUT ${POWERSHELL_SHIM}
-    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/powershell_shim.ps1 ${POWERSHELL_SHIM}
-    DEPENDS powershell_shim.ps1)
-add_custom_target(powershell_shim ALL DEPENDS ${POWERSHELL_SHIM})
-install(FILES powershell_shim.ps1 DESTINATION bin
-    PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+foreach(shim PowershellShim.ps1 PowershellShim-Helper.ps1)
+    set(shim_local ${CMAKE_BINARY_DIR}/bin/${shim})
+    add_custom_command(
+        OUTPUT ${shim_local}
+        COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/${shim} ${shim_local}
+        DEPENDS ${shim})
+    add_custom_target(${shim} ALL DEPENDS ${shim_local})
+    install(FILES ${shim} DESTINATION bin
+        PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+endforeach(shim)
 
 add_test(
     NAME "task\\ wrapper\\ tests"

--- a/exe/CMakeLists.txt
+++ b/exe/CMakeLists.txt
@@ -22,6 +22,16 @@ install(TARGETS task_wrapper DESTINATION bin)
 add_executable(task_wrapper-tests tests/main.cc)
 target_link_libraries(task_wrapper-tests ${TASK_WRAPPER_LIBS})
 
+# Copy powershell shim to bin so we can use with local testing.
+set(POWERSHELL_SHIM ${CMAKE_BINARY_DIR}/bin/powershell_shim.ps1)
+add_custom_command(
+    OUTPUT ${POWERSHELL_SHIM}
+    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/powershell_shim.ps1 ${POWERSHELL_SHIM}
+    DEPENDS powershell_shim.ps1)
+add_custom_target(powershell_shim ALL DEPENDS ${POWERSHELL_SHIM})
+install(FILES powershell_shim.ps1 DESTINATION bin
+    PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+
 add_test(
     NAME "task\\ wrapper\\ tests"
     COMMAND "${EXECUTABLE_OUTPUT_PATH}/task_wrapper-tests"

--- a/exe/PowershellShim.ps1
+++ b/exe/PowershellShim.ps1
@@ -1,0 +1,24 @@
+#!/usr/bin/env powershell
+#requires -version 2.0
+
+try {
+  $here = (Split-Path -Parent $MyInvocation.MyCommand.Path)
+  . $here\PowershellShim-Helper.ps1
+
+  $scriptArgsHash = Get-ContentAsJson ($input -join "")
+
+  Write-Debug "`nTask-shim deserialized arguments to Hashtable:`n"
+
+  if ($scriptArgsHash) {
+    $scriptArgsHash.GetEnumerator() | % {
+      Write-Debug "* $($_.Key) ($($_.Value.GetType())):`n$($_.Value | ConvertTo-String)"
+    }
+  }
+
+  & $args[0] @scriptArgsHash
+
+} catch {
+  Write-Error $_
+  if ($LASTEXITCODE -eq $null) { $LASTEXITCODE = 1 }
+}
+exit $LASTEXITCODE

--- a/exe/README.md
+++ b/exe/README.md
@@ -1,0 +1,8 @@
+# PowerShell Shim Testing
+
+A simple smoke test can be run on any platform with PowerShell via
+```
+type ../acceptance/files/complex-args.json | ./PowershellShim.ps1 ../acceptance/files/complex-task.ps1
+```
+
+More complete tests can be run via [Pester](https://github.com/pester/Pester), which will exercise PowerShell 2 code paths.

--- a/exe/powershell_shim.ps1
+++ b/exe/powershell_shim.ps1
@@ -1,0 +1,236 @@
+#!/usr/bin/env powershell
+#requires -version 2.0
+
+# Based on v 1.7 of the JSON_1.7.psm1 from
+#
+#  > $Json = Get-Process |
+#  >> Select PM, WS, CPU, ID, ProcessName, @{n="SnapshotTime";e={Get-Date}} |
+#  >> ConvertTo-Json -NoType
+#
+#  > $Json | ConvertFrom-json -Type PSObject
+
+try {
+
+Add-Type -AssemblyName System.ServiceModel.Web, System.Runtime.Serialization
+$utf8 = [System.Text.Encoding]::UTF8
+
+function Write-Stream {
+  PARAM(
+    [Parameter(Position=0)] $stream,
+    [Parameter(ValueFromPipeline=$true)] $string
+  )
+  PROCESS {
+    $bytes = $utf8.GetBytes($string)
+    $stream.Write( $bytes, 0, $bytes.Length )
+  }
+}
+
+function Convert-JsonToXml {
+  PARAM([Parameter(ValueFromPipeline=$true)] [string[]] $json)
+  BEGIN {
+    $mStream = New-Object System.IO.MemoryStream
+  }
+  PROCESS {
+    $json | Write-Stream -Stream $mStream
+  }
+  END {
+    $mStream.Position = 0
+    try {
+      $jsonReader = [System.Runtime.Serialization.Json.JsonReaderWriterFactory]::CreateJsonReader($mStream,[System.Xml.XmlDictionaryReaderQuotas]::Max)
+      $xml = New-Object Xml.XmlDocument
+      $xml.Load($jsonReader)
+      $xml
+    } finally {
+      $jsonReader.Close()
+      $mStream.Dispose()
+    }
+  }
+}
+
+Function ConvertFrom-Xml {
+  [CmdletBinding(DefaultParameterSetName="AutoType")]
+  PARAM(
+    [Parameter(ValueFromPipeline=$true,Mandatory=$true,Position=1)] [Xml.XmlNode] $xml,
+    [Parameter(Mandatory=$true,ParameterSetName="ManualType")] [Type] $Type,
+    [Switch] $ForceType
+  )
+  PROCESS{
+    if (Get-Member -InputObject $xml -Name root) {
+      return $xml.root.Objects | ConvertFrom-Xml
+    } elseif (Get-Member -InputObject $xml -Name Objects) {
+      return $xml.Objects | ConvertFrom-Xml
+    }
+    $propbag = @{}
+    foreach ($name in Get-Member -InputObject $xml -MemberType Properties | Where-Object{$_.Name -notmatch "^__|type"} | Select-Object -ExpandProperty name) {
+      Write-Debug "$Name Type: $($xml.$Name.type)" -Debug:$false
+      $propbag."$Name" = Convert-Properties $xml."$name"
+    }
+    if (!$Type -and $xml.HasAttribute("__type")) { $Type = $xml.__Type }
+    if ($ForceType -and $Type) {
+      try {
+        $output = New-Object $Type -Property $propbag
+      } catch {
+        $output = New-Object PSObject -Property $propbag
+        $output.PsTypeNames.Insert(0, $xml.__type)
+      }
+    } elseif ($propbag.Count -ne 0) {
+      $output = New-Object PSObject -Property $propbag
+      if ($Type) {
+        $output.PsTypeNames.Insert(0, $Type)
+      }
+    }
+    return $output
+  }
+}
+
+Function Convert-Properties {
+  PARAM($InputObject)
+  switch ($InputObject.type) {
+    "object" {
+      return (ConvertFrom-Xml -Xml $InputObject)
+    }
+    "string" {
+      $MightBeADate = $InputObject.get_InnerText() -as [DateTime]
+      ## Strings that are actually dates (*grumble* JSON is crap)
+      if ($MightBeADate -and $propbag."$Name" -eq $MightBeADate.ToString("G")) {
+        return $MightBeADate
+      } else {
+        return $InputObject.get_InnerText()
+      }
+    }
+    "number" {
+      $number = $InputObject.get_InnerText()
+      if ($number -eq ($number -as [int])) {
+        return $number -as [int]
+      } elseif ($number -eq ($number -as [double])) {
+        return $number -as [double]
+      } else {
+        return $number -as [decimal]
+      }
+    }
+    "boolean" {
+      return [bool]::parse($InputObject.get_InnerText())
+    }
+    "null" {
+      return $null
+    }
+    "array" {
+      [object[]]$Items = $(foreach( $item in $InputObject.GetEnumerator() ) {
+        Convert-Properties $item
+      })
+      return $Items
+    }
+    default {
+      return $InputObject
+    }
+  }
+}
+
+Function ConvertFrom-Json2 {
+  [CmdletBinding()]
+  PARAM(
+    [Parameter(ValueFromPipeline=$true,Mandatory=$true,Position=1)] [string] $InputObject,
+    [Parameter(Mandatory=$true)] [Type] $Type,
+    [Switch] $ForceType
+  )
+  PROCESS {
+    $null = $PSBoundParameters.Remove("InputObject")
+    [Xml.XmlElement]$xml = (Convert-JsonToXml $InputObject).Root
+    if ($xml) {
+      if ($xml.Objects) {
+        $xml.Objects.Item.GetEnumerator() | ConvertFrom-Xml @PSBoundParameters
+      } elseif ($xml.Item -and $xml.Item -isnot [System.Management.Automation.PSParameterizedProperty]) {
+        $xml.Item | ConvertFrom-Xml @PSBoundParameters
+      } else {
+        $xml | ConvertFrom-Xml @PSBoundParameters
+      }
+    } else {
+      Write-Error "Failed to parse JSON with JsonReader" -Debug:$false
+    }
+  }
+}
+
+function Get-ContentAsJson
+{
+  [CmdletBinding()]
+  PARAM(
+    [Parameter(Mandatory = $true)] $Text,
+    [Parameter(Mandatory = $false)] [Text.Encoding] $Encoding = [Text.Encoding]::UTF8
+  )
+
+  # using polyfill cmdlet on PS2, so pass type info
+  if ($PSVersionTable.PSVersion -lt [Version]'3.0') {
+    $Text | ConvertFrom-Json2 -Type PSObject
+  } else {
+    $Text | ConvertFrom-Json
+  }
+}
+
+function ConvertFrom-PSCustomObject
+{
+  PARAM([Parameter(ValueFromPipeline = $true)] $InputObject)
+  PROCESS {
+    if ($null -eq $InputObject) { return $null }
+
+    if ($InputObject -is [System.Collections.IEnumerable] -and $InputObject -isnot [string]) {
+      $collection = @(
+        foreach ($object in $InputObject) { ConvertFrom-PSCustomObject $object }
+      )
+
+      $collection
+    } elseif ($InputObject -is [System.Management.Automation.PSCustomObject]) {
+      $hash = @{}
+      foreach ($property in $InputObject.PSObject.Properties) {
+        $hash[$property.Name] = ConvertFrom-PSCustomObject $property.Value
+      }
+
+      $hash
+    } else {
+      $InputObject
+    }
+  }
+}
+
+function ConvertTo-String
+{
+  [CmdletBinding()]
+  PARAM([Parameter(Mandatory = $True, ValueFromPipeline = $True)] $Object)
+  BEGIN {
+    $outputs = @()
+  }
+  PROCESS {
+    if ($Object -is [Hashtable]) {
+      $outputs += (HashtableTo-String $Object)
+    } else {
+      $outputs += $Object
+    }
+  } end {
+    $outputs -join "`n"
+  }
+}
+
+function HashtableTo-String
+{
+  [CmdletBinding()]
+  PARAM([Parameter(Mandatory = $True, ValueFromPipeline = $True)] [Hashtable] $Hashtable)
+
+  ($Hashtable.GetEnumerator() | % { "$($_.Key): $($_.Value)" }) -join "`n"
+}
+
+$scriptArgsHash = Get-ContentAsJson ($input -join "") | ConvertFrom-PSCustomObject
+
+Write-Debug "`nTask-shim deserialized arguments to Hashtable:`n"
+
+if ($scriptArgsHash) {
+  $scriptArgsHash.GetEnumerator() | % {
+    Write-Debug "* $($_.Key) ($($_.Value.GetType())):`n$($_.Value | ConvertTo-String)"
+  }
+}
+
+& $args[0] @scriptArgsHash
+
+} catch {
+  Write-Error $_
+  if ($LASTEXITCODE -eq $null) { $LASTEXITCODE = 1 }
+}
+exit $LASTEXITCODE

--- a/exe/tests/PowershellShim.Tests.ps1
+++ b/exe/tests/PowershellShim.Tests.ps1
@@ -1,0 +1,43 @@
+. $PSScriptRoot\..\PowershellShim-Helper.ps1
+
+Describe 'ConvertFrom-Json2 | ConvertFrom-PSCustomObject' {
+  It 'Given an empty string, will return an empty object' {
+    $result = '{}' | ConvertFrom-Json2 -Type PSObject | ConvertFrom-PSCustomObject
+    $result | Should -Be $null
+  }
+
+  It 'Given boolean json, should return a hash containing a boolean' {
+    $result = '{"boolKey": true}' | ConvertFrom-Json2 -Type PSObject | ConvertFrom-PSCustomObject
+    $result.Count | Should -Be 1
+    $result['boolKey'] | Should -Be $true
+  }
+
+  It 'Given integer json, should return a hash containing an int' {
+    $result = '{"intKey": 5}' | ConvertFrom-Json2 -Type PSObject | ConvertFrom-PSCustomObject
+    $result.Count | Should -Be 1
+    $result['intKey'] | Should -Be 5
+  }
+
+  It 'Given float json, should return a hash containing a float' {
+    $result = '{"floatKey": 5.5}' | ConvertFrom-Json2 -Type PSObject | ConvertFrom-PSCustomObject
+    $result.Count | Should -Be 1
+    $result['floatKey'] | Should -Be 5.5
+  }
+
+  It 'Given string json, should return a hash containing a string' {
+    $result = '{"stringKey": "hello world"}' | ConvertFrom-Json2 -Type PSObject | ConvertFrom-PSCustomObject
+    $result.Count | Should -Be 1
+    $result['stringKey'] | Should -Be "hello world"
+  }
+
+  It 'Given array json, should return a hash containing the array' {
+    $result = Get-ContentAsJson '{"arrayOfHashes": [{"name": "puppet", "version": 42}, {"name": "pe", "version": 2015}]}'
+    $result.Count | Should -Be 1
+    $arr = $result['arrayOfHashes']
+    $arr.Count | Should -Be 2
+    $arr[0]['name'] | Should -Be 'puppet'
+    $arr[0]['version'] | Should -Be 42
+    $arr[1]['name'] | Should -Be 'pe'
+    $arr[1]['version'] | Should -Be 2015
+  }
+}

--- a/lib/inc/pxp-agent/modules/task.hpp
+++ b/lib/inc/pxp-agent/modules/task.hpp
@@ -42,7 +42,9 @@ class Task : public PXPAgent::Module {
   private:
     ResultsStorage storage_;
 
-    std::string task_cache_dir_, wrapper_executable_;
+    std::string task_cache_dir_;
+
+    boost::filesystem::path exec_prefix_;
 
     std::vector<std::string> master_uris_;
 

--- a/lib/src/modules/task.cc
+++ b/lib/src/modules/task.cc
@@ -445,7 +445,7 @@ ActionResponse Task::callAction(const ActionRequest& request)
 
     if (task_input_method == "powershell") {
         // Run using the powershell shim
-        task_command = getTaskCommand(exec_prefix_ / "powershell_shim.ps1");
+        task_command = getTaskCommand(exec_prefix_ / "PowershellShim.ps1");
         task_command.arguments.push_back(task_file.string());
         // Pass input on stdin ($input)
         task_input = task_execution_params.get<lth_jc::JsonContainer>("input").toString();


### PR DESCRIPTION
By default invokes .ps1 files (and any that request input_method: powershell) with a shim that parses JSON into named params. Includes acceptance tests.