### PR TITLE
(PCP-835) Add support for task implementations

### DIFF
--- a/acceptance/lib/pxp-agent/task_helper.rb
+++ b/acceptance/lib/pxp-agent/task_helper.rb
@@ -5,14 +5,12 @@ def file_entry(filename, sha256, path = 'foo')
   {:uri => {:path => path, :params => {}}, :filename => filename, :sha256 => sha256}
 end
 
-def run_task(broker, target_identities, task, input, files, rpc_request, expected_response_type, &check_datas)
+def run_task(broker, target_identities, task, input, files, metadata, rpc_request, expected_response_type, &check_datas)
   responses =
     begin
-      rpc_request.call(broker, target_identities,
-                               'task', 'run',
-                               {:task => task,
-                                :input => input,
-                                :files => files})
+      params = { task: task, input: input, files: files }
+      params = params.merge(metadata: metadata) if metadata
+      rpc_request.call(broker, target_identities, 'task', 'run', params)
     rescue => exception
       fail("Exception occurred when trying to run task '#{task}' on all agents: #{exception.message}")
     end
@@ -30,10 +28,11 @@ end
 
 # Runs a task on targets, and passes the output to the block for validation
 # Block should expect a map parsed from the JSON output
-def run_successful_task(broker, targets, task, files, input: {}, max_retries: 30, query_interval: 1, &block)
+def run_successful_task(broker, targets, task, files, input: {}, metadata: nil, max_retries: 30, query_interval: 1, &block)
   target_identities = targets.map {|agent| "pcp://#{agent}/agent"}
 
-  run_task(broker, target_identities, task, input, files, method(:rpc_non_blocking_request), "http://puppetlabs.com/rpc_provisional_response") do |datas|
+  run_task(broker, target_identities, task, input, files, metadata,
+           method(:rpc_non_blocking_request), "http://puppetlabs.com/rpc_provisional_response") do |datas|
     transaction_ids = datas.map { |data| data["transaction_id"] }
     target_identities.zip(transaction_ids).map do |identity, transaction_id|
       check_non_blocking_response(broker, identity, transaction_id, max_retries, query_interval) do |result|
@@ -46,10 +45,11 @@ def run_successful_task(broker, targets, task, files, input: {}, max_retries: 30
   end
 end
 
-def run_failed_task(broker, targets, task, files, input: {}, max_retries: 30, query_interval: 1, &block)
+def run_failed_task(broker, targets, task, files, input: {}, metadata: nil, max_retries: 30, query_interval: 1, &block)
   target_identities = targets.map {|agent| "pcp://#{agent}/agent"}
 
-  run_task(broker, target_identities, task, input, files, method(:rpc_non_blocking_request), "http://puppetlabs.com/rpc_provisional_response") do |datas|
+  run_task(broker, target_identities, task, input, files, metadata,
+           method(:rpc_non_blocking_request), "http://puppetlabs.com/rpc_provisional_response") do |datas|
     transaction_ids = datas.map { |data| data["transaction_id"] }
     target_identities.zip(transaction_ids).map do |identity, transaction_id|
       check_non_blocking_response(broker, identity, transaction_id, max_retries, query_interval) do |result|
@@ -64,10 +64,11 @@ end
 
 # Runs a task that's expected to result in a PXP error. Block should
 # expect the description of the PXP error to verify.
-def run_pxp_errored_task(broker, targets, task, files, input: {}, &block)
+def run_pxp_errored_task(broker, targets, task, files, input: {}, metadata: nil, &block)
   target_identities = targets.map {|agent| "pcp://#{agent}/agent"}
 
-  run_task(broker, target_identities, task, input, files, method(:rpc_blocking_request), "http://puppetlabs.com/rpc_error_message") do |datas|
+  run_task(broker, target_identities, task, input, files, metadata,
+           method(:rpc_blocking_request), "http://puppetlabs.com/rpc_error_message") do |datas|
     descriptions = datas.map { |data| data["description"] }
     descriptions.each { |description| block.call(description) }
   end

--- a/acceptance/tests/proxy_connection.rb
+++ b/acceptance/tests/proxy_connection.rb
@@ -107,7 +107,8 @@ test_name 'Connect via proxy' do
         assert_match(/ensure => 'absent'/, on(agent, puppet("resource file #{tasks_cache}/#{sha256}")).stdout)
       end
       # download task through the web proxy
-      run_successful_task(master, agents, 'echo', filename, sha256, {:message => 'hello'}, "/task-files/#{filename}") do |stdout|
+      files = [file_entry(filename, sha256, "/task-files/#{filename}")]
+      run_successful_task(master, agents, 'echo', files, input: {:message => 'hello'}) do |stdout|
         assert_equal('hello', stdout.strip, "Output did not contain 'hello'")
       end
 

--- a/acceptance/tests/tasks/run_echo.rb
+++ b/acceptance/tests/tasks/run_echo.rb
@@ -26,7 +26,8 @@ test_name 'run echo task' do
   end
 
   step 'Run echo task on agent hosts' do
-    run_successful_task(master, agents, 'echo', 'init.bat', @sha256, {:message => 'hello'}) do |stdout|
+    files = [file_entry('init.bat', @sha256)]
+    run_successful_task(master, agents, 'echo', files, input: {:message => 'hello'}) do |stdout|
       assert_equal('hello', stdout.strip, "Output did not contain 'hello'")
     end
   end # test step

--- a/acceptance/tests/tasks/run_ps1.rb
+++ b/acceptance/tests/tasks/run_ps1.rb
@@ -31,7 +31,8 @@ test_name 'run powershell task' do
   step 'Run powershell task on Windows agent hosts' do
     task_input = JSON.parse(File.read(File.join(fixtures, 'complex-args.json')))
     task_output = File.read(File.join(fixtures, 'complex-output'))
-    run_successful_task(master, windows_hosts, 'echo', 'init.ps1', @sha256, task_input) do |stdout|
+    files = [file_entry('init.ps1', @sha256)]
+    run_successful_task(master, windows_hosts, 'echo', files, input: task_input) do |stdout|
       # Handle some known variations
       stdout.gsub!(/System\.Guid/, 'guid')
       stdout.gsub!(/System\.TimeSpan/, 'timespan')
@@ -46,7 +47,8 @@ test_name 'run powershell task' do
       @sha256 = create_task_on(agent, 'echo', 'init.ps1', task_body)
     end
 
-    run_failed_task(master, windows_hosts, 'echo', 'init.ps1', @sha256, {}) do |stderr|
+    files = [file_entry('init.ps1', @sha256)]
+    run_failed_task(master, windows_hosts, 'echo', files) do |stderr|
       assert_match(/Error trying to do a task/, stderr.delete("\n"), 'stderr did not contain error text')
     end
   end
@@ -58,7 +60,8 @@ test_name 'run powershell task' do
       @sha256 = create_task_on(agent, 'echo', 'init.ps1', task_body)
     end
 
-    run_failed_task(master, windows_hosts, 'echo', 'init.ps1', @sha256, {}) do |stderr|
+    files = [file_entry('init.ps1', @sha256)]
+    run_failed_task(master, windows_hosts, 'echo', files) do |stderr|
       assert_equal(nil, stderr)
     end
   end

--- a/acceptance/tests/tasks/run_puppet.rb
+++ b/acceptance/tests/tasks/run_puppet.rb
@@ -39,7 +39,8 @@ EOF
   end
 
   step 'Run puppet task on agent hosts' do
-    run_successful_task(master, agents, 'hello', 'init.pp', @sha256, {:data => [1, 2, 3]}) do |stdout|
+    files = [file_entry('init.pp', @sha256)]
+    run_successful_task(master, agents, 'hello', files, input: {:data => [1, 2, 3]}) do |stdout|
       assert_match(/Notify\[hello\]\/message: defined 'message' as 'hello'/, stdout, "Output did not contain 'hello'")
     end
   end # test step

--- a/acceptance/tests/tasks/run_ruby.rb
+++ b/acceptance/tests/tasks/run_ruby.rb
@@ -21,7 +21,8 @@ test_name 'run ruby task' do
   end
 
   step 'Run ruby task on agent hosts' do
-    run_successful_task(master, agents, 'echo', 'init.rb', @sha256, {:data => [1, 2, 3]}) do |stdout|
+    files = [file_entry('init.rb', @sha256)]
+    run_successful_task(master, agents, 'echo', files, input: {:data => [1, 2, 3]}) do |stdout|
       json, data = stdout.delete("\r").split("\n")
       assert_equal('{"data":[1,2,3]}', json, "Output did not contain 'data'")
       assert_equal('[1,2,3]', data, "Output did not contain 'data'")

--- a/acceptance/tests/tasks/task_download.rb
+++ b/acceptance/tests/tasks/task_download.rb
@@ -62,7 +62,8 @@ test_name 'task download' do
         assert_match(/ensure => 'absent'/, on(agent, puppet("resource file #{tasks_cache}/#{sha256}")).stdout)
       end
 
-      run_successful_task(master, agents, 'echo', filename, sha256, {:message => 'hello'}, "/task-files/#{filename}") do |stdout|
+      files = [file_entry(filename, sha256, "/task-files/#{filename}")]
+      run_successful_task(master, agents, 'echo', files, input: {:message => 'hello'}, ) do |stdout|
         assert_equal('hello', stdout.strip, "Output did not contain 'hello'")
       end
     end
@@ -86,7 +87,8 @@ test_name 'task download' do
     test_cases = { win_agents => ["init", @win_sha256, "init.bat"], nix_agents => ["init.bat", @nix_sha256, "init"] }
 
     test_cases.each do |agents, (filename, sha256, expected_file)|
-      run_pxp_errored_task(master, agents, 'echo', filename, sha256, {:message => 'hello'}, "/task-files/#{filename}") do |description|
+      files = [file_entry(filename, sha256, "/task-files/#{filename}")]
+      run_pxp_errored_task(master, agents, 'echo', files, input: {:message => 'hello'}) do |description|
         assert_match(/The downloaded #{filename}'s sha differs from the provided sha/, description, 'Expected SHA version conflict was not detected')
       end
 
@@ -106,7 +108,8 @@ test_name 'task download' do
     # the corresponding test.
     assert_match(/Error 404 Not Found/, on(master, "curl -k https://#{master}:8140/task-files/non_existent_task").stdout.chomp)
 
-    run_pxp_errored_task(master, agents, 'echo', "some_file", "1234", {}, "/task-files/non_existent_task") do |description|
+    files = [file_entry('some_file', '1234', "/task-files/non_existent_task")]
+    run_pxp_errored_task(master, agents, 'echo', files) do |description|
       assert_match(/Error:?\s+404/i, description, 'Expected 404 HTTP status was not detected')
     end
 

--- a/acceptance/tests/tasks/task_implementations.rb
+++ b/acceptance/tests/tasks/task_implementations.rb
@@ -1,0 +1,65 @@
+require 'pxp-agent/task_helper.rb'
+require 'pxp-agent/config_helper.rb'
+require 'puppet/acceptance/environment_utils.rb'
+
+test_name 'task downloads correct implementation' do
+
+  extend Puppet::Acceptance::EnvironmentUtils
+
+  PUPPETSERVER_CONFIG_FILE = windows?(master) ?
+    '/cygdrive/c/ProgramData/PuppetLabs/puppetserver/etc/conf.d/webserver.conf'
+  : '/etc/puppetlabs/puppetserver/conf.d/webserver.conf'
+
+  step 'Ensure each agent host has pxp-agent running and associated' do
+    agents.each do |agent|
+      on agent, puppet('resource service pxp-agent ensure=stopped')
+      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_hocon_using_puppet_certs(master, agent))
+      on agent, puppet('resource service pxp-agent ensure=running')
+
+      assert(is_associated?(master, "pcp://#{agent}/agent"),
+             "Agent #{agent} with PCP identity pcp://#{agent}/agent should be associated with pcp-broker")
+    end
+  end
+
+  filename = 'init_rb.rb'
+  step 'Create the downloadable tasks on the master' do
+    # Make the static content path
+    env_name = File.basename(__FILE__, '.*')
+    @static_content_path = File.join(environmentpath, mk_tmp_environment(env_name))
+
+    # Create the task
+    task_body = "#!/opt/puppetlabs/puppet/bin/ruby\nputs ENV['PT_message']"
+    taskpath = "#{@static_content_path}/#{filename}"
+    create_remote_file(master, taskpath, task_body)
+    on master, "chmod 1777 #{taskpath}"
+    @sha256 = Digest::SHA256.hexdigest(task_body + "\n")
+  end
+
+  step 'Setup the static task file mount on puppetserver' do
+    on master, puppet('resource service puppetserver ensure=stopped')
+    hocon_file_edit_in_place_on(master, PUPPETSERVER_CONFIG_FILE) do |host, doc|
+      doc.set_config_value("webserver.static-content", Hocon::ConfigValueFactory.from_any_ref([{
+        "path" => "/task-files",
+        "resource" => @static_content_path
+      }]))
+    end
+    on master, puppet('resource service puppetserver ensure=running')
+  end
+
+  step 'Download and run the task on agent hosts' do
+    agents.each do |agent|
+      tasks_cache = get_tasks_cache(agent)
+      on agent, "rm -rf #{tasks_cache}/#{@sha256}"
+      assert_match(/ensure => 'absent'/, on(agent, puppet("resource file #{tasks_cache}/#{@sha256}")).stdout)
+    end
+
+    files = [file_entry(filename, @sha256, "/task-files/#{filename}"), file_entry('invalid', 'wrong')]
+    metadata = { implementations: [
+      { name: filename, requirements: ['puppet-agent'] },
+      { name: 'invalid' }
+    ]}
+    run_successful_task(master, agents, 'echo', files, input: {:message => 'hello'}, metadata: metadata) do |stdout|
+      assert_equal('hello', stdout.strip, "Output did not contain 'hello'")
+    end
+  end
+end # test

--- a/acceptance/tests/tasks/task_purged_from_cache.rb
+++ b/acceptance/tests/tasks/task_purged_from_cache.rb
@@ -39,7 +39,8 @@ test_name 'remove old task from pxp-agent cache' do
   end
 
   step "Run #{task_name} task on agent hosts to populate cache" do
-    run_successful_task(master, agents, task_name, 'init.bat', @sha256, {:message => 'hello'}){}
+    files = [file_entry('init.bat', @sha256)]
+    run_successful_task(master, agents, task_name, files, input: {:message => 'hello'}){}
   end
 
   step 'Update access time on file and restart pxp-agent to trigger cache purge' do

--- a/lib/inc/pxp-agent/modules/task.hpp
+++ b/lib/inc/pxp-agent/modules/task.hpp
@@ -9,6 +9,7 @@
 #include <cpp-pcp-client/util/thread.hpp>
 
 #include <leatherman/curl/client.hpp>
+#include <set>
 
 namespace PXPAgent {
 namespace Modules {
@@ -54,6 +55,8 @@ class Task : public PXPAgent::Module, public PXPAgent::Util::Purgeable {
         std::vector<std::string> ongoing_transactions,
         std::function<void(const std::string& dir_path)> purge_callback = nullptr) override;
 
+    std::set<std::string> const& features() const;
+
   private:
     std::shared_ptr<ResultsStorage> storage_;
 
@@ -65,6 +68,8 @@ class Task : public PXPAgent::Module, public PXPAgent::Util::Purgeable {
     std::vector<std::string> master_uris_;
 
     uint32_t task_download_connect_timeout_, task_download_timeout_;
+
+    std::set<std::string> features_;
 
     leatherman::curl::client client_;
 

--- a/lib/src/modules/task.cc
+++ b/lib/src/modules/task.cc
@@ -27,7 +27,6 @@
 #include <curl/curl.h>
 
 #include <tuple>
-#include <set>
 
 namespace PXPAgent {
 namespace Modules {
@@ -130,7 +129,8 @@ Task::Task(const fs::path& exec_prefix,
     exec_prefix_ { exec_prefix },
     master_uris_ { master_uris },
     task_download_connect_timeout_ { task_download_connect_timeout },
-    task_download_timeout_ { task_download_timeout }
+    task_download_timeout_ { task_download_timeout },
+    features_ { "puppet-agent" }
 {
     module_name = "task";
     actions.push_back(TASK_RUN_ACTION);
@@ -145,6 +145,11 @@ Task::Task(const fs::path& exec_prefix,
     client_.set_client_cert(crt, key);
     client_.set_supported_protocols(CURLPROTO_HTTPS);
     client_.set_proxy(proxy);
+}
+
+std::set<std::string> const& Task::features() const
+{
+    return features_;
 }
 
 static void addParametersToEnvironment(const lth_jc::JsonContainer &input, std::map<std::string, std::string> &environment)

--- a/lib/tests/unit/modules/task_test.cc
+++ b/lib/tests/unit/modules/task_test.cc
@@ -82,6 +82,15 @@ TEST_CASE("Modules::Task", "[modules]") {
     }
 }
 
+TEST_CASE("Modules::Task::features", "[modules]") {
+    Modules::Task mod { PXP_AGENT_BIN_PATH, TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, "", 10, 20, STORAGE };
+
+    SECTION("reports available features") {
+        REQUIRE(mod.features().size() == 1);
+        REQUIRE(mod.features().find("puppet-agent") != mod.features().end());
+    }
+}
+
 TEST_CASE("Modules::Task::hasAction", "[modules]") {
     Modules::Task mod { PXP_AGENT_BIN_PATH, TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, "", 10, 20, STORAGE };
 

--- a/lib/tests/unit/modules/task_test.cc
+++ b/lib/tests/unit/modules/task_test.cc
@@ -447,6 +447,100 @@ TEST_CASE("Modules::Task::executeAction", "[modules][output]") {
     }
 }
 
+template <typename T>
+static ActionRequest getEchoRequest(T& metadata)
+{
+    auto files = "["
+        "{\"sha256\": \"823c013467ce03b12dbe005757a6c842894373e8bcfb0cf879329afb5abcd543\", \"filename\": \"multi\"},"
+        "{\"sha256\": \"88a07e5b672aa44a91aa7d63e22c91510af5d4707e12f75e0d5de2dfdbde1dec\", \"filename\": \"multi.bat\"}"
+        "]";
+    auto params = boost::format("{\"metadata\": %1%, \"input\":{\"message\":\"hello\"}, \"files\": %2%}") % metadata % files;
+    auto echo_txt = (DATA_FORMAT % "\"0632\"" % "\"task\"" % "\"run\"" % params).str();
+    PCPClient::ParsedChunks echo_content {
+        lth_jc::JsonContainer(ENVELOPE_TXT),
+        lth_jc::JsonContainer(echo_txt),
+        {},
+        0 };
+    return ActionRequest { RequestType::Blocking, echo_content };
+}
+
+TEST_CASE("Modules::Task::executeAction implementations", "[modules][output]") {
+    configureTest();
+    lth_util::scope_exit config_cleaner { resetTest };
+    Modules::Task e_m { PXP_AGENT_BIN_PATH, TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, "", 10, 20, STORAGE };
+
+    SECTION("uses a matching implementation") {
+        auto impls = "["
+#ifdef _WIN32
+            "{\"name\": \"multi.bat\", \"requirements\": [\"puppet-agent\"]},"
+#else
+            "{\"name\": \"multi\", \"requirements\": [\"puppet-agent\"]},"
+#endif
+            "{\"name\": \"invalid\"}"
+            "]";
+        auto metadata = boost::format("{\"implementations\": %1%, \"input_method\": \"environment\"}") % impls;
+
+        auto output = e_m.executeAction(getEchoRequest(metadata)).action_metadata.get<std::string>({ "results", "stdout" });
+        boost::trim(output);
+        REQUIRE(output == "hello");
+    }
+
+    SECTION("uses an unrestricted implementation") {
+        auto impls = "["
+            "{\"name\": \"invalid\", \"requirements\": [\"foobar\"]},"
+#ifdef _WIN32
+            "{\"name\": \"multi.bat\"}"
+#else
+            "{\"name\": \"multi\"}"
+#endif
+            "]";
+        auto metadata = boost::format("{\"implementations\": %1%, \"input_method\": \"environment\"}") % impls;
+
+        auto output = e_m.executeAction(getEchoRequest(metadata)).action_metadata.get<std::string>({ "results", "stdout" });
+        boost::trim(output);
+        REQUIRE(output == "hello");
+    }
+
+    SECTION("uses the implementation's input_method") {
+        auto impls = "["
+#ifdef _WIN32
+            "{\"name\": \"multi.bat\", \"input_method\": \"environment\"}"
+#else
+            "{\"name\": \"multi\", \"input_method\": \"environment\"}"
+#endif
+            "]";
+        auto metadata = boost::format("{\"implementations\": %1%}") % impls;
+
+        auto output = e_m.executeAction(getEchoRequest(metadata)).action_metadata.get<std::string>({ "results", "stdout" });
+        boost::trim(output);
+        REQUIRE(output == "hello");
+    }
+
+    SECTION("errors if no implementations are accepted") {
+        auto impls = "[{\"name\": \"invalid\", \"requirements\": [\"foobar\"]}]";
+        auto metadata = boost::format("{\"implementations\": %1%, \"input_method\": \"environment\"}") % impls;
+
+        auto response = e_m.executeAction(getEchoRequest(metadata));
+        REQUIRE_FALSE(response.action_metadata.includes("results"));
+        REQUIRE_FALSE(response.action_metadata.get<bool>("results_are_valid"));
+        REQUIRE(response.action_metadata.includes("execution_error"));
+        REQUIRE(boost::contains(response.action_metadata.get<std::string>("execution_error"),
+                                "no implementations match supported features: puppet-agent"));
+    }
+
+    SECTION("errors if implementation specifies file that doesn't exist") {
+        auto impls = "[{\"name\": \"invalid\"}]";
+        auto metadata = boost::format("{\"implementations\": %1%, \"input_method\": \"environment\"}") % impls;
+
+        auto response = e_m.executeAction(getEchoRequest(metadata));
+        REQUIRE_FALSE(response.action_metadata.includes("results"));
+        REQUIRE_FALSE(response.action_metadata.get<bool>("results_are_valid"));
+        REQUIRE(response.action_metadata.includes("execution_error"));
+        REQUIRE(boost::contains(response.action_metadata.get<std::string>("execution_error"),
+                                "'invalid' file requested by implementation not found"));
+    }
+}
+
 // Present in Boost 1.58. That's currently not required, so reproducing it here since it's simple.
 static std::time_t my_to_time_t(pt::ptime t)
 {

--- a/locales/pxp-agent.pot
+++ b/locales/pxp-agent.pot
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: pxp-agent 1.9.3\n"
+"Project-Id-Version: pxp-agent 1.10.0\n"
 "Report-Msgid-Bugs-To: docs@puppet.com\n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
@@ -44,7 +44,8 @@ msgid "Fatal error: {1}"
 msgstr ""
 
 #. error
-#: exe/main.cc lib/src/module.cc
+#: exe/main.cc
+#: lib/src/module.cc
 msgid "Unexpected error: {1}"
 msgstr ""
 
@@ -94,7 +95,8 @@ msgstr ""
 msgid "Task '{1}' failed to run: {2}"
 msgstr ""
 
-#: lib/src/action_request.cc lib/src/action_response.cc
+#: lib/src/action_request.cc
+#: lib/src/action_response.cc
 msgid "{1} '{2} {3}' request (transaction {4})"
 msgstr ""
 
@@ -498,7 +500,8 @@ msgid ""
 "The task executed for the {1} returned invalid JSON on stdout - stderr:{2}"
 msgstr ""
 
-#: lib/src/external_module.cc lib/src/modules/task.cc
+#: lib/src/external_module.cc
+#: lib/src/modules/task.cc
 msgid " (empty)"
 msgstr ""
 
@@ -586,7 +589,8 @@ msgstr ""
 msgid "The task for the {1} has completed"
 msgstr ""
 
-#: lib/src/external_module.cc lib/src/module.cc
+#: lib/src/external_module.cc
+#: lib/src/module.cc
 msgid "(empty)"
 msgstr ""
 
@@ -692,10 +696,6 @@ msgstr ""
 msgid "The downloaded {1}'s sha differs from the provided sha"
 msgstr ""
 
-#: lib/src/modules/task.cc
-msgid "at least one file must be specified for a task"
-msgstr ""
-
 #. debug
 #: lib/src/modules/task.cc
 msgid "Verifying task file based on {1}"
@@ -703,6 +703,10 @@ msgstr ""
 
 #: lib/src/modules/task.cc
 msgid "unsupported task input method: {1}"
+msgstr ""
+
+#: lib/src/modules/task.cc
+msgid "at least one file must be specified for a task"
 msgstr ""
 
 #. debug
@@ -723,12 +727,14 @@ msgid "About to purge cached tasks from '{1}'; TTL = {2}"
 msgstr ""
 
 #. error
-#: lib/src/modules/task.cc lib/src/results_storage.cc
+#: lib/src/modules/task.cc
+#: lib/src/results_storage.cc
 msgid "Failed to remove '{1}': {2}"
 msgstr ""
 
 #. LOCALE: info
-#: lib/src/modules/task.cc lib/src/results_storage.cc
+#: lib/src/modules/task.cc
+#: lib/src/results_storage.cc
 msgid "Removed {1} directory from '{2}'"
 msgid_plural "Removed {1} directories from '{2}'"
 msgstr[0] ""
@@ -742,51 +748,60 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. info
-#: lib/src/pxp_connector_v1.cc lib/src/pxp_connector_v2.cc
+#: lib/src/pxp_connector_v1.cc
+#: lib/src/pxp_connector_v2.cc
 msgid "Replied to request {1} with a PCP error message"
 msgstr ""
 
 #. error
-#: lib/src/pxp_connector_v1.cc lib/src/pxp_connector_v2.cc
+#: lib/src/pxp_connector_v1.cc
+#: lib/src/pxp_connector_v2.cc
 msgid "Failed to send PCP error message for request {1}: {2}"
 msgstr ""
 
 #. info
-#: lib/src/pxp_connector_v1.cc lib/src/pxp_connector_v2.cc
+#: lib/src/pxp_connector_v1.cc
+#: lib/src/pxp_connector_v2.cc
 msgid "Sent provisional response for the {1} by {2}"
 msgstr ""
 
 #. error
-#: lib/src/pxp_connector_v1.cc lib/src/pxp_connector_v2.cc
+#: lib/src/pxp_connector_v1.cc
+#: lib/src/pxp_connector_v2.cc
 msgid ""
 "Failed to send provisional response for the {1} by {2} (no further attempts "
 "will be made): {3}"
 msgstr ""
 
 #. info
-#: lib/src/pxp_connector_v1.cc lib/src/pxp_connector_v2.cc
+#: lib/src/pxp_connector_v1.cc
+#: lib/src/pxp_connector_v2.cc
 msgid "Replied to {1} by {2}, request ID {3}, with a PXP error message"
 msgstr ""
 
 #. error
-#: lib/src/pxp_connector_v1.cc lib/src/pxp_connector_v2.cc
+#: lib/src/pxp_connector_v1.cc
+#: lib/src/pxp_connector_v2.cc
 msgid ""
 "Failed to send a PXP error message for the {1} by {2} (no further sending "
 "attempts will be made): {3}"
 msgstr ""
 
 #. info
-#: lib/src/pxp_connector_v1.cc lib/src/pxp_connector_v2.cc
+#: lib/src/pxp_connector_v1.cc
+#: lib/src/pxp_connector_v2.cc
 msgid "Sent response for the {1} by {2}"
 msgstr ""
 
 #. error
-#: lib/src/pxp_connector_v1.cc lib/src/pxp_connector_v2.cc
+#: lib/src/pxp_connector_v1.cc
+#: lib/src/pxp_connector_v2.cc
 msgid "Failed to reply to {1} by {2}, (no further attempts will be made): {3}"
 msgstr ""
 
 #. error
-#: lib/src/pxp_connector_v1.cc lib/src/pxp_connector_v2.cc
+#: lib/src/pxp_connector_v1.cc
+#: lib/src/pxp_connector_v2.cc
 msgid "Failed to reply to the {1} by {2}: {3}"
 msgstr ""
 

--- a/locales/pxp-agent.pot
+++ b/locales/pxp-agent.pot
@@ -702,11 +702,19 @@ msgid "Verifying task file based on {1}"
 msgstr ""
 
 #: lib/src/modules/task.cc
-msgid "unsupported task input method: {1}"
+msgid "no implementations match supported features: {1}"
 msgstr ""
 
 #: lib/src/modules/task.cc
 msgid "at least one file must be specified for a task"
+msgstr ""
+
+#: lib/src/modules/task.cc
+msgid "'{1}' file requested by implementation not found"
+msgstr ""
+
+#: lib/src/modules/task.cc
+msgid "unsupported task input method: {1}"
 msgstr ""
 
 #. debug


### PR DESCRIPTION
Select implementation that matches known features, initially only `puppet-agent`. Uses first file in `files` if no implementations are provided. Errors if implementations are provided but features do not satisfy any of their requirements.