### PR TITLE
(PA-2219) Add support for Fedora 30

### DIFF
--- a/acceptance/tests/multiple_pxp_agent_daemon.rb
+++ b/acceptance/tests/multiple_pxp_agent_daemon.rb
@@ -9,7 +9,7 @@ test_name 'Start pxp-agent daemon with pidfile present' do
 
   applicable_agents = applicable_agents.reject do |agent|
     on(agent, 'service pxp-agent status', :accept_all_exit_codes => true)
-    stdout =~ /systemd/
+    stdout =~ /systemd/ || stderr =~ /not found/
   end
   unless applicable_agents.length > 0 then
     skip_test('systemd hosts use --foreground')

--- a/acceptance/tests/pxp-module-puppet/run_puppet_umask.rb
+++ b/acceptance/tests/pxp-module-puppet/run_puppet_umask.rb
@@ -63,7 +63,7 @@ SITEPP
       end
 
       on(agent, 'service pxp-agent status', :accept_all_exit_codes => true)
-      if stdout =~ /systemd/
+      if stdout =~ /systemd/ || stderr =~ /not found/
         on agent, 'mkdir /etc/systemd/system/pxp-agent.service.d'
         create_remote_file(agent, '/etc/systemd/system/pxp-agent.service.d/override.conf', "[Service]\nUMask=0222")
       end


### PR DESCRIPTION
Due to Fedora removing its 'service' command in release 30, we need to better handle checking the service provider in the acceptance tests.

Previous implementation assumed the 'service' command is always present, however Fedora 30 and future releases will not include this command/package, as Sys-V services are deprecated in favor of systemd.

I tested these changes on a beaker-provisioned Fedora 30 machine and they work as expected.