### PR TITLE
(maint) Fix local tmp dir creation

### DIFF
--- a/acceptance/Rakefile
+++ b/acceptance/Rakefile
@@ -84,12 +84,14 @@ EOS
   if target && !target.start_with?(master_host)
     target = "#{master_host}-#{target}"
   end
+
+  # Tests depend on this dir existing, always create it
+  FileUtils.mkdir_p('tmp')
   if config and File.exists?(config)
     config_opt = "--hosts=#{config}"
   elsif target
     cli = BeakerHostGenerator::CLI.new([target, '--disable-default-role', '--osinfo-version', '1'])
     ENV['BEAKER_HOSTS'] = "tmp/#{target}-#{SecureRandom.uuid}.yaml"
-    FileUtils.mkdir_p('tmp')
     File.open(config, 'w') do |fh|
       fh.print(cli.execute)
     end

--- a/acceptance/setup/aio/010_Install.rb
+++ b/acceptance/setup/aio/010_Install.rb
@@ -4,7 +4,8 @@ extend Beaker::DSL::InstallUtils
 
 test_name "Install Packages"
 
-dev_builds_url = ENV['DEV_BUILDS_URL'] || 'http://builds.delivery.puppetlabs.net'
+DEFAULT_BUILDS_URL = 'http://builds.delivery.puppetlabs.net'
+dev_builds_url = ENV['DEV_BUILDS_URL'] || DEFAULT_BUILDS_URL
 
 step "Install puppet-agent..." do
   if dev_builds_url == 'http://builds.delivery.puppetlabs.net'
@@ -30,17 +31,12 @@ step "Install puppetserver..." do
       on(master, "rpm -Uvh https://yum.puppetlabs.com/puppet5-release-el-#{version}.noarch.rpm")
     end
   else
-    if ENV['SERVER_VERSION'] && ENV['SERVER_VERSION'] != 'latest' && dev_builds_url == 'http://builds.delivery.puppetlabs.net'
+    if ENV['SERVER_VERSION'] && ENV['SERVER_VERSION'] != 'latest' && dev_builds_url == DEFAULT_BUILDS_URL
       install_from_build_data_url('puppetserver', "#{dev_builds_url}/puppetserver/#{ENV['SERVER_VERSION']}/artifacts/#{ENV['SERVER_VERSION']}.yaml", master)
     else
-      if ENV['SERVER_VERSION'].nil? || ENV['SERVER_VERSION'] == 'latest'
-        server_version = ''
-        project = 'puppetserver-latest'
-      else
-        server_version = ENV['SERVER_VERSION']
-        project = 'puppetserver'
-      end
-      install_puppetlabs_dev_repo(master, project, server_version, nil, :dev_builds_url => dev_builds_url)
+      dev_builds_url = 'https://nightlies.puppetlabs.com' if dev_builds_url == DEFAULT_BUILDS_URL
+      server_version = ENV['SERVER_VERSION'] || 'latest'
+      install_puppetlabs_dev_repo(master, 'puppetserver', server_version, nil, :dev_builds_url => dev_builds_url)
       master.install_package('puppetserver')
     end
   end


### PR DESCRIPTION
Test setup depends on a local tmp dir existing. We create it when
generating a hosts file, and used to create it when installing the
puppet-agent package. We no longer create it for install, but still use
it for testing and the hosts file. Ensure it's always created in the
Rakefile so it's available during setup.