### PR TITLE
(PCP-871) Extract a base module class for bolt support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
 
 script:
   - >
-    docker run -v `pwd`:/pxp-agent gcr.io/cpp-projects/cpp-ci:1 /bin/bash -c "
+    docker run -v `pwd`:/pxp-agent gcr.io/cpp-projects/cpp-ci:3 /bin/bash -c "
     wget https://github.com/puppetlabs/leatherman/releases/download/${LEATHERMAN_VERSION}/leatherman.tar.gz &&
     tar xzvf leatherman.tar.gz --strip 1 -C / &&
     wget https://github.com/puppetlabs/cpp-pcp-client/releases/download/${CPP_PCP_CLIENT_VERSION}/cpp-pcp-client.tar.gz &&

--- a/exe/tests/main.cc
+++ b/exe/tests/main.cc
@@ -18,8 +18,7 @@ namespace lth_util = leatherman::util;
 
 // Creates a unique temporary directory.
 struct temp_directory {
-    temp_directory() {
-        dir = fs::absolute(fs::unique_path("task_fixture_%%%%-%%%%-%%%%-%%%%"));
+    temp_directory() : dir{fs::absolute(fs::unique_path("task_fixture_%%%%-%%%%-%%%%-%%%%"))} {
         fs::create_directory(dir);
     }
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -31,6 +31,7 @@ set(LIBRARY_COMMON_SOURCES
     src/modules/echo.cc
     src/modules/ping.cc
     src/modules/task.cc
+    src/util/utf8.cc
 )
 
 if (UNIX)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -31,6 +31,7 @@ set(LIBRARY_COMMON_SOURCES
     src/modules/echo.cc
     src/modules/ping.cc
     src/modules/task.cc
+    src/util/bolt_module.cc
     src/util/utf8.cc
 )
 

--- a/lib/inc/pxp-agent/util/bolt_module.hpp
+++ b/lib/inc/pxp-agent/util/bolt_module.hpp
@@ -1,0 +1,72 @@
+#ifndef SRC_UTIL_BOLT_MODULE_HPP_
+#define SRC_UTIL_BOLT_MODULE_HPP_
+
+#include <pxp-agent/action_response.hpp>
+#include <pxp-agent/module.hpp>
+#include <pxp-agent/results_storage.hpp>
+
+#include <leatherman/execution/execution.hpp>
+
+#include <boost/filesystem.hpp>
+
+namespace PXPAgent {
+namespace Util {
+
+// CommandObject holds collected parameters for leatherman's execution methods
+struct CommandObject {
+    std::string executable;
+    std::vector<std::string> arguments;
+    std::map<std::string, std::string> environment;
+    std::string input;
+    std::function<void(size_t)> pid_callback;
+};
+
+// This module is a basis for PXP modules supporting bolt functionality
+class BoltModule : public PXPAgent::Module {
+    public:
+        explicit BoltModule(std::shared_ptr<ResultsStorage> storage)
+           : storage_(std::move(storage)) {}
+
+        /// Whether the module supports non-blocking / asynchronous requests.
+        bool supportsAsync() override { return true; }
+
+        /// Log information about the output of the performed action
+        /// while validating the output is valid UTF-8.
+        /// Update the metadata of the ActionResponse instance (the
+        /// 'results_are_valid', 'status', and 'execution_error' entries
+        /// will be set appropriately; 'end' will be set to the current
+        /// time).
+        /// This function does not throw a ProcessingError in case of
+        /// invalid output on stdout; such failure is instead reported
+        /// in the response object's metadata.
+        void processOutputAndUpdateMetadata(ActionResponse& response) override;
+
+    protected:
+        std::shared_ptr<ResultsStorage> storage_;
+
+        // Construct a CommandObject based on an ActionRequest - all inheriting classes must implement this method.
+        virtual CommandObject buildCommandObject(const ActionRequest& request) = 0;
+
+        // Execute a CommandObject synchronously
+        virtual leatherman::execution::result run_sync(const CommandObject &cmd);
+
+        // Execute a CommandObject asynchronously, spawning a new process
+        virtual leatherman::execution::result run(const CommandObject &cmd);
+
+        virtual void callBlockingAction(
+                const ActionRequest& request,
+                const Util::CommandObject &command,
+                ActionResponse &response);
+
+        virtual void callNonBlockingAction(
+                const ActionRequest& request,
+                const CommandObject &command,
+                ActionResponse &response);
+
+        ActionResponse callAction(const ActionRequest& request) override;
+};
+
+}  // namespace Util
+}  // namespace PXPAgent
+
+#endif  // SRC_UTIL_BOLT_MODULE_HPP_

--- a/lib/inc/pxp-agent/util/utf8.hpp
+++ b/lib/inc/pxp-agent/util/utf8.hpp
@@ -1,0 +1,10 @@
+#ifndef SRC_UTIL_UTF8_HPP_
+#define SRC_UTIL_UTF8_HPP_
+
+namespace PXPAgent {
+    namespace Util {
+        bool isValidUTF8(std::string &s);
+    }  // namespace Util
+}  // namespace PXPAgent
+
+#endif  // SRC_UTIL_UTF8_HPP_

--- a/lib/inc/pxp-agent/util/utf8.hpp
+++ b/lib/inc/pxp-agent/util/utf8.hpp
@@ -2,9 +2,9 @@
 #define SRC_UTIL_UTF8_HPP_
 
 namespace PXPAgent {
-    namespace Util {
-        bool isValidUTF8(std::string &s);
-    }  // namespace Util
+namespace Util {
+    bool isValidUTF8(std::string &s);
+}  // namespace Util
 }  // namespace PXPAgent
 
 #endif  // SRC_UTIL_UTF8_HPP_

--- a/lib/src/external_module.cc
+++ b/lib/src/external_module.cc
@@ -140,6 +140,7 @@ void ExternalModule::validateConfiguration()
 // Static class members
 //
 
+// cppcheck-suppress constStatement
 const int ExternalModule::OUTPUT_DELAY_MS { 100 };
 
 void ExternalModule::processOutputAndUpdateMetadata(ActionResponse& response)

--- a/lib/src/util/bolt_module.cc
+++ b/lib/src/util/bolt_module.cc
@@ -1,0 +1,137 @@
+#include <pxp-agent/util/bolt_module.hpp>
+#include <pxp-agent/util/utf8.hpp>
+
+#include <leatherman/execution/execution.hpp>
+#include <leatherman/file_util/file.hpp>
+#include <leatherman/locale/locale.hpp>
+
+#define LEATHERMAN_LOGGING_NAMESPACE "puppetlabs.pxp_agent.modules.bolt"
+#include <leatherman/logging/logging.hpp>
+
+namespace PXPAgent {
+namespace Util {
+
+namespace fs = boost::filesystem;
+
+namespace lth_exec = leatherman::execution;
+namespace lth_file = leatherman::file_util;
+namespace lth_jc   = leatherman::json_container;
+namespace lth_loc  = leatherman::locale;
+
+void BoltModule::processOutputAndUpdateMetadata(PXPAgent::ActionResponse &response) {
+    if (response.output.std_out.empty()) {
+        LOG_TRACE("Obtained no results on stdout for the {1}",
+                  response.prettyRequestLabel());
+    } else {
+        LOG_TRACE("Results on stdout for the {1}: {2}",
+                  response.prettyRequestLabel(), response.output.std_out);
+    }
+
+    if (response.output.exitcode != EXIT_SUCCESS) {
+        LOG_TRACE("Execution failure (exit code {1}) for the {2}{3}",
+                  response.output.exitcode, response.prettyRequestLabel(),
+                  (response.output.std_err.empty()
+                   ? ""
+                   : "; stderr:\n" + response.output.std_err));
+    } else if (!response.output.std_err.empty()) {
+        LOG_TRACE("Output on stderr for the {1}:\n{2}",
+                  response.prettyRequestLabel(), response.output.std_err);
+    }
+
+    std::string &output = response.output.std_out;
+
+    if (Util::isValidUTF8(output)) {
+        // Return all relevant results: exitcode, stdout, stderr.
+        lth_jc::JsonContainer result;
+        result.set("exitcode", response.output.exitcode);
+        if (!output.empty()) {
+            result.set("stdout", output);
+        }
+        if (!response.output.std_err.empty()) {
+            result.set("stderr", response.output.std_err);
+        }
+
+        response.setValidResultsAndEnd(std::move(result));
+    } else {
+        LOG_DEBUG("Obtained invalid UTF-8 on stdout for the {1}; stdout:\n{2}",
+                  response.prettyRequestLabel(), output);
+        std::string execution_error {
+                lth_loc::format("The task executed for the {1} returned invalid "
+                                "UTF-8 on stdout - stderr:{2}",
+                                response.prettyRequestLabel(),
+                                (response.output.std_err.empty()
+                                 ? lth_loc::translate(" (empty)")
+                                 : "\n" + response.output.std_err)) };
+        response.setBadResultsAndEnd(execution_error);
+    }
+}
+
+leatherman::execution::result BoltModule::run_sync(const CommandObject &cmd) {
+    return lth_exec::execute(
+            cmd.executable,
+            cmd.arguments,
+            cmd.input,
+            cmd.environment,
+            cmd.pid_callback,
+            0,  // timeout
+            leatherman::util::option_set<lth_exec::execution_options> {
+                    lth_exec::execution_options::thread_safe,
+                    lth_exec::execution_options::merge_environment,
+                    lth_exec::execution_options::inherit_locale
+            });
+}
+
+leatherman::execution::result BoltModule::run(const CommandObject &cmd) {
+    return lth_exec::execute(
+            cmd.executable,
+            cmd.arguments,
+            cmd.input,
+            cmd.environment,
+            cmd.pid_callback,
+            0,  // timeout
+            leatherman::util::option_set<lth_exec::execution_options> {
+                    lth_exec::execution_options::thread_safe,
+                    lth_exec::execution_options::merge_environment,
+                    lth_exec::execution_options::inherit_locale,
+                    lth_exec::execution_options::create_detached_process
+            });
+}
+
+void BoltModule::callBlockingAction(
+        const ActionRequest& request,
+        const Util::CommandObject &command,
+        ActionResponse &response
+) {
+    auto exec = run_sync(command);
+    response.output = ActionOutput { exec.exit_code, exec.output, exec.error };
+    processOutputAndUpdateMetadata(response);
+}
+
+void BoltModule::callNonBlockingAction(
+        const ActionRequest& request,
+        const Util::CommandObject &command,
+        ActionResponse &response
+) {
+    // TODO: throw if storage_ isn't available
+    auto exec = run(command);
+    // Stdout / stderr output should be on file; read it
+    response.output = storage_->getOutput(request.transactionId(), exec.exit_code);
+    processOutputAndUpdateMetadata(response);
+}
+
+ActionResponse BoltModule::callAction(const ActionRequest& request)
+{
+    auto task_command = buildCommandObject(request);
+    ActionResponse response { ModuleType::Internal, request };
+
+    if (request.type() == RequestType::Blocking) {
+        callBlockingAction(request, task_command, response);
+    } else {
+        callNonBlockingAction(request, task_command, response);
+    }
+
+    return response;
+}
+
+}  // namespace Modules
+}  // namespace PXPAgent

--- a/lib/src/util/utf8.cc
+++ b/lib/src/util/utf8.cc
@@ -1,0 +1,24 @@
+#include <rapidjson/rapidjson.h>
+#if RAPIDJSON_MAJOR_VERSION > 1 || RAPIDJSON_MAJOR_VERSION == 1 && RAPIDJSON_MINOR_VERSION >= 1
+// Header for StringStream was added in rapidjson 1.1 in a backwards incompatible way.
+#include <rapidjson/stream.h>
+#endif
+
+#include <string>
+
+namespace PXPAgent {
+namespace Util {
+    bool isValidUTF8(std::string &s) {
+        rapidjson::StringStream source(s.data());
+        rapidjson::InsituStringStream target(&s[0]);
+
+        target.PutBegin();
+        while (source.Tell() < s.size()) {
+            if (!rapidjson::UTF8<char>::Validate(source, target)) {
+                return false;
+            }
+        }
+        return true;
+    }
+}  // namespace Util
+}  // namespace PXPAgent


### PR DESCRIPTION
In preparation for supporting run_command, upload_file, and run_script over PCP, these changes extract reusable functionality from the existing Task module into a base bolt module class. Future work will introduce other modules that extend this base class.