### PR TITLE
(maint) Make task download 404 test more flexible

### DIFF
--- a/acceptance/tests/tasks/task_download.rb
+++ b/acceptance/tests/tasks/task_download.rb
@@ -107,8 +107,7 @@ test_name 'task download' do
     assert_match(/Error 404 Not Found/, on(master, "curl -k https://#{master}:8140/task-files/non_existent_task").stdout.chomp)
 
     run_pxp_errored_task(master, agents, 'echo', "some_file", "1234", {}, "/task-files/non_existent_task") do |description|
-      assert_match(/HTTP status 404/, description, 'Expected 404 HTTP status was not detected')
-      assert_match(/Error 404 Not Found/, description, 'Expected response body was not detected')
+      assert_match(/Error:?\s+404/i, description, 'Expected 404 HTTP status was not detected')
     end
 
     # Ensure things were properly cleaned up


### PR DESCRIPTION
Removes the 404 response body check from the task_download acceptance
tests, so that they don't fail when the body text generated by the
server has been updated.

We saw this happen in an [experimental build](https://jenkins-cinext.delivery.puppetlabs.net/job/experimental_puppet-agent_intn-van-sys_suite-daily-pxp-agent-opswork-1.10.x/SLAVE_LABEL=beaker,TEST_TARGET=amazon6-64a/1/testReport/) today - it seems beyond the scope of these tests to validate the response body from the server. 