### PR TITLE
(PCP-834) Fix pxp-agent log rotation

### DIFF
--- a/ext/systemd/pxp-agent.logrotate
+++ b/ext/systemd/pxp-agent.logrotate
@@ -6,6 +6,6 @@
     notifempty
     sharedscripts
     postrotate
-        if [ systemctl status pxp-agent.service > /dev/null 2>&1 ]; then systemctl kill --signal=USR2 --kill-who=main pxp-agent.service; fi
+        systemctl is-active --quiet pxp-agent.service && systemctl kill --signal=USR2 --kill-who=main pxp-agent.service
     endscript
 }


### PR DESCRIPTION
Previously pxp-agent log rotation didn't complete correctly. It would
rotate the log file, but fail to signal the service because the if
statement was testing the output, not the exit code. Simplify the test
by using is-active and signal the service based on exit code.