### PR TITLE
(PCP-801) Use kill -15 rather than kill -s TERM for broader support

### DIFF
--- a/acceptance/lib/pxp-agent/test_helper.rb
+++ b/acceptance/lib/pxp-agent/test_helper.rb
@@ -83,6 +83,7 @@ def kill_all_pcp_brokers(host)
   on(host, "ps -C java -f | grep pcp-broker | sed 's/[^0-9]*//' | cut -d\\  -f1") do |result|
     pids = result.stdout.chomp.split("\n")
     pids.each do |pid|
+      # Send SIGKILL (9); not all shells support '-s KILL'
       on(host, "kill -9 #{pid}")
     end
   end
@@ -475,7 +476,8 @@ def stop_sleep_process(targets, seconds_to_sleep, accept_no_pid_found = false)
     pids.each do |pid|
       target['platform'] =~ /win/ ?
         on(target, "taskkill /F /pid #{pid}") :
-        on(target, "kill -s TERM #{pid}")
+        # Send SIGTERM (15); not all shells support '-s TERM'
+        on(target, "kill -15 #{pid}")
     end
   end
 end


### PR DESCRIPTION
The default shell on Solaris 10 (SPARC) doesn't support `kill -s TERM`,
so use `kill -15` instead. This is more consistent with other `kill`
calls used in acceptance tests as well.

[skip ci]