### PR TITLE
(PCP-856) Update tests to use 'puppetserver ca'

### DIFF
--- a/acceptance/setup/common/060_Setup_PCP_Client.rb
+++ b/acceptance/setup/common/060_Setup_PCP_Client.rb
@@ -5,16 +5,16 @@ require 'fileutils'
 test_name 'Set up SSL certs for pcp-client to use'
 
 step 'On master create certs for the host running pcp-client' do
-  hostname = Socket.gethostname
-  on master, puppet("cert generate #{hostname}")
+  hostname = Socket.gethostname.downcase
+  on master, "puppetserver ca generate --certname #{hostname}"
   on(master, puppet('config print ssldir')) do |result|
     puppet_ssldir = result.stdout.chomp
     FileUtils.mkdir_p('tmp/ssl/private_keys')
     FileUtils.mkdir_p('tmp/ssl/public_keys')
     FileUtils.mkdir_p('tmp/ssl/certs')
-    scp_from(master, "#{puppet_ssldir}/private_keys/#{hostname.downcase}.pem", 'tmp/ssl/private_keys')
-    scp_from(master, "#{puppet_ssldir}/public_keys/#{hostname.downcase}.pem", 'tmp/ssl/public_keys')
-    scp_from(master, "#{puppet_ssldir}/certs/#{hostname.downcase}.pem", 'tmp/ssl/certs')
+    scp_from(master, "#{puppet_ssldir}/private_keys/#{hostname}.pem", 'tmp/ssl/private_keys')
+    scp_from(master, "#{puppet_ssldir}/public_keys/#{hostname}.pem", 'tmp/ssl/public_keys')
+    scp_from(master, "#{puppet_ssldir}/certs/#{hostname}.pem", 'tmp/ssl/certs')
     scp_from(master, "#{puppet_ssldir}/certs/ca.pem", 'tmp/ssl/certs')
   end
 end


### PR DESCRIPTION
Puppet 6 is removing `puppet cert`. Update tests to use `puppetserver
ca`. For the `invalid_ssl_config` test, this requires a small change in
implementation to generate the alternate CA on the master and copy certs
around, because it's no longer simple to generate it on each agent.