### PR TITLE
(maint) Set `server` in puppet.conf in acceptance

### DIFF
--- a/acceptance/setup/common/045_SetPuppetServerOnAgents.rb
+++ b/acceptance/setup/common/045_SetPuppetServerOnAgents.rb
@@ -1,3 +1,3 @@
 test_name 'Configure puppet server on each agent'
 
-on agents, puppet("config set server #{master} --section agent")
+on agents, puppet("config set server #{master} --section main")

--- a/acceptance/setup/common/060_Setup_PCP_Client.rb
+++ b/acceptance/setup/common/060_Setup_PCP_Client.rb
@@ -5,6 +5,9 @@ require 'fileutils'
 test_name 'Set up SSL certs for pcp-client to use'
 
 step 'On master create certs for the host running pcp-client' do
+  master_fqdn = on(master, 'facter fqdn').stdout.strip
+  on master, puppet("config set server #{master_fqdn} --section main")
+
   hostname = Socket.gethostname.downcase
   on master, "puppetserver ca generate --certname #{hostname}"
   on(master, puppet('config print ssldir')) do |result|

--- a/acceptance/tests/pxp-module-puppet/run_puppet_killed_puppet.rb
+++ b/acceptance/tests/pxp-module-puppet/run_puppet_killed_puppet.rb
@@ -29,7 +29,6 @@ test_name 'Run Puppet while a Puppet Agent run is in-progress, wait for it to be
   end
 
   step 'Start long-running Puppet agent jobs' do
-
     agents.each do |agent|
       on agent, puppet('agent', '--test', '--environment', environment_name, '--server', "#{master}",
                        '</dev/null >/dev/null 2>&1 & echo $!')


### PR DESCRIPTION
- Specify the `server` setting in puppet.conf to avoid requiring the use
  of `--server <server>` in acceptance tests; The puppetserver ca CLI does
  not have a `--server` flag like puppet does
- Ensure that the `server` setting is written to the [main] section (not
  [agent]) during setup

This is expected to resolve acceptance test failures [like these](https://jenkins-master-prod-1.delivery.puppetlabs.net/view/puppet-agent/view/Acceptance%20Suites/view/6.0.x/view/Suite/job/platform_puppet-agent_puppet-agent-integration-suite_daily-6.0.x/62/), but it must be tested alongside https://github.com/puppetlabs/beaker-puppet/pull/85 -- I'll update once I have an example run.