### PR TITLE
(PCP-511) Use HOCON configuration syntax

### DIFF
--- a/lib/tests/resources/config/bad-broker.conf
+++ b/lib/tests/resources/config/bad-broker.conf
@@ -1,3 +1,1 @@
-{
-    "broker-ws-uris" : ["//test_pcp_broker"]
-}
+broker-ws-uris: ["//test_pcp_broker"]

--- a/lib/tests/resources/config/bad-master.conf
+++ b/lib/tests/resources/config/bad-master.conf
@@ -1,3 +1,1 @@
-{
-    "master-uris" : ["http://test_master"]
-}
+master-uris: ["http://test_master"]

--- a/lib/tests/resources/config/duplicate.conf
+++ b/lib/tests/resources/config/duplicate.conf
@@ -1,4 +1,2 @@
-{
-    "broker-ws-uri" : "wss://test_pcp_broker",
-    "broker-ws-uris" : ["wss://test_pcp_broker", "wss://alt_pcp_broker"]
-}
+broker-ws-uri: "wss://test_pcp_broker"
+broker-ws-uris: ["wss://test_pcp_broker", "wss://alt_pcp_broker"]

--- a/lib/tests/resources/config/multi-broker.conf
+++ b/lib/tests/resources/config/multi-broker.conf
@@ -1,4 +1,2 @@
-{
-    "broker-ws-uris" : ["wss://test_pcp_broker", "wss://alt_pcp_broker"],
-    "master-uris" : ["test_master:8140", "https://alt_master"]
-}
+broker-ws-uris: ["wss://test_pcp_broker", "wss://alt_pcp_broker"]
+master-uris: ["test_master:8140", "https://alt_master"]


### PR DESCRIPTION
Take advantage of the recently added support for using the HOCON syntax in the configuration files in the configuration files used in unit test.