### PR TITLE
(PCP-511) Add iconv dependency for libpxp-agent

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -72,6 +72,11 @@ if (CMAKE_SYSTEM_NAME MATCHES "Linux" OR CMAKE_SYSTEM_NAME MATCHES "SunOS" OR CM
     list(APPEND LIBS rt ${CMAKE_THREAD_LIBS_INIT})
 endif()
 
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND BOOST_STATIC AND LEATHERMAN_USE_LOCALES)
+    # Needed with cpp-hocon using Boost.Locale
+    list(APPEND LIBS iconv)
+endif()
+
 add_library(libpxp-agent STATIC ${LIBRARY_COMMON_SOURCES} ${LIBRARY_STANDARD_SOURCES})
 add_dependencies(libpxp-agent horsewhisperer)
 target_link_libraries(libpxp-agent ${LIBS})


### PR DESCRIPTION
libpxp-agent now uses libcpp-hocon, which introduces a dependency on
Boost.Locale. On macOS that requires linking iconv. Include it as a
public dependency of libpxp-agent so it's incorporated into binaries
that link against it (pxp-agent and pxp-agent-unittests).