### PR TITLE
(PCP-826) Add helpful error message if .NET assemblies are not found

### DIFF
--- a/exe/PowershellShim-Helper.ps1
+++ b/exe/PowershellShim-Helper.ps1
@@ -6,7 +6,12 @@
 #
 #  > $Json | ConvertFrom-json -Type PSObject
 
-Add-Type -AssemblyName System.ServiceModel.Web, System.Runtime.Serialization
+try {
+  Add-Type -AssemblyName System.ServiceModel.Web, System.Runtime.Serialization -ErrorAction "Stop"
+} catch {
+  throw "PXP Agent could not load the assemblies needed for JSON parsing. Please install .NET Framework 3.5 or greater, or rewrite the task to use a different input method than 'powershell'."
+}
+
 $utf8 = [System.Text.Encoding]::UTF8
 
 function Write-Stream {

--- a/exe/tests/PowershellShim.Tests.ps1
+++ b/exe/tests/PowershellShim.Tests.ps1
@@ -1,3 +1,11 @@
+Describe 'Loading Shim' {
+  Mock Add-Type { throw "Could not load file or assembly 'System.ServiceModel.Web, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35' or one of its dependencies. The system cannot find the file specified." }
+
+  It 'Throws a helpful error message' {
+    { . $PSScriptRoot\..\PowershellShim-Helper.ps1 } | Should -Throw "PXP Agent could not load the assemblies needed for JSON parsing. Please install .NET Framework 3.5 or greater, or rewrite the task to use a different input method than 'powershell'."
+  }
+}
+
 . $PSScriptRoot\..\PowershellShim-Helper.ps1
 
 Describe 'ConvertFrom-Json2 | ConvertFrom-PSCustomObject' {


### PR DESCRIPTION
The powershell shim for using the powershell input method for tasks
requires .NET Framework 3.5. This is a new dependency for pxp-agent, but
isn't required for all functionality. Add a useful error to help users
configure their systems correctly if they want to use the powershell
input method.