### PR TITLE
(PCP-511) Generate HOCON config file

### DIFF
--- a/acceptance/lib/pxp-agent/task_helper.rb
+++ b/acceptance/lib/pxp-agent/task_helper.rb
@@ -1,5 +1,4 @@
 require 'pxp-agent/test_helper.rb'
-require 'json'
 require 'digest'
 
 def run_task(broker, target_identities, task, filename, sha256, input, path, rpc_request, expected_response_type, &check_datas)

--- a/acceptance/tests/failover/intentional_shutdown_failover.rb
+++ b/acceptance/tests/failover/intentional_shutdown_failover.rb
@@ -15,7 +15,7 @@ test_name 'C97934 - agent should use next broker if primary is intentionally shu
       on agent, puppet('resource service pxp-agent ensure=stopped')
       num_brokers = 2
       pxp_config = pxp_config_hash_using_puppet_certs(master, agent, num_brokers)
-      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config.to_json.to_s)
+      create_remote_file(agent, pxp_agent_config_file(agent), to_hocon(pxp_config))
       reset_logfile(agent)
       on agent, puppet('resource service pxp-agent ensure=running')
 

--- a/acceptance/tests/failover/timeout_failover.rb
+++ b/acceptance/tests/failover/timeout_failover.rb
@@ -19,7 +19,7 @@ test_name 'C97964 - agent should use next broker if primary is timing out' do
       # Should attempt to reconnect in ~10 seconds.
       pxp_config['allowed-keepalive-timeouts'] = 0
       pxp_config['ping-interval'] = 6
-      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config.to_json.to_s)
+      create_remote_file(agent, pxp_agent_config_file(agent), to_hocon(pxp_config))
       reset_logfile(agent)
       on agent, puppet('resource service pxp-agent ensure=running')
 

--- a/acceptance/tests/multiple_pxp_agent_daemon.rb
+++ b/acceptance/tests/multiple_pxp_agent_daemon.rb
@@ -24,7 +24,7 @@ test_name 'Start pxp-agent daemon with pidfile present' do
   step 'Ensure each agent host has pxp-agent service running and enabled' do
     applicable_agents.each do |agent|
       on agent, puppet('resource service pxp-agent ensure=stopped')
-      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
+      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_hocon_using_puppet_certs(master, agent))
       on agent, puppet('resource service pxp-agent ensure=running enable=true')
 
       assert(is_associated?(master, "pcp://#{agent}/agent"),

--- a/acceptance/tests/pxp-module-puppet/negative/attempt_puppet_flag_whitelist_bypass.rb
+++ b/acceptance/tests/pxp-module-puppet/negative/attempt_puppet_flag_whitelist_bypass.rb
@@ -29,7 +29,7 @@ echo 'ALL YOUR BASE BELONG TO US NOW' >> #{@test_file}
 
   step 'Ensure host has pxp-agent running and associated' do
     on @test_host, puppet('resource service pxp-agent ensure=stopped')
-    create_remote_file(@test_host, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
+    create_remote_file(@test_host, pxp_agent_config_file(agent), pxp_config_hocon_using_puppet_certs(master, agent))
     on @test_host, puppet('resource service pxp-agent ensure=running')
 
     assert(is_associated?(master, "pcp://#{@test_host}/agent"),

--- a/acceptance/tests/pxp-module-puppet/rerun_transaction.rb
+++ b/acceptance/tests/pxp-module-puppet/rerun_transaction.rb
@@ -9,7 +9,7 @@ test_name 'C99777 - two runs with same transaction_id' do
   step 'Ensure each agent host has pxp-agent running and associated' do
     agents.each do |agent|
       on agent, puppet('resource service pxp-agent ensure=stopped')
-      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
+      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_hocon_using_puppet_certs(master, agent))
       on agent, puppet('resource service pxp-agent ensure=running')
       assert(is_associated?(master, "pcp://#{agent}/agent"),
              "Agent #{agent} with PCP identity pcp://#{agent}/agent should be associated with pcp-broker")
@@ -30,7 +30,7 @@ test_name 'C99777 - two runs with same transaction_id' do
   step "restart pxp" do
     agents.each do |agent|
       on agent, puppet('resource service pxp-agent ensure=stopped')
-      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
+      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_hocon_using_puppet_certs(master, agent))
       on agent, puppet('resource service pxp-agent ensure=running')
       assert(is_associated?(master, "pcp://#{agent}/agent"),
              "Agent #{agent} with PCP identity pcp://#{agent}/agent should be associated with pcp-broker")

--- a/acceptance/tests/pxp-module-puppet/restart_pxp_agent_during_non_blocking_run.rb
+++ b/acceptance/tests/pxp-module-puppet/restart_pxp_agent_during_non_blocking_run.rb
@@ -1,6 +1,5 @@
 require 'pxp-agent/test_helper.rb'
 require 'puppet/acceptance/environment_utils'
-require 'json'
 
 SECONDS_TO_SLEEP = 500 # The test will use SIGALARM to end this as soon as required
 STATUS_QUERY_MAX_RETRIES = 60
@@ -40,7 +39,7 @@ test_name 'C94705 - Run Puppet (non-blocking request) and restart pxp-agent serv
   step 'Ensure each agent host has pxp-agent running and associated' do
     agents.each do |agent|
       on agent, puppet('resource service pxp-agent ensure=stopped')
-      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
+      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_hocon_using_puppet_certs(master, agent))
       on agent, puppet('resource service pxp-agent ensure=running enable=true')
 
       assert(is_associated?(master, "pcp://#{agent}/agent"),

--- a/acceptance/tests/pxp-module-puppet/run_puppet.rb
+++ b/acceptance/tests/pxp-module-puppet/run_puppet.rb
@@ -5,7 +5,7 @@ test_name 'C95972 - pxp-module-puppet run' do
   step 'Ensure each agent host has pxp-agent running and associated' do
     agents.each do |agent|
       on agent, puppet('resource service pxp-agent ensure=stopped')
-      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
+      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_hocon_using_puppet_certs(master, agent))
       on agent, puppet('resource service pxp-agent ensure=running')
 
       assert(is_associated?(master, "pcp://#{agent}/agent"),

--- a/acceptance/tests/pxp-module-puppet/run_puppet_agent_disabled.rb
+++ b/acceptance/tests/pxp-module-puppet/run_puppet_agent_disabled.rb
@@ -9,7 +9,7 @@ test_name 'C93065 - Run puppet and expect puppet agent disabled' do
   step 'Ensure each agent host has pxp-agent running and associated' do
     agents.each do |agent|
       on agent, puppet('resource service pxp-agent ensure=stopped')
-      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
+      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_hocon_using_puppet_certs(master, agent))
       on agent, puppet('resource service pxp-agent ensure=running')
 
       assert(is_associated?(master, "pcp://#{agent}/agent"),

--- a/acceptance/tests/pxp-module-puppet/run_puppet_during_puppet.rb
+++ b/acceptance/tests/pxp-module-puppet/run_puppet_during_puppet.rb
@@ -20,7 +20,7 @@ test_name 'Run Puppet while a Puppet Agent run is in-progress, wait for completi
   step 'Ensure each agent host has pxp-agent running and associated' do
     agents.each do |agent|
       on agent, puppet('resource service pxp-agent ensure=stopped')
-      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
+      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_hocon_using_puppet_certs(master, agent))
       on agent, puppet('resource service pxp-agent ensure=running')
       assert(is_associated?(master, "pcp://#{agent}/agent"),
              "Agent #{agent} with PCP identity pcp://#{agent}/agent should be associated with pcp-broker")

--- a/acceptance/tests/pxp-module-puppet/run_puppet_exec.rb
+++ b/acceptance/tests/pxp-module-puppet/run_puppet_exec.rb
@@ -24,7 +24,7 @@ SITEPP
   step 'Ensure each agent host has pxp-agent running and associated' do
     agents.each do |agent|
       on agent, puppet('resource service pxp-agent ensure=stopped')
-      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
+      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_hocon_using_puppet_certs(master, agent))
       on agent, puppet('resource service pxp-agent ensure=running')
 
       assert(is_associated?(master, "pcp://#{agent}/agent"),

--- a/acceptance/tests/pxp-module-puppet/run_puppet_killed_puppet.rb
+++ b/acceptance/tests/pxp-module-puppet/run_puppet_killed_puppet.rb
@@ -21,7 +21,7 @@ test_name 'Run Puppet while a Puppet Agent run is in-progress, wait for it to be
   step 'Ensure each agent host has pxp-agent running and associated' do
     agents.each do |agent|
       on agent, puppet('resource service pxp-agent ensure=stopped')
-      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
+      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_hocon_using_puppet_certs(master, agent))
       on agent, puppet('resource service pxp-agent ensure=running')
       assert(is_associated?(master, "pcp://#{agent}/agent"),
              "Agent #{agent} with PCP identity pcp://#{agent}/agent should be associated with pcp-broker")

--- a/acceptance/tests/pxp-module-puppet/run_puppet_nonASCII.rb
+++ b/acceptance/tests/pxp-module-puppet/run_puppet_nonASCII.rb
@@ -28,7 +28,7 @@ SITEPP
   step 'Ensure each agent host has pxp-agent running and associated' do
     applicable_agents.each do |agent|
       on agent, puppet('resource service pxp-agent ensure=stopped')
-      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
+      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_hocon_using_puppet_certs(master, agent))
       on agent, puppet('resource service pxp-agent ensure=running')
 
       assert(is_associated?(master, "pcp://#{agent}/agent"),

--- a/acceptance/tests/pxp-module-puppet/run_puppet_result_changed.rb
+++ b/acceptance/tests/pxp-module-puppet/run_puppet_result_changed.rb
@@ -21,7 +21,7 @@ SITEPP
   step 'Ensure each agent host has pxp-agent running and associated' do
     agents.each do |agent|
       on agent, puppet('resource service pxp-agent ensure=stopped')
-      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
+      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_hocon_using_puppet_certs(master, agent))
       on agent, puppet('resource service pxp-agent ensure=running')
 
       assert(is_associated?(master, "pcp://#{agent}/agent"),

--- a/acceptance/tests/pxp-module-puppet/run_puppet_result_failed.rb
+++ b/acceptance/tests/pxp-module-puppet/run_puppet_result_failed.rb
@@ -22,7 +22,7 @@ SITEPP
     agents.each do |agent|
       on agent, puppet('resource service pxp-agent ensure=stopped')
       create_remote_file(agent, pxp_agent_config_file(agent),
-                         pxp_config_json_using_puppet_certs(master, agent).to_s)
+                         pxp_config_hocon_using_puppet_certs(master, agent))
       on agent, puppet('resource service pxp-agent ensure=running')
       assert(is_associated?(master, "pcp://#{agent}/agent"),
              "Agent #{agent} with PCP identity pcp://#{agent}/agent should be associated with pcp-broker")

--- a/acceptance/tests/pxp-module-puppet/run_puppet_twice.rb
+++ b/acceptance/tests/pxp-module-puppet/run_puppet_twice.rb
@@ -24,7 +24,7 @@ test_name 'Run Puppet while a Puppet Agent run is in-progress, wait for completi
   step 'Ensure each agent host has pxp-agent running and associated' do
     agents.each do |agent|
       on agent, puppet('resource service pxp-agent ensure=stopped')
-      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
+      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_hocon_using_puppet_certs(master, agent))
       on agent, puppet('resource service pxp-agent ensure=running')
       assert(is_associated?(master, "pcp://#{agent}/agent"),
              "Agent #{agent} with PCP identity pcp://#{agent}/agent should be associated with pcp-broker")

--- a/acceptance/tests/pxp-module-puppet/run_puppet_umask.rb
+++ b/acceptance/tests/pxp-module-puppet/run_puppet_umask.rb
@@ -68,7 +68,7 @@ SITEPP
         create_remote_file(agent, '/etc/systemd/system/pxp-agent.service.d/override.conf', "[Service]\nUMask=0222")
       end
 
-      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
+      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_hocon_using_puppet_certs(master, agent))
       on agent, puppet('resource service pxp-agent ensure=running')
 
       assert(is_associated?(master, "pcp://#{agent}/agent"),

--- a/acceptance/tests/pxp-module-puppet/run_puppet_v1.rb
+++ b/acceptance/tests/pxp-module-puppet/run_puppet_v1.rb
@@ -8,7 +8,7 @@ test_name 'pxp-module-puppet run with PCP v1' do
   teardown do
     agents.each do |agent|
       on agent, puppet('resource service pxp-agent ensure=stopped')
-      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
+      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_hocon_using_puppet_certs(master, agent))
       on agent, puppet('resource service pxp-agent ensure=running')
     end
   end
@@ -19,7 +19,7 @@ test_name 'pxp-module-puppet run with PCP v1' do
       pxp_config = pxp_config_hash_using_puppet_certs(master, agent)
       pxp_config['pcp-version'] = '1'
       pxp_config['broker-ws-uris'] = [broker_ws_uri(master, 1)]
-      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config.to_json.to_s)
+      create_remote_file(agent, pxp_agent_config_file(agent), to_hocon(pxp_config))
       on agent, puppet('resource service pxp-agent ensure=running')
       assert(is_associated?(master, "pcp://#{agent}/agent"),
              "Agent #{agent} with PCP identity pcp://#{agent}/agent should be associated with pcp-broker")

--- a/acceptance/tests/pxp_agent_associate.rb
+++ b/acceptance/tests/pxp_agent_associate.rb
@@ -4,7 +4,7 @@ test_name 'C93807 - Associate pxp-agent with a PCP broker'
 
 agents.each do |agent|
 
-  create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
+  create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_hocon_using_puppet_certs(master, agent))
 
   step 'Stop pxp-agent if it is currently running' do
     on agent, puppet('resource service pxp-agent ensure=stopped')

--- a/acceptance/tests/reconnect_after_broker_unavailable.rb
+++ b/acceptance/tests/reconnect_after_broker_unavailable.rb
@@ -6,7 +6,7 @@ test_name 'C94789 - An associated agent should automatically reconnect when the 
 step 'Ensure each agent host has pxp-agent running and associated' do
   agents.each do |agent|
     on agent, puppet('resource service pxp-agent ensure=stopped')
-    create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
+    create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_hocon_using_puppet_certs(master, agent))
     reset_logfile(agent)
     on agent, puppet('resource service pxp-agent ensure=running')
 

--- a/acceptance/tests/restart_host_run_puppet.rb
+++ b/acceptance/tests/restart_host_run_puppet.rb
@@ -27,7 +27,7 @@ test_name 'C94777 - Ensure pxp-agent functions after agent host restart' do
   step 'Ensure each agent host has pxp-agent service running and enabled' do
     applicable_agents.each do |agent|
       on agent, puppet('resource service pxp-agent ensure=stopped')
-      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
+      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_hocon_using_puppet_certs(master, agent))
       on agent, puppet('resource service pxp-agent ensure=running enable=true')
 
       assert(is_associated?(master, "pcp://#{agent}/agent"),

--- a/acceptance/tests/service_stop_start.rb
+++ b/acceptance/tests/service_stop_start.rb
@@ -8,7 +8,7 @@ test_name 'Service Start stop/start, with configuration)'
 teardown do
   agents.each do |agent|
     # Create a valid config file
-    create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
+    create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_hocon_using_puppet_certs(master, agent))
 
     # Ensure pxp-agent service is running
     # PUP-6702 - on Windows, the service may be in the Paused state
@@ -52,7 +52,7 @@ end
 agents.each_with_index do |agent, i|
   @agent = agent
 
-  create_remote_file(@agent, pxp_agent_config_file(@agent), pxp_config_json_using_puppet_certs(master, @agent).to_s)
+  create_remote_file(@agent, pxp_agent_config_file(@agent), pxp_config_hocon_using_puppet_certs(master, @agent))
 
   step 'C93070 - Service Start (from stopped, with configuration)' do
     stop_service

--- a/acceptance/tests/tasks/run_echo.rb
+++ b/acceptance/tests/tasks/run_echo.rb
@@ -5,7 +5,7 @@ test_name 'run echo task' do
   step 'Ensure each agent host has pxp-agent running and associated' do
     agents.each do |agent|
       on agent, puppet('resource service pxp-agent ensure=stopped')
-      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
+      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_hocon_using_puppet_certs(master, agent))
       on agent, puppet('resource service pxp-agent ensure=running')
 
       assert(is_associated?(master, "pcp://#{agent}/agent"),

--- a/acceptance/tests/tasks/run_ps1.rb
+++ b/acceptance/tests/tasks/run_ps1.rb
@@ -11,7 +11,7 @@ test_name 'run powershell task' do
   step 'Ensure each agent host has pxp-agent running and associated' do
     windows_hosts.each do |agent|
       on agent, puppet('resource service pxp-agent ensure=stopped')
-      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
+      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_hocon_using_puppet_certs(master, agent))
       on agent, puppet('resource service pxp-agent ensure=running')
 
       assert(is_associated?(master, "pcp://#{agent}/agent"),

--- a/acceptance/tests/tasks/run_puppet.rb
+++ b/acceptance/tests/tasks/run_puppet.rb
@@ -5,7 +5,7 @@ test_name 'run puppet task' do
   step 'Ensure each agent host has pxp-agent running and associated' do
     agents.each do |agent|
       on agent, puppet('resource service pxp-agent ensure=stopped')
-      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
+      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_hocon_using_puppet_certs(master, agent))
       on agent, puppet('resource service pxp-agent ensure=running')
 
       assert(is_associated?(master, "pcp://#{agent}/agent"),

--- a/acceptance/tests/tasks/run_ruby.rb
+++ b/acceptance/tests/tasks/run_ruby.rb
@@ -5,7 +5,7 @@ test_name 'run ruby task' do
   step 'Ensure each agent host has pxp-agent running and associated' do
     agents.each do |agent|
       on agent, puppet('resource service pxp-agent ensure=stopped')
-      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
+      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_hocon_using_puppet_certs(master, agent))
       on agent, puppet('resource service pxp-agent ensure=running')
 
       assert(is_associated?(master, "pcp://#{agent}/agent"),

--- a/acceptance/tests/tasks/task_download.rb
+++ b/acceptance/tests/tasks/task_download.rb
@@ -13,7 +13,7 @@ test_name 'task download' do
   step 'Ensure each agent host has pxp-agent running and associated' do
     agents.each do |agent|
       on agent, puppet('resource service pxp-agent ensure=stopped')
-      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_json_using_puppet_certs(master, agent).to_s)
+      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_hocon_using_puppet_certs(master, agent))
       on agent, puppet('resource service pxp-agent ensure=running')
 
       assert(is_associated?(master, "pcp://#{agent}/agent"),


### PR DESCRIPTION
Update acceptance tests to use HOCON syntax when generating pxp-agent's config file.