### PR TITLE
Revert "(PA-2219) Add support for Fedora 30"

### DIFF
--- a/acceptance/tests/multiple_pxp_agent_daemon.rb
+++ b/acceptance/tests/multiple_pxp_agent_daemon.rb
@@ -9,7 +9,7 @@ test_name 'Start pxp-agent daemon with pidfile present' do
 
   applicable_agents = applicable_agents.reject do |agent|
     on(agent, 'service pxp-agent status', :accept_all_exit_codes => true)
-    stdout =~ /systemd/ || stderr =~ /not found/
+    stdout =~ /systemd/
   end
   unless applicable_agents.length > 0 then
     skip_test('systemd hosts use --foreground')

--- a/acceptance/tests/pxp-module-puppet/run_puppet_umask.rb
+++ b/acceptance/tests/pxp-module-puppet/run_puppet_umask.rb
@@ -63,7 +63,7 @@ SITEPP
       end
 
       on(agent, 'service pxp-agent status', :accept_all_exit_codes => true)
-      if stdout =~ /systemd/ || stderr =~ /not found/
+      if stdout =~ /systemd/
         on agent, 'mkdir /etc/systemd/system/pxp-agent.service.d'
         create_remote_file(agent, '/etc/systemd/system/pxp-agent.service.d/override.conf', "[Service]\nUMask=0222")
       end


### PR DESCRIPTION
Reverts puppetlabs/pxp-agent#750 since it causes failures:

https://jenkins-master-prod-1.delivery.puppetlabs.net/view/puppet-agent/view/Acceptance%20Suites/view/CI%20Goalie/job/platform_puppet-agent_puppet-agent-integration-suite_daily-master/590/RMM_COMPONENT_TO_TEST_NAME=pxp_agent,SLAVE_LABEL=beaker,TEST_TARGET=osx1012-64a/console