### PR TITLE
(PCP-814) Stop writing task execution params to disk

### DIFF
--- a/lib/src/request_processor.cc
+++ b/lib/src/request_processor.cc
@@ -217,8 +217,6 @@ RequestProcessor::~RequestProcessor()
 void RequestProcessor::processRequest(const RequestType& request_type,
                                       const PCPClient::ParsedChunks& parsed_chunks)
 {
-    LOG_TRACE("About to validate and process PXP request message: {1}",
-              parsed_chunks.toString());
     try {
         // Inspect and validate the request message format
         ActionRequest request { request_type, parsed_chunks };

--- a/lib/src/results_storage.cc
+++ b/lib/src/results_storage.cc
@@ -40,7 +40,11 @@ bool ResultsStorage::find(const std::string& transaction_id)
     return fs::exists(p) && fs::is_directory(p);
 }
 
-static void writeMetadata(const std::string& txt, const std::string& file_path) {
+static void writeMetadata(const lth_jc::JsonContainer& metadata, const std::string& file_path) {
+    // Redact "request_params" key in case parameters are sensitive.
+    lth_jc::JsonContainer metadata_ { metadata };
+    metadata_.set<std::string>("request_params", "{}");
+    std::string txt = metadata_.toString() + "\n";
     try {
         lth_file::atomic_write_to_file(txt, file_path, NIX_FILE_PERMS, std::ios::binary);
     } catch (const std::exception& e) {
@@ -68,7 +72,7 @@ void ResultsStorage::initializeMetadataFile(const std::string& transaction_id,
     }
 
     auto metadata_file = (results_path / METADATA).string();
-    writeMetadata(metadata.toString() + "\n", metadata_file);
+    writeMetadata(metadata, metadata_file);
 }
 
 void ResultsStorage::updateMetadataFile(const std::string& transaction_id,
@@ -80,7 +84,7 @@ void ResultsStorage::updateMetadataFile(const std::string& transaction_id,
                             transaction_id) };
 
     auto metadata_file = (spool_dir_path_ / transaction_id / METADATA).string();
-    writeMetadata(metadata.toString() + "\n", metadata_file);
+    writeMetadata(metadata, metadata_file);
 }
 
 lth_jc::JsonContainer

--- a/lib/tests/component/external_modules_interface_test.cc
+++ b/lib/tests/component/external_modules_interface_test.cc
@@ -99,7 +99,7 @@ TEST_CASE("Process correctly requests for external modules", "[component]") {
     dummy_metadata.set<std::string>("requester", "foo");
     dummy_metadata.set<std::string>("module", "reverse_valid");
     dummy_metadata.set<std::string>("action", "string");
-    dummy_metadata.set<std::string>("request_params", "{}");
+    dummy_metadata.set<std::string>("request_params", "abc");
     dummy_metadata.set<std::string>("transaction_id", "0");
     dummy_metadata.set<std::string>("request_id", "0");
     dummy_metadata.set<bool>("notify_outcome", false);
@@ -197,8 +197,10 @@ TEST_CASE("Process correctly requests for external modules", "[component]") {
             REQUIRE_NOTHROW(r_p.processRequest(RequestType::NonBlocking, p_c));
             REQUIRE(c_ptr->sent_provisional_response);
 
-            // Verify metadata file wasn't updated, i.e. no action was run.
-            REQUIRE(dummy_metadata.toString() == test_storage.getActionMetadata(t_id).toString());
+            // Verify metadata file wasn't updated, i.e. no action was run. "request_params" should be emptied to
+            // prevent writing sensitive metadata to disk.
+            dummy_metadata.set<std::string>("request_params", "{}");
+            REQUIRE(dummy_metadata.toString().compare(test_storage.getActionMetadata(t_id).toString()) == 0);
         }
 
         SECTION("send a provisional response when a duplicate request for a forgotten"
@@ -234,8 +236,10 @@ TEST_CASE("Process correctly requests for external modules", "[component]") {
             REQUIRE_NOTHROW(r_p2.processRequest(RequestType::NonBlocking, p_c));
             REQUIRE(c_ptr->sent_provisional_response);
 
-            // Verify metadata file wasn't updated, i.e. no action was run.
-            REQUIRE(dummy_metadata.toString() == test_storage.getActionMetadata(t_id).toString());
+            // Verify metadata file wasn't updated, i.e. no action was run. "request_params" should be emptied to
+            // prevent writing sensitive metadata to disk.
+            dummy_metadata.set<std::string>("request_params", "{}");
+            REQUIRE(dummy_metadata.toString().compare(test_storage.getActionMetadata(t_id).toString()) == 0);
         }
 
         SECTION("send a non-blocking response when the requested action succeeds") {


### PR DESCRIPTION
Potentially sensitive task execution parameters were being
written to spool-dir. This modifies the way the metadata
is written to enter `"null"` for the "request_params" key.