### PR TITLE
(PCP-833) Kill all pxp-agent processes during restart

### DIFF
--- a/ext/debian/pxp-agent.init
+++ b/ext/debian/pxp-agent.init
@@ -32,7 +32,15 @@ start_pxp_agent() {
 }
 
 stop_pxp_agent() {
-    start-stop-daemon --stop --retry TERM/10/KILL/5 --quiet --oknodo --pidfile $pidfile --name $prog && rm -f "${pidfile}"
+    start-stop-daemon --stop --retry TERM/10/KILL/5 --quiet --oknodo --pidfile $pidfile --name $prog
+
+    pids=$(pgrep -u `whoami` -x $prog)
+    if [ -n "${pids}" ]; then
+        trap '' TERM
+        pkill -TERM  -u `whoami` -f $exec 2>/dev/null
+        trap TERM
+    fi
+    rm -f "${pidfile}"
 }
 
 restart_pxp_agent() {

--- a/ext/redhat/pxp-agent.init
+++ b/ext/redhat/pxp-agent.init
@@ -55,6 +55,15 @@ stop() {
             RETVAL=$?
         fi
     fi
+
+    pids=$(pgrep -u `whoami` -x $prog)
+    # Ensure we killed all pxp-agent processes owned by the current user
+    if [ -n "${pids}" ]; then
+        trap '' TERM
+        pkill -TERM  -u `whoami` -f $exec 2>/dev/null
+        trap TERM
+    fi
+
     echo
     [ $RETVAL = 0 ] && rm -f ${lockfile} ${pidfile}
     return $RETVAL

--- a/ext/suse/pxp-agent.init
+++ b/ext/suse/pxp-agent.init
@@ -103,9 +103,19 @@ case "$1" in
             fi
         fi
 
-        killproc -QUIT -p "${pidfile}" "${exec}" && rm -f "${lockfile}" "${pidfile}"
-        # Remember status and be verbose
-        rc_status -v
+        if [ ! $done ]; then
+          killproc -QUIT -p "${pidfile}" "${exec}" && rm -f "${lockfile}" "${pidfile}"
+          # Remember status and be verbose
+          rc_status -v
+        fi
+
+        pids=$(pgrep -u `whoami` -f $exec)
+        # Ensure we killed all pxp-agent processes owned by the current user
+        if [ -n "${pids}" ]; then
+          trap '' TERM
+          pkill -TERM  -u `whoami` -f $exec 2>/dev/null
+          trap TERM
+        fi
         ;;
     try-restart|condrestart)
         ## Stop the service and if this succeeds (i.e. the


### PR DESCRIPTION
This modifies the pxp-agent sysv init script to use `killall pxp-agent` in place of `killproc` when stopping the pxp-agent service. `killproc` did not properly remove all pxp-agent processes, but did remove the pxp-agent pid file, which led to dangling processes that never got cleaned up. This PR also removes logic around using `kill` or `killproc` in the stop function, since it's now not necessary.

Note: the `killall` pattern is copied from sshd.

To reproduce the issue on CentOS 6:
1. Install the puppet-agent
1. Run `pgrep -x pxp-agent` to see the current process id
1. Remove the pxp-agent pid file at `/var/run/puppetlabs/pxp-agent.pid`
1. Restart the pxp-agent service: `service pxp-agent restart`
1. Run `pgrep -x pxp-agent` to see that there are now 2 process ids