### PR TITLE
(PCP-838) Update windows agent install paths

### DIFF
--- a/acceptance/lib/pxp-agent/config_helper.rb
+++ b/acceptance/lib/pxp-agent/config_helper.rb
@@ -31,9 +31,9 @@ def pxp_agent_dir(host)
   if (windows?(host))
     # If 32bit Puppet on 64bit Windows then Puppet will be in Program Files (x86)
     if((host.is_x86_64?) && (host[:ruby_arch] == "x86"))
-      return "/cygdrive/c/Program\\ Files\\ \\(x86\\)/Puppet\\ Labs/Puppet/pxp-agent/bin"
+      return "/cygdrive/c/Program\\ Files\\ \\(x86\\)/Puppet\\ Labs/Puppet/puppet/bin"
     end
-    return "/cygdrive/c/Program\\ Files/Puppet\\ Labs/Puppet/pxp-agent/bin"
+    return "/cygdrive/c/Program\\ Files/Puppet\\ Labs/Puppet/puppet/bin"
   end
   "/opt/puppetlabs/puppet/bin"
 end

--- a/acceptance/tests/validate_file_paths.rb
+++ b/acceptance/tests/validate_file_paths.rb
@@ -24,13 +24,15 @@ def config_options(host)
       ruby_arch = /-32/
     end
     if platform =~ ruby_arch
-      pupdir = 'C:/Program Files/Puppet Labs/Puppet'
+      install_root = 'C:/Program Files/Puppet Labs/Puppet'
     else
-      pupdir = 'C:/Program Files (x86)/Puppet Labs/Puppet'
+      install_root = 'C:/Program Files (x86)/Puppet Labs/Puppet'
     end
 
-    exdir = "#{pupdir}/pxp-agent"
-    binfile = "#{exdir}/bin/pxp-agent.exe"
+    exdir = "#{install_root}/pxp-agent"
+    pupdir = "#{install_root}/puppet"
+
+    binfile = "#{pupdir}/bin/pxp-agent.exe"
     moduledir = "#{exdir}/modules"
     puppetlabs_data = "#{common_app_data}/PuppetLabs"
     confdir = "#{puppetlabs_data}/pxp-agent/etc"
@@ -39,7 +41,7 @@ def config_options(host)
     logdir = "#{vardir}/log"
     spooldir = "#{vardir}/spool"
     rundir = "#{vardir}/run"
-    nssm =  "#{pupdir}/service/nssm.exe"
+    nssm =  "#{pupdir}/bin/nssm.exe"
 
   else
     bindir = '/opt/puppetlabs/puppet/bin'

--- a/lib/src/configuration.cc
+++ b/lib/src/configuration.cc
@@ -82,14 +82,16 @@ namespace lth_util = leatherman::util;
             throw Configuration::Error {
                 lth_loc::translate("failed to retrive pxp-agent binary path") };
         }
-        // Go up twice, assuming the subtree from Puppet Specs:
-        //      C:\Program Files\Puppet Labs\Puppet\pxp-agent
-        //          bin
-        //              pxp-agent.exe
-        //          modules
-        //              pxp-module-puppet
+        // Go up three times, assuming the subtree from Puppet Specs:
+        //      C:\Program Files\Puppet Labs\Puppet
+        //          puppet
+        //              bin
+        //                  pxp-agent.exe
+        //          pxp-agent
+        //              modules
+        //                  pxp-module-puppet
         try {
-            return (fs::path(szPath).parent_path().parent_path() / "modules").string();
+            return (fs::path(szPath).parent_path().parent_path().parent_path() / "pxp-agent" / "modules").string();
         } catch (const std::exception& e) {
             throw Configuration::Error {
                 lth_loc::format("failed to determine the modules directory path: {1}",


### PR DESCRIPTION
This updates paths for Windows so that they match new installation paths in puppet-agent 6. 

The puppet-specifications PR for these new paths is here: https://github.com/puppetlabs/puppet-specifications/pull/123. These changes shouldn't be merged until that PR is merged.

These changes should be merged at the same time as the changes that require them in puppet-agent, here: https://github.com/puppetlabs/puppet-agent/pull/1517.