### PR TITLE
(maint) Fix acceptance teardown on Cisco NX

### DIFF
--- a/acceptance/teardown/common/099_Archive_Logs.rb
+++ b/acceptance/teardown/common/099_Archive_Logs.rb
@@ -6,6 +6,10 @@ step 'Archive files created during tests' do
 
   ## Copy file(s) from agents
   agents.each do |agent|
+    if agent['platform'] =~ /cisco_nexus/
+      # On Cisco, we don't login as root
+      on agent, "chmod -R 777 #{logdir(agent)}"
+    end
     archive_file_from(agent, logdir(agent))
   end
 end


### PR DESCRIPTION
On Cisco NX we don't login as root. However, pxp-agent runs as root and
restricts permissions on the logdir to root owner and group.

Ensure logdir is readable by login user before attempting to copy it
back.