### PR TITLE
Revert "(maint) Fixes needed by cppcheck 1.87"

### DIFF
--- a/exe/tests/main.cc
+++ b/exe/tests/main.cc
@@ -18,7 +18,8 @@ namespace lth_util = leatherman::util;
 
 // Creates a unique temporary directory.
 struct temp_directory {
-    temp_directory() : dir{fs::absolute(fs::unique_path("task_fixture_%%%%-%%%%-%%%%-%%%%"))} {
+    temp_directory() {
+        dir = fs::absolute(fs::unique_path("task_fixture_%%%%-%%%%-%%%%-%%%%"));
         fs::create_directory(dir);
     }
 

--- a/lib/inc/pxp-agent/external_module.hpp
+++ b/lib/inc/pxp-agent/external_module.hpp
@@ -17,7 +17,7 @@ class ExternalModule : public Module {
   public:
     /// Time interval to wait after the external module completes,
     /// before retrieving its output
-    static constexpr int OUTPUT_DELAY_MS = 100;
+    static const int OUTPUT_DELAY_MS;
 
     /// Run the specified executable; its output must define the
     /// module by providing the metadata in JSON format.

--- a/lib/src/external_module.cc
+++ b/lib/src/external_module.cc
@@ -140,6 +140,8 @@ void ExternalModule::validateConfiguration()
 // Static class members
 //
 
+const int ExternalModule::OUTPUT_DELAY_MS { 100 };
+
 void ExternalModule::processOutputAndUpdateMetadata(ActionResponse& response)
 {
     if (response.output.std_out.empty()) {


### PR DESCRIPTION
It looks like certain clang versions are tripping over the switch from `const` to `constexpr`.

Reverts puppetlabs/pxp-agent#747