### PR TITLE
(PE-26615) Fail gracefully when multiple Puppet runs stack up

### DIFF
--- a/modules/pxp-module-puppet
+++ b/modules/pxp-module-puppet
@@ -13,6 +13,7 @@ module Pxp
       NoLastRunReport = "no_last_run_report"
       InvalidLastRunReport = "invalid_last_run_report"
       Disabled = "agent_disabled"
+      Locked = "agent_locked"
       FailedToStart = "agent_failed_to_start"
       NonZeroExit = "agent_exit_non_zero"
     end
@@ -181,7 +182,7 @@ module Pxp
 
       if start_time && File.mtime(last_run_report) == start_time
         return make_error_result(exitcode, Errors::NoLastRunReport,
-                                 "#{last_run_report} was not written")
+                                 "The Puppet run failed in an unexpected way")
       end
 
       last_run_report_yaml = {}
@@ -277,10 +278,21 @@ module Pxp
           wait_for_lockfile(lockfile)
 
           start_time, exitcode = try_run(last_run_report)
-
           if exitcode.nil?
             return make_error_result(DEFAULT_EXITCODE, Errors::FailedToStart,
                                      "Failed to start Puppet agent")
+          end
+
+          if exitcode != 0
+            if disabled?(puppet_config['agent_disabled_lockfile'] || '')
+              return make_error_result(exitcode, Errors::Disabled,
+                                       "Puppet agent is disabled")
+            end
+
+            if running?(lockfile)
+              return make_error_result(exitcode, Errors::Locked,
+                                       "Puppet agent run is already in progress")
+            end
           end
         end
       end


### PR DESCRIPTION
Previously, if a Puppet run was blocked by an in-progress run, it would
wait for the lockfile to disappear, attempt to run, and assume that
the run must have now succeeded.

This behavior was incorrect in multiple cases. First, if multiple runs
queue up, they will all wait for the lock and when it becomes free, one
of them will acquire it and the rest will fail. This case was unhandled,
and the result would indicate that no report was written. That is
technically true, but meaningless as the real issue was that the agent
didn't run.

The other case this could happen is if the lock was in place for more
than ten minutes, at which point the module will trigger a second agent
run attempt regardless, which can fail if the lock is still legitimate.

In both of those cases, the error message indicates
"last_run_report.yaml was not written", which is unhelpful at best and
profoundly misleading at worst.

We now explicitly check for the same failure conditions after the second
run as after the first: namely, whether the agent is disabled or locked.
If that is the case, then we report the failure as such rather than
attempting to read a non-existent report.

This also rewords the error message in the case where we _do_ attempt to
read a report that hasn't been updated. It's unclear whether this case
can actually happen under _normal_ operation, but it's a worthwhile
validation step nonetheless. Thus, rather than the purely symptomatic
and "last_run_report.yaml was not written", we now report a more generic
"unexpected failure", which more accurately conveys the reality of the
situation.