### PR TITLE
(PCP-585) Re-enable restart test on Fedora

### DIFF
--- a/acceptance/tests/restart_host_run_puppet.rb
+++ b/acceptance/tests/restart_host_run_puppet.rb
@@ -19,16 +19,6 @@ test_name 'C94777 - Ensure pxp-agent functions after agent host restart' do
     skip_test('RE-7673 - Arista hosts cannot be restarted')
   end
 
-  # QENG-4371, PCP-585 The fedora hosts in our VM Pooler consistently take 10+
-  # minutes to reboot, causing this test to fail sporadically (~20% of the
-  # time). Additionally, after reboot, sporadically we see failures of the PCP
-  # agent to connect to the broker (PCP-585). Until these issues are ironed
-  # out, we disable running against Fedora
-  applicable_agents = applicable_agents.select { |agent| agent['platform'] !~ /fedora/ }
-  unless applicable_agents.length > 0 then
-    skip_test('QENG-4371 - Fedora hosts reboot time exceeds test timeout')
-  end
-
   applicable_agents = applicable_agents.select { |agent| agent['platform'] !~ /huaweios/}
   unless applicable_agents.length > 0 then
     skip_test('BKR-958 - Huawei hosts cannot be restarted')


### PR DESCRIPTION
We've gone through several fedora releases, and made some fixes to make
pxp-agent tests more reliable. Enable the test and see how they do.

[skip ci]