### PR TITLE
(maint) Replace :fail_on_fail with :accept_all_exit_codes

### DIFF
--- a/acceptance/tests/service_stop_start.rb
+++ b/acceptance/tests/service_stop_start.rb
@@ -15,7 +15,7 @@ teardown do
     # 'puppet resource service pxp-agent' will not work as expected
     # Workaround: stop/start it using net
     if(windows?(agent)) then
-      on(agent, 'net stop pxp-agent', :fail_on_fail => false) # Will error if already stopped, ignore
+      on(agent, 'net stop pxp-agent', :accept_all_exit_codes => true) # Will error if already stopped, ignore
       on(agent, 'net start pxp-agent')
     end
     on(agent, puppet('resource service pxp-agent ensure=running'))


### PR DESCRIPTION
:fail_on_fail is not a supported option of the Beaker DSL's 'on'
method. Use :accept_all_exit_codes instead.