### PR TITLE
(PCP-789) Remove DateTime from testing

### DIFF
--- a/acceptance/files/complex-args.json
+++ b/acceptance/files/complex-args.json
@@ -21,7 +21,6 @@
   "argfileinfo": "/Users/foo/source/puppet/Gemfile",
   "argbool": false,
   "argtimespan": "12:34:56",
-  "argdatetime": "9/8/2017 2:23:59 PM",
   "argguid": "74be6039-e777-45fe-aa56-3d356443e096",
   "argregex": "^http:\\/\\/",
   "argswitch": true

--- a/acceptance/files/complex-output
+++ b/acceptance/files/complex-output
@@ -2,7 +2,6 @@ Defined with arguments:
 * ArgArray of type array
 * ArgArrayOfHashes of type hashtable[]
 * ArgBool of type bool
-* ArgDateTime of type datetime
 * ArgFileInfo of type System.IO.FileInfo
 * ArgFloat of type float
 * ArgGuid of type guid
@@ -26,8 +25,6 @@ name: pe
 version_requirement: >= 5.0.0
 * ArgBool (bool):
 False
-* ArgDateTime (datetime):
-9/8/2017 2:23:59 PM
 * ArgFileInfo (System.IO.FileInfo):
 /Users/foo/source/puppet/Gemfile
 * ArgFloat (float):

--- a/acceptance/files/complex-task.ps1
+++ b/acceptance/files/complex-task.ps1
@@ -37,10 +37,6 @@ param(
   $ArgTimeSpan,
 
   [Parameter(Mandatory = $False)]
-  [DateTime]
-  $ArgDateTime,
-
-  [Parameter(Mandatory = $False)]
   [Guid]
   $ArgGuid,
 

--- a/acceptance/tests/tasks/run_ps1.rb
+++ b/acceptance/tests/tasks/run_ps1.rb
@@ -33,7 +33,6 @@ test_name 'run powershell task' do
     task_output = File.read(File.join(fixtures, 'complex-output'))
     run_successful_task(master, windows_hosts, 'echo', 'init.ps1', @sha256, task_input) do |stdout|
       # Handle some known variations
-      stdout.gsub!(/System\.DateTime/, 'datetime')
       stdout.gsub!(/System\.Guid/, 'guid')
       stdout.gsub!(/System\.TimeSpan/, 'timespan')
 


### PR DESCRIPTION
This varies a lot across platforms and locales, and is marginally
interesting. Remove from testing rather than add more complex handling
of it.

[skip ci]