### PR TITLE
(PCP-805) Enable testing system openssl linked PA in CI pipelines on rhel7

### DIFF
--- a/acceptance/setup/aio/010_Install.rb
+++ b/acceptance/setup/aio/010_Install.rb
@@ -12,6 +12,15 @@ def install_from_local(hosts, package)
       scp_to(agent, package, tmpdir)
     end
 
+    if agent[:platform].match(/(?:el-7|redhat-7)/)
+      step "Upgrade openssl package...(" + agent[:platform] + ")" do
+      end
+      on(agent, "yum -y install openssl-1.0.1e-51.el7_2.4.x86_64")
+    else
+      step "Skipping upgrade of openssl package...(" + agent[:platform] + ")" do
+      end
+    end
+
     step "Install package on #{agent}" do
       agent.install_package("#{tmpdir}/#{File.basename(package)}")
     end
@@ -31,6 +40,16 @@ step "Install puppet-agent..." do
     }
     agents.each do |agent|
       next if agent == master # Avoid SERVER-528
+
+      if agent[:platform].match(/(?:el-7|redhat-7)/)
+        step "Upgrade openssl package...(" + agent[:platform] + ")" do
+        end
+        on(agent, "yum -y install openssl-1.0.1e-51.el7_2.4.x86_64")
+      else
+        step "Skipping upgrade of openssl package...(" + agent[:platform] + ")" do
+        end
+      end
+
       install_puppet_agent_dev_repo_on(agent, opts)
     end
   end
@@ -57,6 +76,16 @@ step "Install puppetserver..." do
       server_download_url = "http://builds.delivery.puppetlabs.net"
     end
     install_puppetlabs_dev_repo(master, 'puppetserver', server_version, nil, :dev_builds_url => server_download_url)
+    # Bump version of openssl on rhel7 platforms
+    if master[:platform].match(/(?:el-7|redhat-7)/)
+      step "Upgrade openssl package...(" + master[:platform] + ")" do
+      end
+      on(master, "yum -y install openssl-1.0.1e-51.el7_2.4.x86_64")
+    else
+      step "Skipping upgrade of openssl package...(" + master[:platform] + ")" do
+      end
+    end
+
     install_puppetlabs_dev_repo(master, 'puppet-agent', ENV['SHA'])
   end
   master.install_package('puppetserver')

--- a/acceptance/setup/aio/010_Install.rb
+++ b/acceptance/setup/aio/010_Install.rb
@@ -111,3 +111,76 @@ step 'Make sure install is sane' do
     on agent, "#{ruby} --version"
   end
 end
+
+
+step "Enable FIPS on agent hosts..." do
+
+ # There might be a better way to do some things below but till then...
+ # The TODO's need to be followed up
+
+  agents.each do |agent|
+    next if agent == master # Only on agents.
+
+    # Do this only on rhel7, rhel6, f24, f25
+    use_system_openssl = ENV['USE_SYSTEM_OPENSSL']
+    if use_system_openssl
+      # Other platforms to come...
+      next if !agent[:platform].match(/(?:el-7|redhat-7)/)
+
+      # Step 1: Disable prelinking
+      # TODO:: Handle cases where the /etc/sysconfig/prelink might exist
+      on(agent, 'echo "PRELINKING=no" > /etc/sysconfig/prelink')
+      # TODO: prelink is commented till we figure how to attempt executing
+      # it so any failures do not cause this thing to exit
+      # on(agent, "prelink -u -a")
+ 
+      # Step 2: Install dracut-fips, dracut-fips-aesni
+      on(agent, "yum -y install dracut-fips")
+      on(agent, "yum -y install dracut-fips-aesni")
+
+      # TODO:: Backup existing kernel image in case anything goes south..
+      # Step 3: Run dracut to update system for fips. 
+      on(agent, "dracut -v -f")
+
+
+      # TODO:: Steps 4 and 5 need to be adjusted for rhel6, f24, f25
+      # as the method of enabling FIPS are different on those platforms. 
+      # Below works on rhel7
+      
+      # Step 4: Find out the device details (BLOCK ID) of boot partition
+      # append enable fips and boot block id to kernel command line in grub file
+      
+      on(agent, 'boot_blkid=$(blkid `df /boot | grep "/dev" | awk \'BEGIN{ FS=" "}; {print $1}\'` | awk \'BEGIN{ FS=" "}; {print $2}\' | sed \'s/"//g\');\
+                 fips_bootblk="fips=1 boot="$boot_blkid;\
+                 grub_linux_cmdline=`grep -e "^GRUB_CMDLINE_LINUX" /etc/default/grub | sed "s/\"$/ $fips_bootblk\"/"`;\
+                 grep -v GRUB_CMDLINE_LINUX /etc/default/grub > /etc/default/grub.bak;\
+                 /bin/cp -rf /etc/default/grub.bak /etc/default/grub;\
+                 sed -i "/GRUB_DISABLE_RECOVERY/i $grub_linux_cmdline" /etc/default/grub')
+
+
+      # Step 5: Run grub2 mkconfig to make the changes take effect.
+      on(agent, 'grub2-mkconfig -o /boot/grub2/grub.cfg')
+
+      # Reboot is needed for the system to start in FIPS mode
+      agent.reboot
+      timeout = 30
+      begin
+        Timeout.timeout(timeout) do
+          until agent.up?
+            sleep 1
+          end
+        end
+      rescue Timeout::Error => e
+        raise "Agent did not come back up within #{timeout} seconds."
+      end
+      
+      # TODO:
+      # Ensure that agent is actually in fips mode by examining the contents of
+      # /proc/sys/crypto/fips_enabled and that it is 1
+
+      # Switch to using sha256 to work in fips mode.
+      on agent, puppet('config set digest_algorithm sha256')
+      
+    end
+  end
+end


### PR DESCRIPTION

Openssl versions on RHEL7 images being used by CI/VMpooler have an old version
which causes failures when running agent setup and test scripts. They need to be
upgraded to a desired version that is >= that on Centos7 used to build PA.

Related to PA-1580 (part of epic PA-1608). Has been test in PA CI - logs would be attached to PR for PA-1264 (enables linking PA against system openssl).
This does not impact regular agent build using vendored openssl which disregard system
openssl. 