### PR TITLE
(FACT-1772) Use CMAKE_INSTALL_LIBDIR for multilib install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.5.7
+
+This is a maintenance release
+
+* [FACT-1772] Use CMAKE\_INSTALL\_LIBDIR when setting RPATH and installing libpxp-agent instead of LIB\_SUFFIX
+
 ## 1.5.6
 
 This is a maintenance release.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,9 +38,11 @@ if ("${CMAKE_SYSTEM_NAME}" MATCHES "Darwin")
 endif()
 
 # Set RPATH if not installing to a system library directory
-list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" INSTALL_IS_SYSTEM_DIR)
+# TODO: Once a new version of Leatherman is released, update this
+# to use the set_cmake_install_rpath macro
+list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}" INSTALL_IS_SYSTEM_DIR)
 if ("${INSTALL_IS_SYSTEM_DIR}" STREQUAL "-1")
-    set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+    set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
 endif()
 
 # Find libraries

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -71,11 +71,7 @@ endif()
 add_library(libpxp-agent STATIC ${LIBRARY_COMMON_SOURCES} ${LIBRARY_STANDARD_SOURCES})
 add_dependencies(libpxp-agent horsewhisperer)
 target_link_libraries(libpxp-agent ${LIBS})
-set_target_properties(libpxp-agent PROPERTIES PREFIX "" IMPORT_PREFIX "")
 
-install(TARGETS libpxp-agent
-    RUNTIME DESTINATION bin
-    LIBRARY DESTINATION lib
-    ARCHIVE DESTINATION lib)
+leatherman_install(lib${PROJECT_NAME})
 
 add_subdirectory(tests)


### PR DESCRIPTION
This allows the libpxp-agent library to be installed in e.g.
/usr/lib, /usr/lib64, etc. depending on the platform that it
is being built on.