### PR TITLE
(PCP-809) Purge old cached tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,20 @@ Note that if the specified task-cache directory does not exist, pxp-agent will
 create it when starting. It will also be recreated before attempting to download
 a task to it in case it was deleted without restarting pxp-agent.
 
+**task-cache-dir-purge-ttl (optional)**
+
+Automatically delete cached tasks located in the `task-cache-dir` directory
+that have a `start` timestamp that has expired in respect to the specified TTL.
+The TTL value must be an integer with one of the following suffixes:
+ - 'm' - minutes
+ - 'h' - hours
+ - 'd' - days
+
+The default TTL value is "14d" (14 days). Specifying a 0, with any of the above
+suffixes, will disable the purge functionality. Note that the purge will take
+place when pxp-agent starts and will be repeated every hour or TTL, whichever
+is shorter.
+
 **foreground (optional flag)**
 
 Don't become a daemon and execute on foreground on the associated terminal.

--- a/README.md
+++ b/README.md
@@ -400,7 +400,8 @@ The TTL value must be an integer with one of the following suffixes:
 
 The default TTL value is "14d" (14 days). Specifying a 0, with any of the above
 suffixes, will disable the purge functionality. Note that the purge will take
-place when pxp-agent starts and will be repeated at each 1.2*TTL interval.
+place when pxp-agent starts and will be repeated every hour or TTL, whichever
+is shorter.
 
 **task-cache-dir (optional)**
 

--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ it when starting.
 
 **spool-dir-purge-ttl (optional)**
 
-Automatically delete results subdirectories located in the `spool` directory
+Automatically delete results subdirectories located in the `spool-dir` directory
 that have a `start` timestamp that has expired in respect to the specified TTL.
 The TTL value must be an integer with one of the following suffixes:
  - 'm' - minutes
@@ -401,6 +401,16 @@ The TTL value must be an integer with one of the following suffixes:
 The default TTL value is "14d" (14 days). Specifying a 0, with any of the above
 suffixes, will disable the purge functionality. Note that the purge will take
 place when pxp-agent starts and will be repeated at each 1.2*TTL interval.
+
+**task-cache-dir (optional)**
+
+The location where the tasks are cached; the default location is:
+ - \*nix: */opt/puppetlabs/pxp-agent/tasks-cache*
+ - Windows: *C:\ProgramData\PuppetLabs\pxp-agent\tasks-cache*
+
+Note that if the specified task-cache directory does not exist, pxp-agent will
+create it when starting. It will also be recreated before attempting to download
+a task to it in case it was deleted without restarting pxp-agent.
 
 **foreground (optional flag)**
 

--- a/lib/inc/pxp-agent/configuration.hpp
+++ b/lib/inc/pxp-agent/configuration.hpp
@@ -143,6 +143,7 @@ class Configuration
         std::string spool_dir_purge_ttl;
         std::string modules_config_dir;
         std::string task_cache_dir;
+        std::string task_cache_dir_purge_ttl;
         std::string client_type;
         long ws_connection_timeout_ms;
         uint32_t association_timeout_s;

--- a/lib/inc/pxp-agent/external_module.hpp
+++ b/lib/inc/pxp-agent/external_module.hpp
@@ -30,12 +30,12 @@ class ExternalModule : public Module {
     /// module metadata; if the metadata is invalid; in case of
     /// invalid input or output schemas.
     explicit ExternalModule(const std::string& exec_path,
-                            const std::string& spool_dir);
+                            std::shared_ptr<ResultsStorage> storage);
 
     explicit ExternalModule(
         const std::string& path,
         const leatherman::json_container::JsonContainer& config,
-        const std::string& spool_dir);
+        std::shared_ptr<ResultsStorage> storage);
 
     /// The type of the module.
     ModuleType type() override { return ModuleType::External; }
@@ -67,7 +67,7 @@ class ExternalModule : public Module {
     leatherman::json_container::JsonContainer config_;
 
     /// Results Storage
-    ResultsStorage storage_;
+    std::shared_ptr<ResultsStorage> storage_;
 
     /// Metadata validator
     static const PCPClient::Validator metadata_validator_;

--- a/lib/inc/pxp-agent/modules/task.hpp
+++ b/lib/inc/pxp-agent/modules/task.hpp
@@ -26,7 +26,7 @@ class Task : public PXPAgent::Module {
          const std::string& ca,
          const std::string& crt,
          const std::string& key,
-         const std::string& spool_dir);
+         std::shared_ptr<ResultsStorage> storage);
 
     ~Task() override;
 
@@ -52,7 +52,7 @@ class Task : public PXPAgent::Module {
         std::function<void(const std::string& dir_path)> purge_callback = nullptr);
 
   private:
-    ResultsStorage storage_;
+    std::shared_ptr<ResultsStorage> storage_;
 
     std::string task_cache_dir_;
     std::string task_cache_dir_purge_ttl_;

--- a/lib/inc/pxp-agent/request_processor.hpp
+++ b/lib/inc/pxp-agent/request_processor.hpp
@@ -133,7 +133,7 @@ class RequestProcessor {
     void logLoadedModules() const;
 
     /// Spool directory purge task; the purge call will be triggered
-    /// in intervals of (TTL + TTL * 1.2) duration
+    /// in intervals of min("1h", TTL) duration
     void spoolDirPurgeTask();
 };
 

--- a/lib/inc/pxp-agent/request_processor.hpp
+++ b/lib/inc/pxp-agent/request_processor.hpp
@@ -121,7 +121,7 @@ class RequestProcessor {
     void loadModulesConfiguration();
 
     /// Register module in the module map
-    void registerModule(Module *module);
+    void registerModule(std::shared_ptr<Module>);
 
     /// Load the modules from the src/modules directory
     void loadInternalModules(const Configuration::Agent& agent_configuration);

--- a/lib/inc/pxp-agent/results_storage.hpp
+++ b/lib/inc/pxp-agent/results_storage.hpp
@@ -2,6 +2,7 @@
 #define SRC_AGENT_RESULTS_STORAGE_HPP_
 
 #include <pxp-agent/action_output.hpp>
+#include <pxp-agent/util/purgeable.hpp>
 
 #include <leatherman/json_container/json_container.hpp>
 
@@ -18,14 +19,14 @@ namespace PXPAgent {
 // NOTE(ale): possible execptions thrown while inspecting files are
 // propagated by ResultsStorage methods (more specifically, errors
 // raised by boost::filesystem::exists() are not filtered).
-class ResultsStorage {
+class ResultsStorage : public PXPAgent::Util::Purgeable {
   public:
     struct Error : public std::runtime_error {
         explicit Error(std::string const& msg) : std::runtime_error(msg) {}
     };
 
     ResultsStorage() = delete;
-    ResultsStorage(const std::string& spool_dir);
+    ResultsStorage(std::string spool_dir, std::string spool_dir_ttl);
     ResultsStorage(const ResultsStorage&) = delete;
     ResultsStorage& operator=(const ResultsStorage&) = delete;
 
@@ -89,11 +90,11 @@ class ResultsStorage {
     // remove_all() will be used.
     unsigned int purge(
         const std::string& ttl,
-        const std::vector<std::string>& ongoing_transactions,
-        std::function<void(const std::string& dir_path)> purge_callback = nullptr);
+        std::vector<std::string> ongoing_transactions,
+        std::function<void(const std::string& dir_path)> purge_callback = nullptr) override;
 
   private:
-    const boost::filesystem::path spool_dir_path_;
+    boost::filesystem::path spool_dir_path_;
 
     ActionOutput getOutput_(const std::string& transaction_id,
                             bool get_exitcode);

--- a/lib/inc/pxp-agent/time.hpp
+++ b/lib/inc/pxp-agent/time.hpp
@@ -46,6 +46,8 @@ class Timestamp {
     // Throws an Error in case it fails to create a time point from
     // the specified extended ISO date time string
     bool isNewerThan(const std::string& extended_ISO8601_time);
+
+    bool isNewerThan(const std::time_t&);
 };
 
 }  // namespace PXPAgents

--- a/lib/inc/pxp-agent/util/purgeable.hpp
+++ b/lib/inc/pxp-agent/util/purgeable.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <vector>
+#include <string>
+#include <memory>
+#include <boost/filesystem.hpp>
+
+namespace PXPAgent {
+namespace Util {
+
+class Purgeable {
+  public:
+    Purgeable() {}
+    Purgeable(std::string ttl) : ttl_(std::move(ttl)) {}
+
+    const std::string& get_ttl() const
+    {
+        return ttl_;
+    }
+
+    virtual unsigned int purge(
+        const std::string& ttl,
+        std::vector<std::string> ongoing_transactions,
+        std::function<void(const std::string& dir_path)> purge_callback = nullptr) = 0;
+
+  protected:
+    static void defaultDirPurgeCallback(const std::string& dir_path)
+    {
+        boost::filesystem::remove_all(dir_path);
+    }
+
+  private:
+    std::string ttl_;
+};
+
+}  // namespace Util
+}  // namespace PXPAgent

--- a/lib/src/configuration.cc
+++ b/lib/src/configuration.cc
@@ -1017,17 +1017,11 @@ void Configuration::validateAndNormalizeOtherSettings()
             lth_loc::format("invalid spool-dir-purge-ttl: {1}", e.what()) };
     }
 
-    if (HW::GetFlag<int>("association-timeout") < 0)
-        throw Configuration::Error {
-            lth_loc::translate("association-timeout must be positive") };
-
-    if (HW::GetFlag<int>("association-request-ttl") < 0)
-        throw Configuration::Error {
-                lth_loc::translate("association-request-ttl must be positive") };
-
-    if (HW::GetFlag<int>("pcp-message-ttl") < 0)
-        throw Configuration::Error {
-            lth_loc::translate("association-request-ttl must be positive") };
+    for (auto msg_ttl : {"association-timeout", "association-request-ttl", "pcp-message-ttl"}) {
+        if (HW::GetFlag<int>(msg_ttl) < 0)
+            throw Configuration::Error {
+                lth_loc::format("{1} must be positive", msg_ttl) };
+    }
 }
 
 const Options::iterator Configuration::getDefaultIndex(const std::string& flagname)

--- a/lib/src/external_module.cc
+++ b/lib/src/external_module.cc
@@ -80,10 +80,10 @@ PCPClient::Validator getMetadataValidator()
 
 ExternalModule::ExternalModule(const std::string& path,
                                const lth_jc::JsonContainer& config,
-                               const std::string& spool_dir)
+                               std::shared_ptr<ResultsStorage> storage)
         : path_ { path },
           config_ { config },
-          storage_ { spool_dir }
+          storage_ { std::move(storage) }
 {
     fs::path module_path { path };
     module_name = module_path.stem().string();
@@ -107,10 +107,10 @@ ExternalModule::ExternalModule(const std::string& path,
 }
 
 ExternalModule::ExternalModule(const std::string& path,
-                               const std::string& spool_dir)
+                               std::shared_ptr<ResultsStorage> storage)
         : path_ { path },
           config_ { "{}" },
-          storage_ { spool_dir }
+          storage_ { std::move(storage) }
 {
     fs::path module_path { path };
     module_name = module_path.stem().string();
@@ -395,7 +395,7 @@ ActionResponse ExternalModule::callNonBlockingAction(const ActionRequest& reques
         pcp_util::chrono::milliseconds(OUTPUT_DELAY_MS));
 
     // Stdout / stderr output should be on file; read it
-    response.output = storage_.getOutput(request.transactionId(), exec.exit_code);
+    response.output = storage_->getOutput(request.transactionId(), exec.exit_code);
     processOutputAndUpdateMetadata(response);
     return response;
 }

--- a/lib/src/modules/task.cc
+++ b/lib/src/modules/task.cc
@@ -120,8 +120,8 @@ Task::Task(const fs::path& exec_prefix,
            const std::string& ca,
            const std::string& crt,
            const std::string& key,
-           const std::string& spool_dir) :
-    storage_ { spool_dir },
+           std::shared_ptr<ResultsStorage> storage) :
+    storage_ { std::move(storage) },
     task_cache_dir_ { task_cache_dir },
     task_cache_dir_purge_ttl_ { task_cache_dir_purge_ttl },
     exec_prefix_ { exec_prefix },
@@ -449,7 +449,7 @@ void Task::callNonBlockingAction(
             lth_exec::execution_options::inherit_locale });  // options
 
     // Stdout / stderr output should be on file; read it
-    response.output = storage_.getOutput(request.transactionId(), exec.exit_code);
+    response.output = storage_->getOutput(request.transactionId(), exec.exit_code);
     processOutputAndUpdateMetadata(response);
 }
 

--- a/lib/src/pxp_connector_v1.cc
+++ b/lib/src/pxp_connector_v1.cc
@@ -11,6 +11,7 @@
 namespace PXPAgent {
 
 namespace lth_jc = leatherman::json_container;
+namespace lth_loc = leatherman::locale;
 
 //
 // PXPConnector V1
@@ -21,14 +22,11 @@ wrapDebug(const PCPClient::ParsedChunks& parsed_chunks)
 {
     auto request_id = parsed_chunks.envelope.get<std::string>("id");
     if (parsed_chunks.num_invalid_debug) {
-        // TODO(ale): deal with locale & plural (PCP-257)
-        if (parsed_chunks.num_invalid_debug == 1) {
-            LOG_WARNING("Message {1} contained {2} bad debug chunk",
-                        request_id, parsed_chunks.num_invalid_debug);
-        } else {
-            LOG_WARNING("Message {1} contained {2} bad debug chunks",
-                        request_id, parsed_chunks.num_invalid_debug);
-        }
+        LOG_WARNING(lth_loc::format_n(
+            // LOCALE: warning
+            "Message {1} contained {2} bad debug chunk",
+            "Message {1} contained {2} bad debug chunks",
+            parsed_chunks.num_invalid_debug, request_id, parsed_chunks.num_invalid_debug));
     }
     std::vector<lth_jc::JsonContainer> debug {};
     for (auto& debug_entry : parsed_chunks.debug) {

--- a/lib/src/request_processor.cc
+++ b/lib/src/request_processor.cc
@@ -922,16 +922,11 @@ void RequestProcessor::spoolDirPurgeTask()
 {
     auto num_minutes = Timestamp::getMinutes(spool_dir_purge_ttl_);
     num_minutes *= 1.2;
-    // TODO(ale): deal with locale & plural (PCP-257)
-    if (num_minutes == 1) {
-        LOG_INFO("Starting the task for purging the spool directory every {1} "
-                 "minute; thread id {2}",
-                 num_minutes, pcp_util::this_thread::get_id());
-    } else {
-        LOG_INFO("Starting the task for purging the spool directory every {1} "
-                 "minutes; thread id {2}",
-                 num_minutes, pcp_util::this_thread::get_id());
-    }
+    LOG_INFO(lth_loc::format_n(
+        // LOCALE: info
+        "Starting the task for purging the spool directory every {1} minute; thread id {2}",
+        "Starting the task for purging the spool directory every {1} minutes; thread id {2}",
+        num_minutes, num_minutes, pcp_util::this_thread::get_id()));
 
     while (true) {
         pcp_util::unique_lock<pcp_util::mutex> the_lock { spool_dir_purge_mutex_ };

--- a/lib/src/request_processor.cc
+++ b/lib/src/request_processor.cc
@@ -920,12 +920,12 @@ void RequestProcessor::logLoadedModules() const
 
 void RequestProcessor::spoolDirPurgeTask()
 {
-    auto num_minutes = Timestamp::getMinutes(spool_dir_purge_ttl_);
-    num_minutes *= 1.2;
+    auto config_minutes = Timestamp::getMinutes(spool_dir_purge_ttl_);
+    auto num_minutes = std::min(60u, config_minutes);
     LOG_INFO(lth_loc::format_n(
         // LOCALE: info
-        "Starting the task for purging the spool directory every {1} minute; thread id {2}",
-        "Starting the task for purging the spool directory every {1} minutes; thread id {2}",
+        "Scheduling the check every {1} minute for spool directories to purge; thread id {2}",
+        "Scheduling the check every {1} minutes for spool directories to purge; thread id {2}",
         num_minutes, num_minutes, pcp_util::this_thread::get_id()));
 
     while (true) {

--- a/lib/src/request_processor.cc
+++ b/lib/src/request_processor.cc
@@ -825,6 +825,7 @@ void RequestProcessor::loadInternalModules(const Configuration::Agent& agent_con
     registerModule(new Modules::Ping);
     registerModule(new Modules::Task(Configuration::Instance().getExecPrefix(),
                                      agent_configuration.task_cache_dir,
+                                     agent_configuration.task_cache_dir_purge_ttl,
                                      agent_configuration.master_uris,
                                      agent_configuration.ca,
                                      agent_configuration.crt,

--- a/lib/src/request_processor.cc
+++ b/lib/src/request_processor.cc
@@ -28,12 +28,14 @@
 
 #include <boost/filesystem/operations.hpp>
 #include <boost/format.hpp>
+#include <boost/math/common_factor_rt.hpp>
 
 #include <vector>
 #include <atomic>
 #include <functional>
 #include <stdexcept>  // out_of_range
 #include <memory>
+#include <numeric>
 #include <stdint.h>
 
 namespace PXPAgent {
@@ -169,18 +171,16 @@ RequestProcessor::RequestProcessor(std::shared_ptr<PXPConnector> connector_ptr,
         : thread_container_ { "Action Executer" },
           thread_container_mutex_ {},
           connector_ptr_ { connector_ptr },
-          storage_ptr_ { new ResultsStorage(agent_configuration.spool_dir) },
+          storage_ptr_ { new ResultsStorage(agent_configuration.spool_dir,
+                                            agent_configuration.spool_dir_purge_ttl) },
           spool_dir_path_ { agent_configuration.spool_dir },
-          spool_dir_purge_ttl_ { agent_configuration.spool_dir_purge_ttl },
           modules_ {},
           modules_config_dir_ { agent_configuration.modules_config_dir },
           modules_config_ {},
-          spool_dir_purge_thread_ptr_ { nullptr },
-          spool_dir_purge_mutex_ {},
-          spool_dir_purge_cond_var_ {},
           is_destructing_ { false }
 {
     assert(!spool_dir_path_.string().empty());
+    registerPurgeable(storage_ptr_);
     loadModulesConfiguration();
     loadInternalModules(agent_configuration);
 
@@ -193,25 +193,25 @@ RequestProcessor::RequestProcessor(std::shared_ptr<PXPConnector> connector_ptr,
 
     logLoadedModules();
 
-    if (Timestamp::getMinutes(spool_dir_purge_ttl_) > 0) {
-        storage_ptr_->purge(spool_dir_purge_ttl_,
-                            thread_container_.getThreadNames());
-        spool_dir_purge_thread_ptr_.reset(
-            new pcp_util::thread(&RequestProcessor::spoolDirPurgeTask, this));
+    if (!purgeables_.empty()) {
+        for (auto purgeable : purgeables_) {
+            purgeable->purge(purgeable->get_ttl(), thread_container_.getThreadNames());
+        }
+        purge_thread_ptr_.reset(
+            new pcp_util::thread(&RequestProcessor::purgeTask, this));
     }
 }
 
 RequestProcessor::~RequestProcessor()
 {
     {
-        pcp_util::lock_guard<pcp_util::mutex> the_lock { spool_dir_purge_mutex_ };
+        pcp_util::lock_guard<pcp_util::mutex> the_lock { purge_mutex_ };
         is_destructing_ = true;
-        spool_dir_purge_cond_var_.notify_one();
+        purge_cond_var_.notify_one();
     }
 
-    if (spool_dir_purge_thread_ptr_ != nullptr
-            && spool_dir_purge_thread_ptr_->joinable())
-        spool_dir_purge_thread_ptr_->join();
+    if (purge_thread_ptr_ != nullptr && purge_thread_ptr_->joinable())
+        purge_thread_ptr_->join();
 }
 
 void RequestProcessor::processRequest(const RequestType& request_type,
@@ -817,11 +817,18 @@ void RequestProcessor::registerModule(std::shared_ptr<Module> module_ptr)
     }
 }
 
+void RequestProcessor::registerPurgeable(std::shared_ptr<Util::Purgeable> p)
+{
+    if (Timestamp::getMinutes(p->get_ttl()) > 0) {
+        purgeables_.emplace_back(std::move(p));
+    }
+}
+
 void RequestProcessor::loadInternalModules(const Configuration::Agent& agent_configuration)
 {
     registerModule(std::make_shared<Modules::Echo>());
     registerModule(std::make_shared<Modules::Ping>());
-    registerModule(std::make_shared<Modules::Task>(
+    auto task = std::make_shared<Modules::Task>(
         Configuration::Instance().getExecPrefix(),
         agent_configuration.task_cache_dir,
         agent_configuration.task_cache_dir_purge_ttl,
@@ -829,7 +836,9 @@ void RequestProcessor::loadInternalModules(const Configuration::Agent& agent_con
         agent_configuration.ca,
         agent_configuration.crt,
         agent_configuration.key,
-        storage_ptr_));
+        storage_ptr_);
+    registerModule(task);
+    registerPurgeable(task);
 }
 
 void RequestProcessor::loadExternalModulesFrom(fs::path dir_path)
@@ -914,33 +923,48 @@ void RequestProcessor::logLoadedModules() const
 }
 
 //
-// Spool directory purge task (private interface)
+// Resource purge task (private interface)
 //
 
-void RequestProcessor::spoolDirPurgeTask()
+static unsigned int minutes_gcd(std::vector<std::shared_ptr<Util::Purgeable>> purgeables)
 {
-    auto config_minutes = Timestamp::getMinutes(spool_dir_purge_ttl_);
-    auto num_minutes = std::min(60u, config_minutes);
+    assert(!purgeables.empty());
+    auto init = Timestamp::getMinutes(purgeables.front()->get_ttl());
+    if (purgeables.size() > 1) {
+        return std::accumulate(purgeables.begin()+1, purgeables.end(), init,
+            [](unsigned int result, std::shared_ptr<Util::Purgeable> &p) {
+                return boost::math::gcd(result, Timestamp::getMinutes(p->get_ttl()));
+            });
+    } else {
+        return init;
+    }
+}
+
+void RequestProcessor::purgeTask()
+{
+    // Use min of 1h and gcd of purgeable TTLs.
+    auto num_minutes = std::min(60u, minutes_gcd(purgeables_));
     LOG_INFO(lth_loc::format_n(
         // LOCALE: info
-        "Scheduling the check every {1} minute for spool directories to purge; thread id {2}",
-        "Scheduling the check every {1} minutes for spool directories to purge; thread id {2}",
+        "Scheduling the check every {1} minute for directories to purge; thread id {2}",
+        "Scheduling the check every {1} minutes for directories to purge; thread id {2}",
         num_minutes, num_minutes, pcp_util::this_thread::get_id()));
 
     while (true) {
-        pcp_util::unique_lock<pcp_util::mutex> the_lock { spool_dir_purge_mutex_ };
+        pcp_util::unique_lock<pcp_util::mutex> the_lock { purge_mutex_ };
         auto now = pcp_util::chrono::system_clock::now();
 
         if (!is_destructing_)
-            spool_dir_purge_cond_var_.wait_until(
+            purge_cond_var_.wait_until(
                 the_lock,
                 now + pcp_util::chrono::minutes(num_minutes));
 
         if (is_destructing_)
             return;
 
-        storage_ptr_->purge(spool_dir_purge_ttl_,
-                            thread_container_.getThreadNames());
+        for (auto purgeable : purgeables_) {
+            purgeable->purge(purgeable->get_ttl(), thread_container_.getThreadNames());
+        }
     }
 }
 

--- a/lib/src/results_storage.cc
+++ b/lib/src/results_storage.cc
@@ -263,14 +263,11 @@ unsigned int ResultsStorage::purge(
             return true;
         });
 
-    // TODO(ale): deal with locale & plural (PCP-257)
-    if (num_purged_dirs == 1) {
-        LOG_INFO("Removed {1} directory from '{2}'",
-                 num_purged_dirs, spool_dir_path_.string());
-    } else {
-        LOG_INFO("Removed {1} directories from '{2}'",
-                 num_purged_dirs, spool_dir_path_.string());
-    }
+    LOG_INFO(lth_loc::format_n(
+        // LOCALE: info
+        "Removed {1} directory from '{2}'",
+        "Removed {1} directories from '{2}'",
+        num_purged_dirs, num_purged_dirs, spool_dir_path_.string()));
     return num_purged_dirs;
 }
 

--- a/lib/src/thread_container.cc
+++ b/lib/src/thread_container.cc
@@ -82,16 +82,11 @@ ThreadContainer::~ThreadContainer() {
 void ThreadContainer::add(std::string thread_name,
                           pcp_util::thread task,
                           std::shared_ptr<std::atomic<bool>> is_done) {
-    // TODO(ale): deal with locale & plural (PCP-257)
-    if (num_added_threads_ == 1) {
-        LOG_TRACE("Adding thread {1}  (named '{2}') to the '{3}' "
-                  "ThreadContainer; added {4} thread so far",
-                  task.get_id(), thread_name,  name_, num_added_threads_);
-    } else {
-        LOG_TRACE("Adding thread {1}  (named '{2}') to the '{3}' "
-                  "ThreadContainer; added {4} threads so far",
-                  task.get_id(), thread_name,  name_, num_added_threads_);
-    }
+    LOG_TRACE(lth_loc::format_n(
+        // LOCALE: trace
+        "Adding thread {1} (named '{2}') to the '{3}' ThreadContainer; added {4} thread so far",
+        "Adding thread {1} (named '{2}') to the '{3}' ThreadContainer; added {4} threads so far",
+        num_added_threads_, task.get_id(), thread_name,  name_, num_added_threads_));
     pcp_util::lock_guard<pcp_util::mutex> the_lock { mutex_ };
 
     if (findLocked(thread_name))
@@ -107,14 +102,11 @@ void ThreadContainer::add(std::string thread_name,
 
     // Start the monitoring thread, if necessary
     if (!is_monitoring_ && threads_.size() > threads_threshold) {
-        // TODO(ale): deal with locale & plural (PCP-257)
-        if (threads_.size() == 1) {
-            LOG_DEBUG("{1} thread stored in the '{2}' ThreadContainer; about "
-                      "to start the monitoring thread", threads_.size(), name_);
-        } else {
-            LOG_DEBUG("{1} threads stored in the '{2}' ThreadContainer; about "
-                      "to start the monitoring thread", threads_.size(), name_);
-        }
+        LOG_DEBUG(lth_loc::format_n(
+            // LOCALE: debug
+            "{1} thread stored in the '{2}' ThreadContainer; about to start the monitoring thread",
+            "{1} threads stored in the '{2}' ThreadContainer; about to start the monitoring thread",
+            threads_.size(), threads_.size(), name_));
 
         if (monitoring_thread_ptr_ != nullptr
                 && monitoring_thread_ptr_->joinable()) {

--- a/lib/src/time.cc
+++ b/lib/src/time.cc
@@ -124,4 +124,9 @@ bool Timestamp::isNewerThan(const std::string& extended_ISO8601_time)
     }
 }
 
+bool Timestamp::isNewerThan(const std::time_t& t)
+{
+    return time_point > pt::from_time_t(t);
+}
+
 }  // namespace PXPAgent

--- a/lib/tests/common/mock_connector.hpp
+++ b/lib/tests/common/mock_connector.hpp
@@ -38,9 +38,10 @@ static Configuration::Agent AGENT_CONFIGURATION { MODULES,
                                                   CERT,
                                                   KEY,
                                                   SPOOL,
-                                                  "0d",  // don't purge!
+                                                  "0d",  // don't purge spool!
                                                   "",    // modules config dir
                                                   "",    // task cache dir
+                                                  "0d",  // don't purge task cache!
                                                   "test_agent",
                                                   5000,  // connection timeout
                                                   10,    // association timeout

--- a/lib/tests/component/external_modules_interface_test.cc
+++ b/lib/tests/component/external_modules_interface_test.cc
@@ -70,7 +70,7 @@ TEST_CASE("Invalid (by metadata) External Module Configuration", "[component]") 
     }
 }
 
-static ResultsStorage test_storage { SPOOL };
+static ResultsStorage test_storage { SPOOL, "0d" };
 
 void wait_for_module(ResultsStorage& storage, const std::string& t_id)
 {

--- a/lib/tests/unit/agent_test.cc
+++ b/lib/tests/unit/agent_test.cc
@@ -27,9 +27,10 @@ TEST_CASE("Agent::Agent", "[agent]") {
                                                getCertPath(),
                                                getKeyPath(),
                                                SPOOL,
-                                               "0d",  // don't purge!
+                                               "0d",  // don't purge spool!
                                                "",    // modules config dir
                                                "",    // task cache dir
+                                               "0d",  // don't purge task cache!
                                                "test_agent",
                                                5000, 10, 5, 5, 2, 15 };
 

--- a/lib/tests/unit/configuration_test.cc
+++ b/lib/tests/unit/configuration_test.cc
@@ -53,7 +53,7 @@ static const std::string SPOOL_DIR { std::string { PXP_AGENT_ROOT_PATH }
                                      + "/lib/tests/resources/test_spool" };
 static const std::string TASK_CACHE_DIR { std::string { PXP_AGENT_ROOT_PATH }
                                           + "/lib/tests/resources/test_task_cache" };
-
+static const std::string DIR_PURGE_TTL { "1h" };
 
 static const char* ARGV[] = {
     "test-command",
@@ -66,7 +66,9 @@ static const char* ARGV[] = {
     "--modules-dir", MODULES_DIR.c_str(),
     "--modules-config-dir", MODULES_CONFIG_DIR.c_str(),
     "--spool-dir", SPOOL_DIR.c_str(),
+    "--spool-dir-purge-ttl", DIR_PURGE_TTL.c_str(),
     "--task-cache-dir", TASK_CACHE_DIR.c_str(),
+    "--task-cache-dir-purge-ttl", DIR_PURGE_TTL.c_str(),
     "--foreground=true",
     nullptr };
 
@@ -353,6 +355,12 @@ TEST_CASE("Configuration::validate", "[configuration]") {
         fs::remove_all(test_task_cache_dir);
     }
 
+    SECTION("it fails when -task-cache-dir-purge-ttl as not a valid timestamp") {
+        HW::SetFlag<std::string>("task-cache-dir-purge-ttl", "1.0");
+        REQUIRE_THROWS_AS(Configuration::Instance().validate(),
+                          Configuration::Error);
+    }
+
     SECTION("it fails when --spool-dir is empty") {
         HW::SetFlag<std::string>("spool-dir", "");
         REQUIRE_THROWS_AS(Configuration::Instance().validate(),
@@ -374,6 +382,12 @@ TEST_CASE("Configuration::validate", "[configuration]") {
         REQUIRE(fs::exists(test_spool));
 
         fs::remove_all(test_spool);
+    }
+
+    SECTION("it fails when -spool-dir-purge-ttl as not a valid timestamp") {
+        HW::SetFlag<std::string>("spool-dir-purge-ttl", "1.0");
+        REQUIRE_THROWS_AS(Configuration::Instance().validate(),
+                          Configuration::Error);
     }
 }
 

--- a/lib/tests/unit/external_module_test.cc
+++ b/lib/tests/unit/external_module_test.cc
@@ -36,7 +36,7 @@ namespace lth_file = leatherman::file_util;
 static const std::string SPOOL_DIR { std::string { PXP_AGENT_ROOT_PATH }
                                      + "/lib/tests/resources/test_spool" };
 
-static const auto STORAGE = std::make_shared<ResultsStorage>(SPOOL_DIR);
+static const auto STORAGE = std::make_shared<ResultsStorage>(SPOOL_DIR, "0d");
 
 static const std::string REVERSE_TXT {
     (DATA_FORMAT % "\"0987\""

--- a/lib/tests/unit/modules/task_test.cc
+++ b/lib/tests/unit/modules/task_test.cc
@@ -40,7 +40,7 @@ namespace lth_file = leatherman::file_util;
 static const std::string SPOOL_DIR { std::string { PXP_AGENT_ROOT_PATH }
                                      + "/lib/tests/resources/test_spool" };
 
-static const auto STORAGE = std::make_shared<ResultsStorage>(SPOOL_DIR);
+static const auto STORAGE = std::make_shared<ResultsStorage>(SPOOL_DIR, "0d");
 
 static const std::string TASK_CACHE_DIR { std::string { PXP_AGENT_ROOT_PATH }
                                           + "/lib/tests/resources/tasks-cache" };
@@ -472,7 +472,7 @@ TEST_CASE("purge old tasks", "[modules]") {
         fs::last_write_time(fs::path(PURGE_TASK_CACHE)/OLD_TRANSACTION, my_to_time_t(old));
         fs::last_write_time(fs::path(PURGE_TASK_CACHE)/RECENT_TRANSACTION, my_to_time_t(recent));
 
-        auto results = e_m.purge("1h", purgeCallback);
+        auto results = e_m.purge("1h", {}, purgeCallback);
         REQUIRE(results == 1);
         REQUIRE(num_purged_results == 1);
     }

--- a/lib/tests/unit/modules/task_test.cc
+++ b/lib/tests/unit/modules/task_test.cc
@@ -40,6 +40,8 @@ namespace lth_file = leatherman::file_util;
 static const std::string SPOOL_DIR { std::string { PXP_AGENT_ROOT_PATH }
                                      + "/lib/tests/resources/test_spool" };
 
+static const auto STORAGE = std::make_shared<ResultsStorage>(SPOOL_DIR);
+
 static const std::string TASK_CACHE_DIR { std::string { PXP_AGENT_ROOT_PATH }
                                           + "/lib/tests/resources/tasks-cache" };
 
@@ -76,12 +78,12 @@ static const PCPClient::ParsedChunks NON_BLOCKING_CONTENT {
 
 TEST_CASE("Modules::Task", "[modules]") {
     SECTION("can successfully instantiate") {
-        REQUIRE_NOTHROW(Modules::Task(PXP_AGENT_BIN_PATH, TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, SPOOL_DIR));
+        REQUIRE_NOTHROW(Modules::Task(PXP_AGENT_BIN_PATH, TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, STORAGE));
     }
 }
 
 TEST_CASE("Modules::Task::hasAction", "[modules]") {
-    Modules::Task mod { PXP_AGENT_BIN_PATH, TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, SPOOL_DIR };
+    Modules::Task mod { PXP_AGENT_BIN_PATH, TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, STORAGE };
 
     SECTION("correctly reports false") {
         REQUIRE(!mod.hasAction("foo"));
@@ -119,7 +121,7 @@ TEST_CASE("Modules::Task::callAction", "[modules]") {
   lth_util::scope_exit config_cleaner { resetTest };
 
   SECTION("throws module processing error when a file system error is thrown") {
-        Modules::Task e_m { PXP_AGENT_BIN_PATH, TEMP_TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, SPOOL_DIR };
+        Modules::Task e_m { PXP_AGENT_BIN_PATH, TEMP_TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, STORAGE };
         auto existent_sha = "existent";
         boost::nowide::ofstream(TEMP_TASK_CACHE_DIR + "/" + existent_sha);
         auto task_txt = (DATA_FORMAT % "\"0632\""
@@ -146,7 +148,7 @@ TEST_CASE("Modules::Task::callAction - non blocking", "[modules]") {
     lth_util::scope_exit config_cleaner { resetTest };
 
     SECTION("the pid is written to file") {
-        Modules::Task e_m { PXP_AGENT_BIN_PATH, TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, SPOOL_DIR };
+        Modules::Task e_m { PXP_AGENT_BIN_PATH, TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, STORAGE };
         ActionRequest request { RequestType::NonBlocking, NON_BLOCKING_CONTENT };
         fs::path spool_path { SPOOL_DIR };
         auto results_dir = (spool_path / request.transactionId()).string();
@@ -171,7 +173,7 @@ TEST_CASE("Modules::Task::executeAction", "[modules][output]") {
     lth_util::scope_exit config_cleaner { resetTest };
 
     SECTION("passes input as json") {
-        Modules::Task e_m { PXP_AGENT_BIN_PATH, TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, SPOOL_DIR };
+        Modules::Task e_m { PXP_AGENT_BIN_PATH, TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, STORAGE };
         auto echo_txt =
 #ifndef _WIN32
             (DATA_FORMAT % "\"0632\""
@@ -197,7 +199,7 @@ TEST_CASE("Modules::Task::executeAction", "[modules][output]") {
     }
 
     SECTION("passes input only on stdin when input_method is stdin") {
-        Modules::Task e_m { PXP_AGENT_BIN_PATH, TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, SPOOL_DIR };
+        Modules::Task e_m { PXP_AGENT_BIN_PATH, TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, STORAGE };
         auto echo_txt =
 #ifndef _WIN32
             (DATA_FORMAT % "\"0632\""
@@ -227,7 +229,7 @@ TEST_CASE("Modules::Task::executeAction", "[modules][output]") {
     }
 
     SECTION("passes input as env variables") {
-        Modules::Task e_m { PXP_AGENT_BIN_PATH, TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, SPOOL_DIR };
+        Modules::Task e_m { PXP_AGENT_BIN_PATH, TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, STORAGE };
         auto echo_txt =
 #ifndef _WIN32
             (DATA_FORMAT % "\"0632\""
@@ -253,7 +255,7 @@ TEST_CASE("Modules::Task::executeAction", "[modules][output]") {
     }
 
     SECTION("passes input only as env variables when input_method is environment") {
-        Modules::Task e_m { PXP_AGENT_BIN_PATH, TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, SPOOL_DIR };
+        Modules::Task e_m { PXP_AGENT_BIN_PATH, TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, STORAGE };
         auto echo_txt =
 #ifndef _WIN32
             (DATA_FORMAT % "\"0632\""
@@ -279,7 +281,7 @@ TEST_CASE("Modules::Task::executeAction", "[modules][output]") {
     }
 
     SECTION("succeeds on non-zero exit") {
-        Modules::Task e_m { PXP_AGENT_BIN_PATH, TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, SPOOL_DIR };
+        Modules::Task e_m { PXP_AGENT_BIN_PATH, TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, STORAGE };
         auto echo_txt =
 #ifndef _WIN32
             (DATA_FORMAT % "\"0632\""
@@ -312,7 +314,7 @@ TEST_CASE("Modules::Task::executeAction", "[modules][output]") {
     }
 
     SECTION("errors on unparseable output") {
-        Modules::Task e_m { PXP_AGENT_BIN_PATH, TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, SPOOL_DIR };
+        Modules::Task e_m { PXP_AGENT_BIN_PATH, TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, STORAGE };
         auto echo_txt =
 #ifndef _WIN32
             (DATA_FORMAT % "\"0632\""
@@ -347,7 +349,7 @@ TEST_CASE("Modules::Task::executeAction", "[modules][output]") {
     }
 
     SECTION("errors on download when no master-uri is provided") {
-        Modules::Task e_m { PXP_AGENT_BIN_PATH, TEMP_TASK_CACHE_DIR, TASK_CACHE_TTL, {}, CA, CRT, KEY, SPOOL_DIR };
+        Modules::Task e_m { PXP_AGENT_BIN_PATH, TEMP_TASK_CACHE_DIR, TASK_CACHE_TTL, {}, CA, CRT, KEY, STORAGE };
         auto task_txt = (DATA_FORMAT % "\"0632\""
                                      % "\"task\""
                                      % "\"run\""
@@ -368,7 +370,7 @@ TEST_CASE("Modules::Task::executeAction", "[modules][output]") {
     }
 
     SECTION("if a master-uri has a server-side error, then it proceeds to try the next master-uri. if they all fail, it errors on download and removes all temporary files") {
-        Modules::Task e_m { PXP_AGENT_BIN_PATH, TEMP_TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, SPOOL_DIR };
+        Modules::Task e_m { PXP_AGENT_BIN_PATH, TEMP_TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, STORAGE };
         auto cache = fs::path(TEMP_TASK_CACHE_DIR) / "some_sha";
         std::string bad_path = "bad_path";
         auto task_txt = (DATA_FORMAT % "\"0632\""
@@ -395,7 +397,7 @@ TEST_CASE("Modules::Task::executeAction", "[modules][output]") {
     }
 
     SECTION("creates the tasks-cache/<sha> directory with ower/group read and write permissions") {
-        Modules::Task e_m { PXP_AGENT_BIN_PATH, TEMP_TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, SPOOL_DIR };
+        Modules::Task e_m { PXP_AGENT_BIN_PATH, TEMP_TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, STORAGE };
         auto cache = fs::path(TEMP_TASK_CACHE_DIR) / "some_other_sha";
         auto task_txt = (DATA_FORMAT % "\"0632\""
                                      % "\"task\""
@@ -420,7 +422,7 @@ TEST_CASE("Modules::Task::executeAction", "[modules][output]") {
     }
 
     SECTION("succeeds even if tasks-cache was deleted") {
-        Modules::Task e_m { PXP_AGENT_BIN_PATH, TEMP_TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, SPOOL_DIR };
+        Modules::Task e_m { PXP_AGENT_BIN_PATH, TEMP_TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, STORAGE };
         fs::remove_all(TEMP_TASK_CACHE_DIR);
 
         auto cache = fs::path(TEMP_TASK_CACHE_DIR) / "some_other_sha";
@@ -456,7 +458,7 @@ TEST_CASE("purge old tasks", "[modules]") {
     const std::string RECENT_TRANSACTION { "valid_recent" };
 
     // Start with 0 TTL to prevent initial cleanup
-    Modules::Task e_m { PXP_AGENT_BIN_PATH, PURGE_TASK_CACHE, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, SPOOL_DIR };
+    Modules::Task e_m { PXP_AGENT_BIN_PATH, PURGE_TASK_CACHE, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, STORAGE };
 
     unsigned int num_purged_results { 0 };
     auto purgeCallback =

--- a/lib/tests/unit/modules/task_test.cc
+++ b/lib/tests/unit/modules/task_test.cc
@@ -11,10 +11,11 @@
 #include <leatherman/util/scope_exit.hpp>
 #include <leatherman/file_util/file.hpp>
 
-#include <boost/filesystem/operations.hpp>
+#include <boost/filesystem.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/erase.hpp>
+#include <boost/date_time/posix_time/posix_time_types.hpp>
 
 #include <catch.hpp>
 
@@ -31,6 +32,7 @@
 namespace PXPAgent {
 
 namespace fs = boost::filesystem;
+namespace pt = boost::posix_time;
 namespace lth_jc = leatherman::json_container;
 namespace lth_util = leatherman::util;
 namespace lth_file = leatherman::file_util;
@@ -40,6 +42,9 @@ static const std::string SPOOL_DIR { std::string { PXP_AGENT_ROOT_PATH }
 
 static const std::string TASK_CACHE_DIR { std::string { PXP_AGENT_ROOT_PATH }
                                           + "/lib/tests/resources/tasks-cache" };
+
+// Disable cache ttl so we don't delete fixtures.
+static const std::string TASK_CACHE_TTL { "0d" };
 
 static const std::string TEMP_TASK_CACHE_DIR { TASK_CACHE_DIR + "/temp" };
 
@@ -71,12 +76,12 @@ static const PCPClient::ParsedChunks NON_BLOCKING_CONTENT {
 
 TEST_CASE("Modules::Task", "[modules]") {
     SECTION("can successfully instantiate") {
-        REQUIRE_NOTHROW(Modules::Task(PXP_AGENT_BIN_PATH, TASK_CACHE_DIR, MASTER_URIS, CA, CRT, KEY, SPOOL_DIR));
+        REQUIRE_NOTHROW(Modules::Task(PXP_AGENT_BIN_PATH, TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, SPOOL_DIR));
     }
 }
 
 TEST_CASE("Modules::Task::hasAction", "[modules]") {
-    Modules::Task mod { PXP_AGENT_BIN_PATH, TASK_CACHE_DIR, MASTER_URIS, CA, CRT, KEY, SPOOL_DIR };
+    Modules::Task mod { PXP_AGENT_BIN_PATH, TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, SPOOL_DIR };
 
     SECTION("correctly reports false") {
         REQUIRE(!mod.hasAction("foo"));
@@ -114,7 +119,7 @@ TEST_CASE("Modules::Task::callAction", "[modules]") {
   lth_util::scope_exit config_cleaner { resetTest };
 
   SECTION("throws module processing error when a file system error is thrown") {
-        Modules::Task e_m { PXP_AGENT_BIN_PATH, TEMP_TASK_CACHE_DIR, MASTER_URIS, CA, CRT, KEY, SPOOL_DIR };
+        Modules::Task e_m { PXP_AGENT_BIN_PATH, TEMP_TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, SPOOL_DIR };
         auto existent_sha = "existent";
         boost::nowide::ofstream(TEMP_TASK_CACHE_DIR + "/" + existent_sha);
         auto task_txt = (DATA_FORMAT % "\"0632\""
@@ -141,7 +146,7 @@ TEST_CASE("Modules::Task::callAction - non blocking", "[modules]") {
     lth_util::scope_exit config_cleaner { resetTest };
 
     SECTION("the pid is written to file") {
-        Modules::Task e_m { PXP_AGENT_BIN_PATH, TASK_CACHE_DIR, MASTER_URIS, CA, CRT, KEY, SPOOL_DIR };
+        Modules::Task e_m { PXP_AGENT_BIN_PATH, TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, SPOOL_DIR };
         ActionRequest request { RequestType::NonBlocking, NON_BLOCKING_CONTENT };
         fs::path spool_path { SPOOL_DIR };
         auto results_dir = (spool_path / request.transactionId()).string();
@@ -166,7 +171,7 @@ TEST_CASE("Modules::Task::executeAction", "[modules][output]") {
     lth_util::scope_exit config_cleaner { resetTest };
 
     SECTION("passes input as json") {
-        Modules::Task e_m { PXP_AGENT_BIN_PATH, TASK_CACHE_DIR, MASTER_URIS, CA, CRT, KEY, SPOOL_DIR };
+        Modules::Task e_m { PXP_AGENT_BIN_PATH, TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, SPOOL_DIR };
         auto echo_txt =
 #ifndef _WIN32
             (DATA_FORMAT % "\"0632\""
@@ -192,7 +197,7 @@ TEST_CASE("Modules::Task::executeAction", "[modules][output]") {
     }
 
     SECTION("passes input only on stdin when input_method is stdin") {
-        Modules::Task e_m { PXP_AGENT_BIN_PATH, TASK_CACHE_DIR, MASTER_URIS, CA, CRT, KEY, SPOOL_DIR };
+        Modules::Task e_m { PXP_AGENT_BIN_PATH, TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, SPOOL_DIR };
         auto echo_txt =
 #ifndef _WIN32
             (DATA_FORMAT % "\"0632\""
@@ -222,7 +227,7 @@ TEST_CASE("Modules::Task::executeAction", "[modules][output]") {
     }
 
     SECTION("passes input as env variables") {
-        Modules::Task e_m { PXP_AGENT_BIN_PATH, TASK_CACHE_DIR, MASTER_URIS, CA, CRT, KEY, SPOOL_DIR };
+        Modules::Task e_m { PXP_AGENT_BIN_PATH, TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, SPOOL_DIR };
         auto echo_txt =
 #ifndef _WIN32
             (DATA_FORMAT % "\"0632\""
@@ -248,7 +253,7 @@ TEST_CASE("Modules::Task::executeAction", "[modules][output]") {
     }
 
     SECTION("passes input only as env variables when input_method is environment") {
-        Modules::Task e_m { PXP_AGENT_BIN_PATH, TASK_CACHE_DIR, MASTER_URIS, CA, CRT, KEY, SPOOL_DIR };
+        Modules::Task e_m { PXP_AGENT_BIN_PATH, TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, SPOOL_DIR };
         auto echo_txt =
 #ifndef _WIN32
             (DATA_FORMAT % "\"0632\""
@@ -274,7 +279,7 @@ TEST_CASE("Modules::Task::executeAction", "[modules][output]") {
     }
 
     SECTION("succeeds on non-zero exit") {
-        Modules::Task e_m { PXP_AGENT_BIN_PATH, TASK_CACHE_DIR, MASTER_URIS, CA, CRT, KEY, SPOOL_DIR };
+        Modules::Task e_m { PXP_AGENT_BIN_PATH, TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, SPOOL_DIR };
         auto echo_txt =
 #ifndef _WIN32
             (DATA_FORMAT % "\"0632\""
@@ -307,7 +312,7 @@ TEST_CASE("Modules::Task::executeAction", "[modules][output]") {
     }
 
     SECTION("errors on unparseable output") {
-        Modules::Task e_m { PXP_AGENT_BIN_PATH, TASK_CACHE_DIR, MASTER_URIS, CA, CRT, KEY, SPOOL_DIR };
+        Modules::Task e_m { PXP_AGENT_BIN_PATH, TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, SPOOL_DIR };
         auto echo_txt =
 #ifndef _WIN32
             (DATA_FORMAT % "\"0632\""
@@ -342,7 +347,7 @@ TEST_CASE("Modules::Task::executeAction", "[modules][output]") {
     }
 
     SECTION("errors on download when no master-uri is provided") {
-        Modules::Task e_m { PXP_AGENT_BIN_PATH, TEMP_TASK_CACHE_DIR, {}, CA, CRT, KEY, SPOOL_DIR };
+        Modules::Task e_m { PXP_AGENT_BIN_PATH, TEMP_TASK_CACHE_DIR, TASK_CACHE_TTL, {}, CA, CRT, KEY, SPOOL_DIR };
         auto task_txt = (DATA_FORMAT % "\"0632\""
                                      % "\"task\""
                                      % "\"run\""
@@ -363,7 +368,7 @@ TEST_CASE("Modules::Task::executeAction", "[modules][output]") {
     }
 
     SECTION("if a master-uri has a server-side error, then it proceeds to try the next master-uri. if they all fail, it errors on download and removes all temporary files") {
-        Modules::Task e_m { PXP_AGENT_BIN_PATH, TEMP_TASK_CACHE_DIR, MASTER_URIS, CA, CRT, KEY, SPOOL_DIR };
+        Modules::Task e_m { PXP_AGENT_BIN_PATH, TEMP_TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, SPOOL_DIR };
         auto cache = fs::path(TEMP_TASK_CACHE_DIR) / "some_sha";
         std::string bad_path = "bad_path";
         auto task_txt = (DATA_FORMAT % "\"0632\""
@@ -390,7 +395,7 @@ TEST_CASE("Modules::Task::executeAction", "[modules][output]") {
     }
 
     SECTION("creates the tasks-cache/<sha> directory with ower/group read and write permissions") {
-        Modules::Task e_m { PXP_AGENT_BIN_PATH, TEMP_TASK_CACHE_DIR, MASTER_URIS, CA, CRT, KEY, SPOOL_DIR };
+        Modules::Task e_m { PXP_AGENT_BIN_PATH, TEMP_TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, SPOOL_DIR };
         auto cache = fs::path(TEMP_TASK_CACHE_DIR) / "some_other_sha";
         auto task_txt = (DATA_FORMAT % "\"0632\""
                                      % "\"task\""
@@ -415,7 +420,7 @@ TEST_CASE("Modules::Task::executeAction", "[modules][output]") {
     }
 
     SECTION("succeeds even if tasks-cache was deleted") {
-        Modules::Task e_m { PXP_AGENT_BIN_PATH, TEMP_TASK_CACHE_DIR, MASTER_URIS, CA, CRT, KEY, SPOOL_DIR };
+        Modules::Task e_m { PXP_AGENT_BIN_PATH, TEMP_TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, SPOOL_DIR };
         fs::remove_all(TEMP_TASK_CACHE_DIR);
 
         auto cache = fs::path(TEMP_TASK_CACHE_DIR) / "some_other_sha";
@@ -436,4 +441,39 @@ TEST_CASE("Modules::Task::executeAction", "[modules][output]") {
         REQUIRE(fs::is_directory(cache));
     }
 }
+
+// Present in Boost 1.58. That's currently not required, so reproducing it here since it's simple.
+static std::time_t my_to_time_t(pt::ptime t)
+{
+    return (t - pt::ptime(boost::gregorian::date(1970, 1, 1))).total_seconds();
+}
+
+TEST_CASE("purge old tasks", "[modules]") {
+    const std::string PURGE_TASK_CACHE { std::string { PXP_AGENT_ROOT_PATH }
+        + "/lib/tests/resources/purge_test" };
+
+    const std::string OLD_TRANSACTION { "valid_old" };
+    const std::string RECENT_TRANSACTION { "valid_recent" };
+
+    // Start with 0 TTL to prevent initial cleanup
+    Modules::Task e_m { PXP_AGENT_BIN_PATH, PURGE_TASK_CACHE, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, SPOOL_DIR };
+
+    unsigned int num_purged_results { 0 };
+    auto purgeCallback =
+        [&num_purged_results](const std::string&) -> void { num_purged_results++; };
+
+    SECTION("Purges only the old results based on ttl") {
+        num_purged_results = 0;
+        auto now = pt::second_clock::universal_time();
+        auto recent = now - pt::minutes(50);
+        auto old = now - pt::minutes(61);
+        fs::last_write_time(fs::path(PURGE_TASK_CACHE)/OLD_TRANSACTION, my_to_time_t(old));
+        fs::last_write_time(fs::path(PURGE_TASK_CACHE)/RECENT_TRANSACTION, my_to_time_t(recent));
+
+        auto results = e_m.purge("1h", purgeCallback);
+        REQUIRE(results == 1);
+        REQUIRE(num_purged_results == 1);
+    }
+}
+
 }  // namespace PXPAgent

--- a/locales/pxp-agent.pot
+++ b/locales/pxp-agent.pot
@@ -407,11 +407,7 @@ msgid "invalid spool-dir-purge-ttl: {1}"
 msgstr ""
 
 #: lib/src/configuration.cc
-msgid "association-timeout must be positive"
-msgstr ""
-
-#: lib/src/configuration.cc
-msgid "association-request-ttl must be positive"
+msgid "{1} must be positive"
 msgstr ""
 
 #: lib/src/configuration.cc

--- a/locales/pxp-agent.pot
+++ b/locales/pxp-agent.pot
@@ -1088,11 +1088,11 @@ msgstr ""
 #. LOCALE: info
 #: lib/src/request_processor.cc
 msgid ""
-"Starting the task for purging the spool directory every {1} minute; thread "
+"Scheduling the check every {1} minute for spool directories to purge; thread "
 "id {2}"
 msgid_plural ""
-"Starting the task for purging the spool directory every {1} minutes; thread "
-"id {2}"
+"Scheduling the check every {1} minutes for spool directories to purge; "
+"thread id {2}"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/locales/pxp-agent.pot
+++ b/locales/pxp-agent.pot
@@ -16,6 +16,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
 #. error
 #: exe/main.cc
@@ -699,15 +700,12 @@ msgid ""
 "The task executed for the {1} returned invalid UTF-8 on stdout - stderr:{2}"
 msgstr ""
 
-#. warning
+#. LOCALE: warning
 #: lib/src/pxp_connector_v1.cc
 msgid "Message {1} contained {2} bad debug chunk"
-msgstr ""
-
-#. warning
-#: lib/src/pxp_connector_v1.cc
-msgid "Message {1} contained {2} bad debug chunks"
-msgstr ""
+msgid_plural "Message {1} contained {2} bad debug chunks"
+msgstr[0] ""
+msgstr[1] ""
 
 #. info
 #: lib/src/pxp_connector_v1.cc
@@ -1087,19 +1085,16 @@ msgstr ""
 msgid "Loaded '{1}' module - {2}{3}"
 msgstr ""
 
-#. info
+#. LOCALE: info
 #: lib/src/request_processor.cc
 msgid ""
 "Starting the task for purging the spool directory every {1} minute; thread "
 "id {2}"
-msgstr ""
-
-#. info
-#: lib/src/request_processor.cc
-msgid ""
+msgid_plural ""
 "Starting the task for purging the spool directory every {1} minutes; thread "
 "id {2}"
-msgstr ""
+msgstr[0] ""
+msgstr[1] ""
 
 #: lib/src/results_mutex.cc
 msgid "does not exists"
@@ -1204,15 +1199,12 @@ msgid ""
 "directory will not be removed): {2}"
 msgstr ""
 
-#. info
+#. LOCALE: info
 #: lib/src/results_storage.cc
 msgid "Removed {1} directory from '{2}'"
-msgstr ""
-
-#. info
-#: lib/src/results_storage.cc
-msgid "Removed {1} directories from '{2}'"
-msgstr ""
+msgid_plural "Removed {1} directories from '{2}'"
+msgstr[0] ""
+msgstr[1] ""
 
 #. warning
 #: lib/src/thread_container.cc
@@ -1221,23 +1213,31 @@ msgid ""
 "agent will not terminate gracefully"
 msgstr ""
 
+#. LOCALE: trace
+#: lib/src/thread_container.cc
+msgid ""
+"Adding thread {1} (named '{2}') to the '{3}' ThreadContainer; added {4} "
+"thread so far"
+msgid_plural ""
+"Adding thread {1} (named '{2}') to the '{3}' ThreadContainer; added {4} "
+"threads so far"
+msgstr[0] ""
+msgstr[1] ""
+
 #: lib/src/thread_container.cc
 msgid "thread name is already stored"
 msgstr ""
 
-#. debug
+#. LOCALE: debug
 #: lib/src/thread_container.cc
 msgid ""
 "{1} thread stored in the '{2}' ThreadContainer; about to start the "
 "monitoring thread"
-msgstr ""
-
-#. debug
-#: lib/src/thread_container.cc
-msgid ""
+msgid_plural ""
 "{1} threads stored in the '{2}' ThreadContainer; about to start the "
 "monitoring thread"
-msgstr ""
+msgstr[0] ""
+msgstr[1] ""
 
 #. debug
 #: lib/src/thread_container.cc

--- a/locales/pxp-agent.pot
+++ b/locales/pxp-agent.pot
@@ -306,6 +306,10 @@ msgid "TTL for action results before being deleted, default: '{1}' (days)"
 msgstr ""
 
 #: lib/src/configuration.cc
+msgid "TTL for cached tasks before being deleted, default: '{1}' (days)"
+msgstr ""
+
+#: lib/src/configuration.cc
 msgid "Don't daemonize, default: false"
 msgstr ""
 
@@ -403,8 +407,9 @@ msgstr ""
 msgid "the PID file '{1}' is not a regular file"
 msgstr ""
 
+#. LOCALE: invalid configuration option
 #: lib/src/configuration.cc
-msgid "invalid spool-dir-purge-ttl: {1}"
+msgid "invalid {1}: {2}"
 msgstr ""
 
 #: lib/src/configuration.cc

--- a/locales/pxp-agent.pot
+++ b/locales/pxp-agent.pot
@@ -724,16 +724,6 @@ msgid_plural "Removed {1} directories from '{2}'"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/src/modules/task.cc
-msgid ""
-"Scheduling the check every {1} minute for task cache directories to purge; "
-"thread id {2}"
-msgid_plural ""
-"Scheduling the check every {1} minutes for task cache directories to purge; "
-"thread id {2}"
-msgstr[0] ""
-msgstr[1] ""
-
 #. LOCALE: warning
 #: lib/src/pxp_connector_v1.cc
 msgid "Message {1} contained {2} bad debug chunk"
@@ -1122,11 +1112,10 @@ msgstr ""
 #. LOCALE: info
 #: lib/src/request_processor.cc
 msgid ""
-"Scheduling the check every {1} minute for spool directories to purge; thread "
-"id {2}"
+"Scheduling the check every {1} minute for directories to purge; thread id {2}"
 msgid_plural ""
-"Scheduling the check every {1} minutes for spool directories to purge; "
-"thread id {2}"
+"Scheduling the check every {1} minutes for directories to purge; thread id "
+"{2}"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/locales/pxp-agent.pot
+++ b/locales/pxp-agent.pot
@@ -705,6 +705,35 @@ msgid ""
 "The task executed for the {1} returned invalid UTF-8 on stdout - stderr:{2}"
 msgstr ""
 
+#. info
+#: lib/src/modules/task.cc
+msgid "About to purge cached tasks from '{1}'; TTL = {2}"
+msgstr ""
+
+#. error
+#: lib/src/modules/task.cc
+#: lib/src/results_storage.cc
+msgid "Failed to remove '{1}': {2}"
+msgstr ""
+
+#. LOCALE: info
+#: lib/src/modules/task.cc
+#: lib/src/results_storage.cc
+msgid "Removed {1} directory from '{2}'"
+msgid_plural "Removed {1} directories from '{2}'"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/src/modules/task.cc
+msgid ""
+"Scheduling the check every {1} minute for task cache directories to purge; "
+"thread id {2}"
+msgid_plural ""
+"Scheduling the check every {1} minutes for task cache directories to purge; "
+"thread id {2}"
+msgstr[0] ""
+msgstr[1] ""
+
 #. LOCALE: warning
 #: lib/src/pxp_connector_v1.cc
 msgid "Message {1} contained {2} bad debug chunk"
@@ -1185,11 +1214,6 @@ msgstr ""
 msgid "About to purge the results directories from '{1}'; TTL = {2}"
 msgstr ""
 
-#. error
-#: lib/src/results_storage.cc
-msgid "Failed to remove '{1}': {2}"
-msgstr ""
-
 #. warning
 #: lib/src/results_storage.cc
 msgid ""
@@ -1203,13 +1227,6 @@ msgid ""
 "Failed to process the metadata for the transaction {1} (the results "
 "directory will not be removed): {2}"
 msgstr ""
-
-#. LOCALE: info
-#: lib/src/results_storage.cc
-msgid "Removed {1} directory from '{2}'"
-msgid_plural "Removed {1} directories from '{2}'"
-msgstr[0] ""
-msgstr[1] ""
 
 #. warning
 #: lib/src/thread_container.cc


### PR DESCRIPTION
Refactor code to reduce duplication, fix error message. Update README to include task-cache-dir. Switch to format_n for pluralization.

Switch to using min of 1h or spool-dir-purge-ttl. Add task-cache-dir-purge-ttl configuration option.

Purge cached tasks older than task-cache-dir-purge-ttl using a thread similar to spool dir purging. The purging thread uses a mutex to check for shutdown.

A separate mutex is used to ensure a directory is not purged while it is also being used - i.e. ensuring the cache directory exists and has an updated last modified time happens under the mutex. After the mutex releases, purge should be prevented by the updated last modified time. The mutex will block downloading tasks, so it's acquired only while creating+updating the directory or checking+deleting it.