### PR TITLE
(maint) Acceptance: Use service scripts to start puppetserver

### DIFF
--- a/acceptance/config/aio/options.rb
+++ b/acceptance/config/aio/options.rb
@@ -1,6 +1,7 @@
 {
   :type => 'aio',
   :is_puppetserver => true,
+  :'use-service' => true, # use service scripts for start/stop
   :puppetservice => 'puppetserver',
   :'puppetserver-confdir' => '/etc/puppetlabs/puppetserver/conf.d',
   :pre_suite => [


### PR DESCRIPTION
Prior to this commit, pxp-agent acceptance is failing in setup
following the removal of the "puppet master" subcommand.

This commit updates the acceptance configuration options so we use
service scripts to start/stop puppetserver services.
