### PR TITLE
(PA-2267) Update pxp tests to check /proc/1/exe for systemd (1.9.x)

### DIFF
--- a/acceptance/tests/multiple_pxp_agent_daemon.rb
+++ b/acceptance/tests/multiple_pxp_agent_daemon.rb
@@ -8,7 +8,7 @@ test_name 'Start pxp-agent daemon with pidfile present' do
   end
 
   applicable_agents = applicable_agents.reject do |agent|
-    on(agent, 'service pxp-agent status', :accept_all_exit_codes => true)
+    on(agent, 'ls -l /proc/1/exe | grep \'systemd\'', :accept_all_exit_codes => true)
     stdout =~ /systemd/
   end
   unless applicable_agents.length > 0 then

--- a/acceptance/tests/pxp-module-puppet/run_puppet_umask.rb
+++ b/acceptance/tests/pxp-module-puppet/run_puppet_umask.rb
@@ -62,7 +62,7 @@ SITEPP
         on agent, 'echo umask 222 > /etc/sysconfig/pxp-agent'
       end
 
-      on(agent, 'service pxp-agent status', :accept_all_exit_codes => true)
+      on(agent, 'ls -l /proc/1/exe | grep \'systemd\'', :accept_all_exit_codes => true)
       if stdout =~ /systemd/
         on agent, 'mkdir /etc/systemd/system/pxp-agent.service.d'
         create_remote_file(agent, '/etc/systemd/system/pxp-agent.service.d/override.conf', "[Service]\nUMask=0222")


### PR DESCRIPTION
Previous to this commit, two tests: run_puppet_umask and
multiple_pxp_agent_daemon were attempting to use the 'service' command to check
for systemd. This will not work for newer fedora versions since sysvinit was
removed and the 'service' command went with it.

Thus we check if the file that /proc/1/exe points to is systemd

Merging this to 1.9.x also, as we need it for puppet-agent 5.5.x.