### PR TITLE
(PCP-849) Set _task metaparameter to the task name

### DIFF
--- a/acceptance/tests/tasks/run_ruby.rb
+++ b/acceptance/tests/tasks/run_ruby.rb
@@ -24,7 +24,7 @@ test_name 'run ruby task' do
     files = [file_entry('init.rb', @sha256)]
     run_successful_task(master, agents, 'echo', files, input: {:data => [1, 2, 3]}) do |stdout|
       json, data = stdout.delete("\r").split("\n")
-      assert_equal('{"data":[1,2,3]}', json, "Output did not contain 'data'")
+      assert_equal({"data" => [1,2,3], "_task" => "echo"}, JSON.parse(json), "Output did not contain 'data'")
       assert_equal('[1,2,3]', data, "Output did not contain 'data'")
     end
   end # test step

--- a/exe/tests/Echo.ps1
+++ b/exe/tests/Echo.ps1
@@ -1,0 +1,8 @@
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)]
+  [String]
+  $Message
+)
+
+Write-Output $Message

--- a/exe/tests/PowershellShim.Tests.ps1
+++ b/exe/tests/PowershellShim.Tests.ps1
@@ -49,3 +49,15 @@ Describe 'ConvertFrom-Json2 | ConvertFrom-PSCustomObject' {
     $arr[1]['version'] | Should -Be 2015
   }
 }
+
+Describe 'PowershellShim' {
+  it 'Runs the powershell script with the parameters supplied as JSON' {
+    $result = '{"message": "hello world"}' | & $PSScriptRoot\..\PowershellShim.ps1 $PSScriptRoot\Echo.ps1
+    $result | Should -Be "hello world"
+  }
+
+  it 'Runs the powershell script with only the parameters it understands' {
+    $result = '{"message": "hello world", "_task": "echo"}' | & $PSScriptRoot\..\PowershellShim.ps1 $PSScriptRoot\Echo.ps1
+    $result | Should -Be "hello world"
+  }
+}

--- a/lib/src/modules/task.cc
+++ b/lib/src/modules/task.cc
@@ -572,6 +572,11 @@ ActionResponse Task::callAction(const ActionRequest& request)
         implementation.input_method = "powershell";
     }
 
+    auto task_name = task_execution_params.get<std::string>("task");
+    auto task_params = task_execution_params.get<lth_jc::JsonContainer>("input");
+
+    task_params.set<std::string>("_task", task_name);
+
     std::map<std::string, std::string> task_environment;
     std::string task_input;
     TaskCommand task_command;
@@ -581,14 +586,14 @@ ActionResponse Task::callAction(const ActionRequest& request)
         task_command = getTaskCommand(exec_prefix_ / "PowershellShim.ps1");
         task_command.arguments.push_back(task_file.string());
         // Pass input on stdin ($input)
-        task_input = task_execution_params.get<lth_jc::JsonContainer>("input").toString();
+        task_input = task_params.toString();
     } else {
         if (implementation.input_method.empty() || implementation.input_method == "stdin") {
-            task_input = task_execution_params.get<lth_jc::JsonContainer>("input").toString();
+            task_input = task_params.toString();
         }
 
         if (implementation.input_method.empty() || implementation.input_method == "environment") {
-            addParametersToEnvironment(task_execution_params.get<lth_jc::JsonContainer>("input"), task_environment);
+            addParametersToEnvironment(task_params, task_environment);
         }
 
         task_command = getTaskCommand(task_file);

--- a/lib/tests/unit/modules/task_test.cc
+++ b/lib/tests/unit/modules/task_test.cc
@@ -136,7 +136,7 @@ TEST_CASE("Modules::Task::callAction", "[modules]") {
         auto task_txt = (DATA_FORMAT % "\"0632\""
                                      % "\"task\""
                                      % "\"run\""
-                                     % "{\"input\":{\"message\":\"hello\"}, \"files\" : [{\"sha256\": \"existent\"}]}").str();
+                                     % "{\"task\": \"test::existent\", \"input\":{\"message\":\"hello\"}, \"files\" : [{\"sha256\": \"existent\"}]}").str();
         PCPClient::ParsedChunks task_content {
             lth_jc::JsonContainer(ENVELOPE_TXT),
             lth_jc::JsonContainer(task_txt),
@@ -188,12 +188,12 @@ TEST_CASE("Modules::Task::executeAction", "[modules][output]") {
             (DATA_FORMAT % "\"0632\""
                          % "\"task\""
                          % "\"run\""
-                         % "{\"input\":{\"message\":\"hello\"}, \"files\" : [{\"sha256\": \"15f26bdeea9186293d256db95fed616a7b823de947f4e9bd0d8d23c5ac786d13\", \"filename\": \"init\"}]}").str();
+                         % "{\"task\": \"test\", \"input\":{\"message\":\"hello\"}, \"files\" : [{\"sha256\": \"15f26bdeea9186293d256db95fed616a7b823de947f4e9bd0d8d23c5ac786d13\", \"filename\": \"init\"}]}").str();
 #else
             (DATA_FORMAT % "\"0632\""
                          % "\"task\""
                          % "\"run\""
-                         % "{\"input\":{\"message\":\"hello\"}, \"files\" : [{\"sha256\": \"e1c10f8c709f06f4327ac6a07a918e297a039a24a788fabf4e2ebc31d16e8dc3\", \"filename\": \"init.bat\"}]}").str();
+                         % "{\"task\": \"test\", \"input\":{\"message\":\"hello\"}, \"files\" : [{\"sha256\": \"e1c10f8c709f06f4327ac6a07a918e297a039a24a788fabf4e2ebc31d16e8dc3\", \"filename\": \"init.bat\"}]}").str();
 #endif
         PCPClient::ParsedChunks echo_content {
             lth_jc::JsonContainer(ENVELOPE_TXT),
@@ -204,7 +204,7 @@ TEST_CASE("Modules::Task::executeAction", "[modules][output]") {
 
         auto output = e_m.executeAction(request).action_metadata.get<std::string>({"results", "stdout"});
         boost::trim(output);
-        REQUIRE(output == "{\"message\":\"hello\"}");
+        REQUIRE(output == "{\"message\":\"hello\",\"_task\":\"test\"}");
     }
 
     SECTION("passes input only on stdin when input_method is stdin") {
@@ -213,12 +213,12 @@ TEST_CASE("Modules::Task::executeAction", "[modules][output]") {
             (DATA_FORMAT % "\"0632\""
                          % "\"task\""
                          % "\"run\""
-                         % "{\"input\":{\"message\":\"hello\"}, \"input_method\": \"stdin\", \"files\" : [{\"sha256\": \"823c013467ce03b12dbe005757a6c842894373e8bcfb0cf879329afb5abcd543\", \"filename\": \"multi\"}]}").str();
+                         % "{\"task\": \"test::multi\", \"input\":{\"message\":\"hello\"}, \"input_method\": \"stdin\", \"files\" : [{\"sha256\": \"823c013467ce03b12dbe005757a6c842894373e8bcfb0cf879329afb5abcd543\", \"filename\": \"multi\"}]}").str();
 #else
             (DATA_FORMAT % "\"0632\""
                          % "\"task\""
                          % "\"run\""
-                         % "{\"input\":{\"message\":\"hello\"}, \"input_method\": \"stdin\", \"files\" : [{\"sha256\": \"88a07e5b672aa44a91aa7d63e22c91510af5d4707e12f75e0d5de2dfdbde1dec\", \"filename\": \"multi.bat\"}]}").str();
+                         % "{\"task\": \"test::multi\", \"input\":{\"message\":\"hello\"}, \"input_method\": \"stdin\", \"files\" : [{\"sha256\": \"88a07e5b672aa44a91aa7d63e22c91510af5d4707e12f75e0d5de2dfdbde1dec\", \"filename\": \"multi.bat\"}]}").str();
 #endif
         PCPClient::ParsedChunks echo_content {
             lth_jc::JsonContainer(ENVELOPE_TXT),
@@ -230,9 +230,9 @@ TEST_CASE("Modules::Task::executeAction", "[modules][output]") {
         auto output = e_m.executeAction(request).action_metadata.get<std::string>({ "results", "stdout" });
         boost::trim(output);
 #ifdef _WIN32
-        REQUIRE(output == "ECHO is on.\r\n{\"message\":\"hello\"}");
+        REQUIRE(output == "ECHO is on.\r\n{\"message\":\"hello\",\"_task\":\"test::multi\"}");
 #else
-        REQUIRE(output == "{\"message\":\"hello\"}");
+        REQUIRE(output == "{\"message\":\"hello\",\"_task\":\"test::multi\"}");
 #endif
     }
 
@@ -242,12 +242,12 @@ TEST_CASE("Modules::Task::executeAction", "[modules][output]") {
             (DATA_FORMAT % "\"0632\""
                          % "\"task\""
                          % "\"run\""
-                         % "{\"input\":{\"message\":\"hello\"}, \"files\" : [{\"sha256\": \"936e85a9b7f1e7b4b593c9f051a36105ed36f7fb8dcff67ff23a3a9af2abe962\", \"filename\": \"printer\"}]}").str();
+                         % "{\"task\":\"test::printer\", \"input\":{\"message\":\"hello\"}, \"files\" : [{\"sha256\": \"936e85a9b7f1e7b4b593c9f051a36105ed36f7fb8dcff67ff23a3a9af2abe962\", \"filename\": \"printer\"}]}").str();
 #else
             (DATA_FORMAT % "\"0632\""
                          % "\"task\""
                          % "\"run\""
-                         % "{\"input\":{\"message\":\"hello\"}, \"files\" : [{\"sha256\": \"1c616ed98f54880444d0c49036cdf930120457c20e7a9a204db750f2d6162999\", \"filename\": \"printer.bat\"}]}").str();
+                         % "{\"task\":\"test::printer\", \"input\":{\"message\":\"hello\"}, \"files\" : [{\"sha256\": \"1c616ed98f54880444d0c49036cdf930120457c20e7a9a204db750f2d6162999\", \"filename\": \"printer.bat\"}]}").str();
 #endif
         PCPClient::ParsedChunks echo_content {
             lth_jc::JsonContainer(ENVELOPE_TXT),
@@ -267,12 +267,12 @@ TEST_CASE("Modules::Task::executeAction", "[modules][output]") {
             (DATA_FORMAT % "\"0632\""
                          % "\"task\""
                          % "\"run\""
-                         % "{\"input\":{\"message\":\"hello\"}, \"input_method\": \"environment\", \"files\" : [{\"sha256\": \"823c013467ce03b12dbe005757a6c842894373e8bcfb0cf879329afb5abcd543\", \"filename\": \"multi\"}]}").str();
+                         % "{\"task\":\"test::multi\", \"input\":{\"message\":\"hello\"}, \"input_method\": \"environment\", \"files\" : [{\"sha256\": \"823c013467ce03b12dbe005757a6c842894373e8bcfb0cf879329afb5abcd543\", \"filename\": \"multi\"}]}").str();
 #else
             (DATA_FORMAT % "\"0632\""
                          % "\"task\""
                          % "\"run\""
-                         % "{\"input\":{\"message\":\"hello\"}, \"input_method\": \"environment\", \"files\" : [{\"sha256\": \"88a07e5b672aa44a91aa7d63e22c91510af5d4707e12f75e0d5de2dfdbde1dec\", \"filename\": \"multi.bat\"}]}").str();
+                         % "{\"task\":\"test::multi\", \"input\":{\"message\":\"hello\"}, \"input_method\": \"environment\", \"files\" : [{\"sha256\": \"88a07e5b672aa44a91aa7d63e22c91510af5d4707e12f75e0d5de2dfdbde1dec\", \"filename\": \"multi.bat\"}]}").str();
 #endif
         PCPClient::ParsedChunks echo_content {
             lth_jc::JsonContainer(ENVELOPE_TXT),
@@ -292,12 +292,12 @@ TEST_CASE("Modules::Task::executeAction", "[modules][output]") {
             (DATA_FORMAT % "\"0632\""
                          % "\"task\""
                          % "\"run\""
-                         % "{\"input\":{\"message\":\"hello\"}, \"files\" : [{\"sha256\" : \"d5b8819b51ecd53b32de74c09def0e71f617076bc8e4f75e1eac99b8f77a6c70\", \"filename\": \"error\"}]}").str();
+                         % "{\"task\": \"test::error\", \"input\":{\"message\":\"hello\"}, \"files\" : [{\"sha256\" : \"d5b8819b51ecd53b32de74c09def0e71f617076bc8e4f75e1eac99b8f77a6c70\", \"filename\": \"error\"}]}").str();
 #else
             (DATA_FORMAT % "\"0632\""
                          % "\"task\""
                          % "\"run\""
-                         % "{\"input\":{\"message\":\"hello\"}, \"files\" : [{\"sha256\" : \"554f86a33add88c371c2bbb79839c9adfd3d420dc5f405a07e97fab54efbe1ba\", \"filename\": \"error.bat\"}]}").str();
+                         % "{\"task\": \"test::error\", \"input\":{\"message\":\"hello\"}, \"files\" : [{\"sha256\" : \"554f86a33add88c371c2bbb79839c9adfd3d420dc5f405a07e97fab54efbe1ba\", \"filename\": \"error.bat\"}]}").str();
 #endif
         PCPClient::ParsedChunks echo_content {
             lth_jc::JsonContainer(ENVELOPE_TXT),
@@ -454,7 +454,7 @@ static ActionRequest getEchoRequest(T& metadata)
         "{\"sha256\": \"823c013467ce03b12dbe005757a6c842894373e8bcfb0cf879329afb5abcd543\", \"filename\": \"multi\"},"
         "{\"sha256\": \"88a07e5b672aa44a91aa7d63e22c91510af5d4707e12f75e0d5de2dfdbde1dec\", \"filename\": \"multi.bat\"}"
         "]";
-    auto params = boost::format("{\"metadata\": %1%, \"input\":{\"message\":\"hello\"}, \"files\": %2%}") % metadata % files;
+    auto params = boost::format("{\"task\": \"test::multi\", \"metadata\": %1%, \"input\":{\"message\":\"hello\"}, \"files\": %2%}") % metadata % files;
     auto echo_txt = (DATA_FORMAT % "\"0632\"" % "\"task\"" % "\"run\"" % params).str();
     PCPClient::ParsedChunks echo_content {
         lth_jc::JsonContainer(ENVELOPE_TXT),


### PR DESCRIPTION
This metaparameter allows a single executable to be used to provide many
tasks, enabling easier code reuse between similar tasks.

This also updates the Powershell shim to only pass along parameters which are understood by the task, to avoid failing when a task doesn't expect the new implicit *_task* parameter.