### PR TITLE
(maint) Fix tests that only worked when agents are all windows or not

### DIFF
--- a/acceptance/tests/proxy_connection.rb
+++ b/acceptance/tests/proxy_connection.rb
@@ -87,6 +87,7 @@ test_name 'Connect via proxy' do
       assert(is_associated?(master, "pcp://#{agent}/agent"),
              "Agent #{agent} with PCP identity pcp://#{agent}/agent should be associated with pcp-broker")
     end
+    clear_squid_log(master)
   end
 
   step 'Download and run the task on agent hosts via proxy' do
@@ -116,9 +117,9 @@ test_name 'Connect via proxy' do
         # stop agent to ensure log is generated in proxy access log
         on(agent, puppet('resource service pxp-agent ensure=stopped'))
       end
-      # each agent should have two entries in squid proxy log
+      # each agent should have an entry in squid proxy log
       on(master, "cat #{squid_log}") do |result|
-        assert_equal(result.stdout.split("\n").length, agents.length * 2)
+        assert_equal(agents.length, result.stdout.split("\n").length)
         assert_match(/CONNECT #{master}/, result.stdout, 'Proxy logs did not indicate use of the proxy.' )
       end
       clear_squid_log(master)

--- a/acceptance/tests/tasks/run_ps1.rb
+++ b/acceptance/tests/tasks/run_ps1.rb
@@ -3,7 +3,7 @@ require 'json'
 
 test_name 'run powershell task' do
 
-  windows_hosts = hosts.select {|h| /windows/ =~ h[:platform]}
+  windows_hosts = agents.select {|h| /windows/ =~ h[:platform]}
   if windows_hosts.empty?
     skip_test "No windows hosts to test powershell on"
   end

--- a/acceptance/tests/tasks/task_purged_from_cache.rb
+++ b/acceptance/tests/tasks/task_purged_from_cache.rb
@@ -26,21 +26,15 @@ test_name 'remove old task from pxp-agent cache' do
     end
   end
 
-  step "Create #{task_name} task on agent hosts" do
-    agents.each do |agent|
-      if agent['platform'] =~ /win/
-        task_body = '@echo %PT_message%'
-      else
-        task_body = "#!/bin/sh\necho $PT_message"
+  step "Create #{task_name} task on agent hosts and run it to populate cache" do
+    win_agents, nix_agents = agents.partition { |agent| windows?(agent) }
+    [[win_agents, '@echo %PT_message%'], [nix_agents, "#!/bin/sh\necho $PT_message"]].each do |targets, task_body|
+      targets.each do |agent|
+        @sha256 = create_task_on(agent, task_name, 'init.bat', task_body)
       end
-
-      @sha256 = create_task_on(agent, task_name, 'init.bat', task_body)
+      files = [file_entry('init.bat', @sha256)]
+      run_successful_task(master, targets, task_name, files, {:message => 'hello'}){}
     end
-  end
-
-  step "Run #{task_name} task on agent hosts to populate cache" do
-    files = [file_entry('init.bat', @sha256)]
-    run_successful_task(master, agents, task_name, files, input: {:message => 'hello'}){}
   end
 
   step 'Update access time on file and restart pxp-agent to trigger cache purge' do


### PR DESCRIPTION
Fix tests so they work with a mixed set of agents - the default when
running `rake ci:test:aio` - rather than only working when agents are
all windows or all non-windows.