### PR TITLE
(maint) Explicitly require beaker-vmpooler for acceptance

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -16,6 +16,7 @@ gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 4')
 gem 'beaker-puppet', *location_for(ENV['BEAKER_PUPPET_VERSION'] || '~> 1')
 gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 1.1")
 gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.5")
+gem "beaker-vmpooler", *location_for(ENV['BEAKER_VMPOOLER_VERSION'] || "~> 1")
 gem 'rake'
 gem 'scooter', '~> 3.2.17'
 gem 'pcp-client', '~> 0.4'

--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -16,6 +16,7 @@ gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 4')
 gem 'beaker-puppet', *location_for(ENV['BEAKER_PUPPET_VERSION'] || '~> 1')
 gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 1.1")
 gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.5")
+gem "beaker-vagrant", *location_for(ENV['BEAKER_VAGRANT_VERSION'] || "~> 0")
 gem "beaker-vmpooler", *location_for(ENV['BEAKER_VMPOOLER_VERSION'] || "~> 1")
 gem 'rake'
 gem 'scooter', '~> 3.2.17'


### PR DESCRIPTION
No longer included as part of beaker