### PR TITLE
(PCP-857) Allow lost message to restarted service

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ install:
   - choco install -y pl-openssl-x64 -Version 1.0.24.1 -source https://www.myget.org/F/puppetlabs
   - choco install -y pl-curl-x64 -Version 7.46.0.1 -source https://www.myget.org/F/puppetlabs
   - choco install -y pl-zlib-x64 -Version 1.2.8.1 -source https://www.myget.org/F/puppetlabs
-  - choco install -y pester --pre
+  - choco install -y pester
 
     # Minimize environment polution; previously we were linking against the wrong OpenSSL DLLs.
     # Include Ruby and Powershell for unit tests.


### PR DESCRIPTION
Allow that a status request may be undelivered to pxp-agent immediately
after restarting the service. We've seen some occasions where the
service restarts but pcp-broker doesn't receive a disconnect meaning it
always looks like pxp-agent is connected; that can result in losing a
message and waiting 60 seconds before timing out. Add one retry in case
that happened, consistent with how other tools (such as Orchestrator)
implement resilience against lost connections.