### PR TITLE
(RE-9880) Update acceptance tests that reference nightlies

### DIFF
--- a/acceptance/setup/aio/010_Install.rb
+++ b/acceptance/setup/aio/010_Install.rb
@@ -51,7 +51,7 @@ step "Install puppetserver..." do
   else
     if ENV['SERVER_VERSION'].nil? || ENV['SERVER_VERSION'] == 'latest'
       server_version = 'latest'
-      server_download_url = "http://nightlies.puppet.com"
+      server_download_url = "http://ravi.puppetlabs.com"
     else
       server_version = ENV['SERVER_VERSION']
       server_download_url = "http://builds.delivery.puppetlabs.net"


### PR DESCRIPTION
This commit changes the name of the nightlies server to the actual hostname so that when we remove the 'nightlies' cname (to use for *new* nightlies), tests won't break. THIS SHOULD NOT BE PERMANENT (see RE-10231).