### PR TITLE
(maint) Skip amazon targets for proxy_connection

### DIFF
--- a/acceptance/tests/proxy_connection.rb
+++ b/acceptance/tests/proxy_connection.rb
@@ -5,6 +5,13 @@ require 'puppet/acceptance/environment_utils.rb'
 test_name 'Connect via proxy' do
   extend Puppet::Acceptance::EnvironmentUtils
 
+  # skip amazon6/7 tests
+  agents.each do |agent|
+    if agent['template'] =~ /amazon/
+      skip_test 'Amazon test instances not configured for proxy test setup'
+    end
+  end
+
   # init
   squid_log = "/var/log/squid/access.log"
   proxy = setup_squid_proxy(master)


### PR DESCRIPTION
Amazon test targets not configured to allow proxy connection. Skip.