### PR TITLE
(maint) Pin lein to 2.7.1

### DIFF
--- a/acceptance/setup/common/050_Setup_Broker.rb
+++ b/acceptance/setup/common/050_Setup_Broker.rb
@@ -43,7 +43,7 @@ end
 
 step 'Download lein bootstrap' do
   on master, 'cd /usr/bin && '\
-           'curl -O https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein'
+    'curl -O https://raw.githubusercontent.com/technomancy/leiningen/2.7.1/bin/lein'
 end
 
 step 'Run lein once so it sets itself up' do


### PR DESCRIPTION
2.8.0 rejects HTTP downloads.