### PR TITLE
(maint) Remove use of System.ServiceModel.Web

### DIFF
--- a/exe/PowershellShim-Helper.ps1
+++ b/exe/PowershellShim-Helper.ps1
@@ -6,7 +6,7 @@
 #
 #  > $Json | ConvertFrom-json -Type PSObject
 
-Add-Type -AssemblyName System.ServiceModel.Web, System.Runtime.Serialization
+Add-Type -AssemblyName System.Runtime.Serialization
 $utf8 = [System.Text.Encoding]::UTF8
 
 function Write-Stream {


### PR DESCRIPTION
System.ServiceModel.Web was included as a relic of a previous iteration
of the powershell shim. It requires .NET Framework 3.5, which is newer
than we intended to support. Drop inclusion of that assembly, as it's
not used.