### PR TITLE
(PCP-792) Update non-root paths to be consistent with spec

### DIFF
--- a/locales/pxp-agent.pot
+++ b/locales/pxp-agent.pot
@@ -145,11 +145,11 @@ msgid "PCP connection established; about to start monitoring it"
 msgstr ""
 
 #: lib/src/configuration.cc
-msgid "failure getting Windows AppData directory: {1}"
+msgid "failure getting HOME directory"
 msgstr ""
 
 #: lib/src/configuration.cc
-msgid "failure getting HOME directory"
+msgid "failure getting Windows AppData directory: {1}"
 msgstr ""
 
 #: lib/src/configuration.cc


### PR DESCRIPTION
Paths for non-root pxp-agent in puppet-specifications differ because the
original implementation of this wasn't consistent with patterns used for
Facter and Puppet. Make the defaults consistent with
puppet-specifications.