### PR TITLE
(maint) Ensure EntryBase is correctly destroyed

### DIFF
--- a/lib/inc/pxp-agent/configuration.hpp
+++ b/lib/inc/pxp-agent/configuration.hpp
@@ -54,6 +54,8 @@ struct EntryBase
               help { std::move(_help) },
               type { std::move(_type) } {
     }
+
+    virtual ~EntryBase() = default;
 };
 
 template <typename T>


### PR DESCRIPTION
Previously members of EntryBase would not be correcty destructed when an
Entry is destroyed. Add a virtual destructor to ensure that happens.