### PR TITLE
(PCP-868) Add ModuleCacheDir class to control cache dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /build/
 /dev-resources/
 /lib/tests/resources/test_spool/
+/lib/tests/resources/cache_dir/
 /lib/tests/resources/tmp/
 .idea/
 .DS_Store

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -20,6 +20,7 @@ set(LIBRARY_COMMON_SOURCES
     src/configuration.cc
     src/external_module.cc
     src/module.cc
+    src/module_cache_dir.cc
     src/pxp_connector_v1.cc
     src/pxp_connector_v2.cc
     src/pxp_schemas.cc

--- a/lib/inc/pxp-agent/module_cache_dir.hpp
+++ b/lib/inc/pxp-agent/module_cache_dir.hpp
@@ -1,0 +1,32 @@
+#ifndef SRC_UTIL_MODULE_CACHE_DIR_HPP_
+#define SRC_UTIL_MODULE_CACHE_DIR_HPP_
+
+#include <cpp-pcp-client/util/thread.hpp>
+#include <boost/filesystem/path.hpp>
+
+
+namespace PXPAgent {
+
+  class ModuleCacheDir {
+    public:
+      ModuleCacheDir() = delete;
+      ModuleCacheDir(const ModuleCacheDir&) = delete;
+      ModuleCacheDir& operator=(const ModuleCacheDir&) = delete;
+      ModuleCacheDir(const std::string& cache_dir,
+                     const std::string& cache_dir_purge_ttl);
+
+      boost::filesystem::path createCacheDir(const std::string& sha256);
+
+      unsigned int purgeCache(const std::string& ttl,
+                              std::vector<std::string> ongoing_transactions,
+                              std::function<void(const std::string& dir_path)> purge_callback);
+
+      std::string cache_dir_;
+      std::string purge_ttl_;
+
+    private:
+      PCPClient::Util::mutex cache_dir_mutex_;
+  };
+
+}
+#endif

--- a/lib/inc/pxp-agent/modules/task.hpp
+++ b/lib/inc/pxp-agent/modules/task.hpp
@@ -2,12 +2,11 @@
 #define SRC_MODULES_TASK_H_
 
 #include <pxp-agent/module.hpp>
+#include <pxp-agent/module_cache_dir.hpp>
 #include <pxp-agent/action_response.hpp>
 #include <pxp-agent/results_storage.hpp>
 #include <pxp-agent/util/purgeable.hpp>
 #include <pxp-agent/util/bolt_module.hpp>
-
-#include <cpp-pcp-client/util/thread.hpp>
 
 #include <leatherman/curl/client.hpp>
 #include <set>
@@ -18,8 +17,6 @@ namespace Modules {
 class Task : public PXPAgent::Util::BoltModule, public PXPAgent::Util::Purgeable {
   public:
     Task(const boost::filesystem::path& exec_prefix,
-         const std::string& task_cache_dir,
-         const std::string& task_cache_dir_purge_ttl,
          const std::vector<std::string>& master_uris,
          const std::string& ca,
          const std::string& crt,
@@ -27,6 +24,7 @@ class Task : public PXPAgent::Util::BoltModule, public PXPAgent::Util::Purgeable
          const std::string& proxy,
          uint32_t task_download_connect_timeout_s,
          uint32_t task_download_timeout_s,
+         std::shared_ptr<ModuleCacheDir> module_cache_dir,
          std::shared_ptr<ResultsStorage> storage);
 
 
@@ -41,9 +39,6 @@ class Task : public PXPAgent::Util::BoltModule, public PXPAgent::Util::Purgeable
     std::set<std::string> const& features() const;
 
   private:
-    std::string task_cache_dir_;
-    PCPClient::Util::mutex task_cache_dir_mutex_;
-
     boost::filesystem::path exec_prefix_;
 
     std::vector<std::string> master_uris_;
@@ -53,6 +48,12 @@ class Task : public PXPAgent::Util::BoltModule, public PXPAgent::Util::Purgeable
     std::set<std::string> features_;
 
     leatherman::curl::client client_;
+
+    boost::filesystem::path getCachedTaskFile(const std::vector<std::string>& master_uris,
+                               uint32_t connect_timeout,
+                               uint32_t timeout,
+                               leatherman::curl::client& client,
+                               leatherman::json_container::JsonContainer& file);
 
     boost::filesystem::path downloadMultiFile(std::vector<leatherman::json_container::JsonContainer> const& files,
         std::set<std::string> const& download_set,

--- a/lib/inc/pxp-agent/request_processor.hpp
+++ b/lib/inc/pxp-agent/request_processor.hpp
@@ -2,6 +2,7 @@
 #define SRC_AGENT_REQUEST_PROCESSOR_HPP_
 
 #include <pxp-agent/module.hpp>
+#include <pxp-agent/module_cache_dir.hpp>
 #include <pxp-agent/thread_container.hpp>
 #include <pxp-agent/action_request.hpp>
 #include <pxp-agent/pxp_connector.hpp>
@@ -72,6 +73,8 @@ class RequestProcessor {
     ThreadContainer thread_container_;
 
     PCPClient::Util::mutex thread_container_mutex_;
+
+    std::shared_ptr<ModuleCacheDir> module_cache_dir_;
 
     /// PXP Connector pointer
     std::shared_ptr<PXPConnector> connector_ptr_;

--- a/lib/inc/pxp-agent/util/bolt_helpers.hpp
+++ b/lib/inc/pxp-agent/util/bolt_helpers.hpp
@@ -25,6 +25,7 @@ namespace Util {
                                                     const leatherman::json_container::JsonContainer& uri);
   std::string createUrlEndpoint(const leatherman::json_container::JsonContainer& uri);
   std::string calculateSha256(const std::string& path);
+  void createDir(const boost::filesystem::path& dir);
 }  // namespace Util
 }  // namespace PXPAgent
 

--- a/lib/inc/pxp-agent/util/bolt_module.hpp
+++ b/lib/inc/pxp-agent/util/bolt_module.hpp
@@ -3,6 +3,7 @@
 
 #include <pxp-agent/action_response.hpp>
 #include <pxp-agent/module.hpp>
+#include <pxp-agent/module_cache_dir.hpp>
 #include <pxp-agent/results_storage.hpp>
 
 #include <leatherman/execution/execution.hpp>
@@ -24,8 +25,9 @@ struct CommandObject {
 // This module is a basis for PXP modules supporting bolt functionality
 class BoltModule : public PXPAgent::Module {
     public:
-        explicit BoltModule(std::shared_ptr<ResultsStorage> storage)
-           : storage_(std::move(storage)) {}
+        explicit BoltModule(std::shared_ptr<ResultsStorage> storage, std::shared_ptr<ModuleCacheDir> module_cache_dir)
+           : storage_(std::move(storage)),
+             module_cache_dir_(std::move(module_cache_dir)) {}
 
         /// Whether the module supports non-blocking / asynchronous requests.
         bool supportsAsync() override { return true; }
@@ -43,6 +45,7 @@ class BoltModule : public PXPAgent::Module {
 
     protected:
         std::shared_ptr<ResultsStorage> storage_;
+        std::shared_ptr<ModuleCacheDir> module_cache_dir_;
 
         // Construct a CommandObject based on an ActionRequest - all inheriting classes must implement this method.
         virtual CommandObject buildCommandObject(const ActionRequest& request) = 0;

--- a/lib/src/module_cache_dir.cc
+++ b/lib/src/module_cache_dir.cc
@@ -1,0 +1,93 @@
+#include <pxp-agent/module_cache_dir.hpp>
+#include <pxp-agent/module.hpp>
+#include <pxp-agent/util/purgeable.hpp>
+#include <pxp-agent/util/bolt_helpers.hpp>
+#include <pxp-agent/configuration.hpp>
+#include <pxp-agent/time.hpp>
+
+#include <leatherman/locale/locale.hpp>
+#include <leatherman/file_util/file.hpp>
+#include <leatherman/file_util/directory.hpp>
+#include <boost/system/error_code.hpp>
+
+#define LEATHERMAN_LOGGING_NAMESPACE "puppetlabs.pxp_agent.util.module_cache_dir"
+#include <leatherman/logging/logging.hpp>
+
+namespace fs          = boost::filesystem;
+namespace pcp_util    = PCPClient::Util;
+namespace lth_loc     = leatherman::locale;
+namespace lth_file    = leatherman::file_util;
+namespace boost_error = boost::system::errc;
+
+namespace PXPAgent {
+  ModuleCacheDir::ModuleCacheDir(const std::string& cache_dir,
+                                 const std::string& cache_dir_purge_ttl) :
+    cache_dir_ { cache_dir },
+    purge_ttl_ { cache_dir_purge_ttl }
+  {}
+
+  // Creates the <cache_dir>/<sha256> directory (and parent dirs), ensuring that its permissions are readable by
+  // the PXP agent owner/group (for unix OSes), writable for the PXP agent owner,
+  // and executable by both PXP agent owner and group. Returns the path to this directory.
+  // Note that the last modified time of the directory is updated, and that this routine
+  // will not fail if the directory already exists.
+  fs::path ModuleCacheDir::createCacheDir(const std::string& sha256) {
+    pcp_util::lock_guard<pcp_util::mutex> the_lock { cache_dir_mutex_ };
+    auto file_cache_dir = static_cast<fs::path>(cache_dir_) / sha256;
+    try {
+      Util::createDir(file_cache_dir);
+      fs::last_write_time(file_cache_dir, time(nullptr));
+    } catch (fs::filesystem_error& e) {
+      auto err_code = e.code();
+      if (err_code == boost_error::no_such_file_or_directory) {
+          throw Module::ProcessingError(lth_loc::format("No such file or directory: {1}", e.path1()));
+      } else {
+          throw Module::ProcessingError(lth_loc::format("Failed to create cache dir {1} to download file to: {2}", file_cache_dir, e.what()));
+      }
+    }
+    return file_cache_dir;
+  }
+
+  unsigned int ModuleCacheDir::purgeCache(const std::string& ttl,
+                                          std::vector<std::string> ongoing_transactions,
+                                          std::function<void(const std::string& dir_path)> purge_callback)
+  {
+    unsigned int num_purged_dirs { 0 };
+    Timestamp ts { ttl };
+
+    LOG_INFO("About to purge cached files from '{1}'; TTL = {2}",
+        cache_dir_, ttl);
+
+    lth_file::each_subdirectory(
+      cache_dir_,
+      // Lambda function
+      [&](std::string const& sub_dir) -> bool {
+        fs::path dir_path { sub_dir };
+        LOG_TRACE("Inspecting '{1}' for purging", sub_dir);
+
+        boost::system::error_code ec;
+        pcp_util::lock_guard<pcp_util::mutex> the_lock { cache_dir_mutex_ };
+        auto last_update = fs::last_write_time(dir_path, ec);
+        if (ec) {
+          LOG_ERROR("Failed to remove '{1}': {2}", sub_dir, ec.message());
+        } else if (ts.isNewerThan(last_update)) {
+          LOG_TRACE("Removing '{1}'", sub_dir);
+
+          try {
+            purge_callback(dir_path.string());
+            num_purged_dirs++;
+          } catch (const std::exception& e) {
+            LOG_ERROR("Failed to remove '{1}': {2}", sub_dir, e.what());
+          }
+        }
+        return true;  // Return from Lamda function passed to lth_file::each_subdirectory
+      });
+
+    LOG_INFO(lth_loc::format_n(
+      // LOCALE: info
+      "Removed {1} directory from '{2}'",
+      "Removed {1} directories from '{2}'",
+      num_purged_dirs, num_purged_dirs, cache_dir_));
+    return num_purged_dirs;
+  }
+}  // PXPAgent

--- a/lib/src/modules/task.cc
+++ b/lib/src/modules/task.cc
@@ -169,8 +169,6 @@ static void findExecutableAndArguments(const fs::path& task_file, Util::CommandO
 }
 
 Task::Task(const fs::path& exec_prefix,
-           const std::string& task_cache_dir,
-           const std::string& task_cache_dir_purge_ttl,
            const std::vector<std::string>& master_uris,
            const std::string& ca,
            const std::string& crt,
@@ -178,10 +176,10 @@ Task::Task(const fs::path& exec_prefix,
            const std::string& proxy,
            uint32_t task_download_connect_timeout,
            uint32_t task_download_timeout,
+           std::shared_ptr<ModuleCacheDir> module_cache_dir,
            std::shared_ptr<ResultsStorage> storage) :
-    BoltModule { std::move(storage) },
-    Purgeable { task_cache_dir_purge_ttl },
-    task_cache_dir_ { task_cache_dir },
+    BoltModule { std::move(storage), std::move(module_cache_dir) },
+    Purgeable { module_cache_dir_->purge_ttl_ },
     exec_prefix_ { exec_prefix },
     master_uris_ { master_uris },
     task_download_connect_timeout_ { task_download_connect_timeout },
@@ -220,69 +218,31 @@ static void addParametersToEnvironment(const lth_jc::JsonContainer &input, std::
     }
 }
 
-// Converts boost filesystem errors to a task_error object.
-static Module::ProcessingError toModuleProcessingError(const fs::filesystem_error& e) {
-    auto err_code = e.code();
-    if (err_code == boost_error::no_such_file_or_directory) {
-        return Module::ProcessingError(lth_loc::format("No such file or directory: {1}", e.path1()));
-    } else if (err_code ==  boost_error::file_exists) {
-        return Module::ProcessingError(lth_loc::format("A file matching the name of the provided sha already exists"));
-    } else {
-        return Module::ProcessingError(e.what());
-    }
-}
-
-// A define is used here because creating a local variable is subject to static initialization ordering.
-#define NIX_TASK_FILE_PERMS NIX_DIR_PERMS
-
-static void createDir(const fs::path& dir) {
-    fs::create_directories(dir);
-    fs::permissions(dir, NIX_DIR_PERMS);
-}
-
-// Creates the <task_cache_dir>/<sha256> directory (and parent dirs) for a single
-// task, ensuring that its permissions are readable by
-// the PXP agent owner/group (for unix OSes), writable for the PXP agent owner,
-// and executable by both PXP agent owner and group. Returns the path to this directory.
-// Note that the last modified time of the directory is updated, and that this routine
-// will not fail if the directory already exists.
-static fs::path createCacheDir(const fs::path& task_cache_dir, const std::string& sha256) {
-    auto cache_dir = task_cache_dir / sha256;
-    createDir(cache_dir);
-    fs::last_write_time(cache_dir, time(nullptr));
-    return cache_dir;
-}
-
 // Verify (this includes checking the SHA256 checksums) that task file is present
 // in the task cache downloading it if necessary.
 // Return the full path of the cached version of the file.
-static fs::path getCachedTaskFile(const fs::path& task_cache_dir,
-                                  PCPClient::Util::mutex& task_cache_dir_mutex,
-                                  const std::vector<std::string>& master_uris,
-                                  uint32_t connect_timeout,
-                                  uint32_t timeout,
-                                  lth_curl::client& client,
-                                  lth_jc::JsonContainer& file) {
+fs::path Task::getCachedTaskFile(const std::vector<std::string>& master_uris,
+                                 uint32_t connect_timeout,
+                                 uint32_t timeout,
+                                 lth_curl::client& client,
+                                 lth_jc::JsonContainer& file) {
     LOG_DEBUG("Verifying task file based on {1}", file.toString());
 
     try {
-        auto cache_dir = [&]() {
-            pcp_util::lock_guard<pcp_util::mutex> the_lock { task_cache_dir_mutex };
-            return createCacheDir(task_cache_dir, file.get<std::string>("sha256"));
-        }();
+        auto cache_dir = module_cache_dir_->createCacheDir(file.get<std::string>("sha256"));
         // Task files remain in the cache_dir rather than being written out to a destination
         // elsewhere on the filesystem.
         auto destination = cache_dir / fs::path(file.get<std::string>("filename")).filename();
         return Util::downloadFileFromMaster(master_uris, connect_timeout, timeout, client, cache_dir, destination, file);
-    } catch (fs::filesystem_error& e) {
-        throw toModuleProcessingError(e);
+    } catch (Module::ProcessingError& e) {
+        throw Module::ProcessingError { lth_loc::format("Failed to download task file with: {1}", e.what()) };
     }
 }
 
 // build a spool dir for the supporting library files requested by a multifile task
 static fs::path createInstallDir(const fs::path& spool_dir, const std::set<std::string>& download_set) {
     auto install_dir = spool_dir / fs::unique_path("temp_task_%%%%-%%%%-%%%%-%%%%");
-    createDir(install_dir);
+    Util::createDir(install_dir);
 
     // this should generate a unique collection of directory paths to append to install_dir
     // for example:
@@ -298,7 +258,7 @@ static fs::path createInstallDir(const fs::path& spool_dir, const std::set<std::
         fs::path tmp = install_dir;
         for (const fs::path &dir : dir_path) {
             tmp /= dir;
-            createDir(tmp);
+            Util::createDir(tmp);
         }
     }
 
@@ -344,7 +304,7 @@ fs::path Task::downloadMultiFile(std::vector<lth_jc::JsonContainer> const& files
     if (fs::is_directory(s)) {
       spool = spool_dir;
     } else {
-      spool = task_cache_dir_;
+      spool = module_cache_dir_->cache_dir_;
     }
     auto install_dir = createInstallDir(spool, download_set);
     for (auto file_name : download_set) {
@@ -352,13 +312,11 @@ fs::path Task::downloadMultiFile(std::vector<lth_jc::JsonContainer> const& files
         auto file_object = selectLibFile(files, file_name);
 
         // get file from cache, download if necessary
-        auto lib_file = getCachedTaskFile(task_cache_dir_,
-                                       task_cache_dir_mutex_,
-                                       master_uris_,
-                                       task_download_connect_timeout_,
-                                       task_download_timeout_,
-                                       client_,
-                                       file_object);
+        auto lib_file = getCachedTaskFile(master_uris_,
+                                          task_download_connect_timeout_,
+                                          task_download_timeout_,
+                                          client_,
+                                          file_object);
 
         // copy to expected location in install_dir
         fs::copy_file(lib_file, install_dir / fs::path(file_name));
@@ -473,9 +431,7 @@ Util::CommandObject Task::buildCommandObject(const ActionRequest& request)
     auto files = task_execution_params.get<std::vector<lth_jc::JsonContainer>>("files");
     auto file = selectTaskFile(files, implementation);
 
-    auto task_file = getCachedTaskFile(task_cache_dir_,
-                                       task_cache_dir_mutex_,
-                                       master_uris_,
+    auto task_file = getCachedTaskFile(master_uris_,
                                        task_download_connect_timeout_,
                                        task_download_timeout_,
                                        client_,
@@ -501,8 +457,8 @@ Util::CommandObject Task::buildCommandObject(const ActionRequest& request)
     if (lib_files.size() > 0) {
         auto install_dir = downloadMultiFile(files, lib_files, request.resultsDir());
         auto module = task_name.substr(0, task_name.find(':'));
-        createDir(install_dir / module);
-        createDir(install_dir / module / "tasks");
+        Util::createDir(install_dir / module);
+        Util::createDir(install_dir / module / "tasks");
         auto task_dest = install_dir / module / "tasks" / task_file.filename();
         fs::copy_file(task_file, task_dest);
         task_file = task_dest;
@@ -570,45 +526,9 @@ unsigned int Task::purge(
     std::vector<std::string> ongoing_transactions,
     std::function<void(const std::string& dir_path)> purge_callback)
 {
-    unsigned int num_purged_dirs { 0 };
-    Timestamp ts { ttl };
     if (purge_callback == nullptr)
-        purge_callback = &Purgeable::defaultDirPurgeCallback;
-
-    LOG_INFO("About to purge cached tasks from '{1}'; TTL = {2}",
-             task_cache_dir_, ttl);
-
-    lth_file::each_subdirectory(
-        task_cache_dir_,
-        [&](std::string const& s) -> bool {
-            fs::path dir_path { s };
-            LOG_TRACE("Inspecting '{1}' for purging", s);
-
-            boost::system::error_code ec;
-            pcp_util::lock_guard<pcp_util::mutex> the_lock { task_cache_dir_mutex_ };
-            auto last_update = fs::last_write_time(dir_path, ec);
-            if (ec) {
-                LOG_ERROR("Failed to remove '{1}': {2}", s, ec.message());
-            } else if (ts.isNewerThan(last_update)) {
-                LOG_TRACE("Removing '{1}'", s);
-
-                try {
-                    purge_callback(dir_path.string());
-                    num_purged_dirs++;
-                } catch (const std::exception& e) {
-                    LOG_ERROR("Failed to remove '{1}': {2}", s, e.what());
-                }
-            }
-
-            return true;
-        });
-
-    LOG_INFO(lth_loc::format_n(
-        // LOCALE: info
-        "Removed {1} directory from '{2}'",
-        "Removed {1} directories from '{2}'",
-        num_purged_dirs, num_purged_dirs, task_cache_dir_));
-    return num_purged_dirs;
+      purge_callback = &Purgeable::defaultDirPurgeCallback;
+    return module_cache_dir_->purgeCache(ttl, ongoing_transactions, purge_callback);
 }
 
 }  // namespace Modules

--- a/lib/src/request_processor.cc
+++ b/lib/src/request_processor.cc
@@ -170,6 +170,8 @@ RequestProcessor::RequestProcessor(std::shared_ptr<PXPConnector> connector_ptr,
                                    const Configuration::Agent& agent_configuration)
         : thread_container_ { "Action Executer" },
           thread_container_mutex_ {},
+          module_cache_dir_ { new ModuleCacheDir(agent_configuration.task_cache_dir,
+                                                 agent_configuration.task_cache_dir_purge_ttl) },
           connector_ptr_ { connector_ptr },
           storage_ptr_ { new ResultsStorage(agent_configuration.spool_dir,
                                             agent_configuration.spool_dir_purge_ttl) },
@@ -828,8 +830,6 @@ void RequestProcessor::loadInternalModules(const Configuration::Agent& agent_con
     registerModule(std::make_shared<Modules::Ping>());
     auto task = std::make_shared<Modules::Task>(
         Configuration::Instance().getExecPrefix(),
-        agent_configuration.task_cache_dir,
-        agent_configuration.task_cache_dir_purge_ttl,
         agent_configuration.master_uris,
         agent_configuration.ca,
         agent_configuration.crt,
@@ -837,6 +837,7 @@ void RequestProcessor::loadInternalModules(const Configuration::Agent& agent_con
         agent_configuration.master_proxy,
         agent_configuration.task_download_connect_timeout_s,
         agent_configuration.task_download_timeout_s,
+        module_cache_dir_,
         storage_ptr_);
     registerModule(task);
     registerPurgeable(task);

--- a/lib/src/util/bolt_helpers.cc
+++ b/lib/src/util/bolt_helpers.cc
@@ -3,6 +3,7 @@
 #include <pxp-agent/module.hpp>
 
 #include <boost/algorithm/hex.hpp>
+#include <boost/algorithm/string.hpp>
 
 #define LEATHERMAN_LOGGING_NAMESPACE "puppetlabs.pxp_agent.util.bolt_helpers"
 #include <leatherman/logging/logging.hpp>
@@ -19,167 +20,174 @@ namespace PXPAgent {
 namespace Util {
 
 
-    // NIX_DIR_PERMS is defined in pxp-agent/configuration
-    #define NIX_TASK_FILE_PERMS NIX_DIR_PERMS
+  // NIX_DIR_PERMS is defined in pxp-agent/configuration
+  #define NIX_DOWNLOADED_FILE_PERMS NIX_DIR_PERMS
 
-    // Downloads a file if it does not already exist on the filesystem. A check is made
-    // on the filesystem to determine if the file at destination already exists and if
-    // it already matches the sha256 provided with the file. If the file already exists
-    // the function immediately returns.
-    //
-    // If the file does not exist attempt to download with leatherman.curl. Once the
-    // download finishes a sha256 check occurs to ensure file contents are correct. Then
-    // the file is moved to destination with boost::filesystem::rename.
-    fs::path downloadFileFromMaster(const std::vector<std::string>& master_uris,
-                                uint32_t connect_timeout,
-                                uint32_t timeout,
-                                lth_curl::client& client,
-                                const fs::path& cache_dir,
-                                const fs::path& destination,
-                                const lth_jc::JsonContainer& file) {
-        auto filename = fs::path(file.get<std::string>("filename")).filename();
-        auto sha256 = file.get<std::string>("sha256");
+  // Downloads a file if it does not already exist on the filesystem. A check is made
+  // on the filesystem to determine if the file at destination already exists and if
+  // it already matches the sha256 provided with the file. If the file already exists
+  // the function immediately returns.
+  //
+  // If the file does not exist attempt to download with leatherman.curl. Once the
+  // download finishes a sha256 check occurs to ensure file contents are correct. Then
+  // the file is moved to destination with boost::filesystem::rename.
+  fs::path downloadFileFromMaster(const std::vector<std::string>& master_uris,
+                uint32_t connect_timeout,
+                uint32_t timeout,
+                lth_curl::client& client,
+                const fs::path& cache_dir,
+                const fs::path& destination,
+                const lth_jc::JsonContainer& file) {
+    auto filename = fs::path(file.get<std::string>("filename")).filename();
+    auto sha256 = file.get<std::string>("sha256");
 
-        if (fs::exists(destination) && sha256 == calculateSha256(destination.string())) {
-            fs::permissions(destination, NIX_TASK_FILE_PERMS);
-            return destination;
-        }
-
-        if (master_uris.empty()) {
-            throw Module::ProcessingError(lth_loc::format("Cannot download task. No master-uris were provided"));
-        }
-
-        auto tempname = cache_dir / fs::unique_path("temp_task_%%%%-%%%%-%%%%-%%%%");
-        // Note that the provided tempname argument is a temporary file, call it "tempA".
-        // Leatherman.curl during the download method will create another temporary file,
-        // call it "tempB", to save the downloaded file's contents in chunks before
-        // renaming it to "tempA." The rationale behind this solution is that:
-        //    (1) After download, we still need to check "tempA" to ensure that its sha matches
-        //    the provided sha. So the downloaded task is not quite a "valid" file after this
-        //    method is called; it's still temporary.
-        //
-        //    (2) It somewhat simplifies error handling if multiple threads try to download
-        //    the same file.
-        auto download_result = downloadFileWithCurl(master_uris, connect_timeout, timeout, client, tempname, file.get<lth_jc::JsonContainer>("uri"));
-        if (!std::get<0>(download_result)) {
-            throw Module::ProcessingError(lth_loc::format(
-                "Downloading the task file {1} failed after trying all the available master-uris. Most recent error message: {2}",
-                file.get<std::string>("filename"),
-                std::get<1>(download_result)));
-        }
-
-        if (sha256 != calculateSha256(tempname.string())) {
-            fs::remove(tempname);
-            throw Module::ProcessingError(lth_loc::format("The downloaded file {1} has a SHA that differs from the provided SHA", filename));
-        }
-        fs::rename(tempname, destination);
-        return destination;
+    if (fs::exists(destination) && boost::to_upper_copy<std::string>(sha256) == boost::to_upper_copy<std::string>(calculateSha256(destination.string()))) {
+      fs::permissions(destination, NIX_DOWNLOADED_FILE_PERMS);
+      return destination;
     }
 
-    // Downloads the file at the specified url into the provided path.
-    // The downloaded task file's permissions will be set to rwx for user and rx for
-    // group for non-Windows OSes.
+    if (master_uris.empty()) {
+      throw Module::ProcessingError(lth_loc::format("Cannot download task. No master-uris were provided"));
+    }
+
+    auto tempname = cache_dir / fs::unique_path("temp_task_%%%%-%%%%-%%%%-%%%%");
+    // Note that the provided tempname argument is a temporary file, call it "tempA".
+    // Leatherman.curl during the download method will create another temporary file,
+    // call it "tempB", to save the downloaded file's contents in chunks before
+    // renaming it to "tempA." The rationale behind this solution is that:
+    //    (1) After download, we still need to check "tempA" to ensure that its sha matches
+    //    the provided sha. So the downloaded task is not quite a "valid" file after this
+    //    method is called; it's still temporary.
     //
-    // The method returns a tuple (success, err_msg). success is true if the file was downloaded;
-    // false otherwise. err_msg contains the most recent http_file_download_exception's error
-    // message; it is initially empty.
-    std::tuple<bool, std::string> downloadFileWithCurl(const std::vector<std::string>& master_uris,
-                                                        uint32_t connect_timeout_s,
-                                                        uint32_t timeout_s,
-                                                        lth_curl::client& client,
-                                                        const fs::path& file_path,
-                                                        const lth_jc::JsonContainer& uri) {
-        auto endpoint = createUrlEndpoint(uri);
-        std::tuple<bool, std::string> result = std::make_tuple(false, "");
-        for (auto& master_uri : master_uris) {
-            auto url = master_uri + endpoint;
-            lth_curl::request req(url);
+    //    (2) It somewhat simplifies error handling if multiple threads try to download
+    //    the same file.
+    auto download_result = downloadFileWithCurl(master_uris, connect_timeout, timeout, client, tempname, file.get<lth_jc::JsonContainer>("uri"));
+    if (!std::get<0>(download_result)) {
+      throw Module::ProcessingError(lth_loc::format(
+        "Downloading the task file {1} failed after trying all the available master-uris. Most recent error message: {2}",
+        file.get<std::string>("filename"),
+        std::get<1>(download_result)));
+    }
 
-            // Request timeouts expect milliseconds.
-            req.connection_timeout(connect_timeout_s*1000);
-            req.timeout(timeout_s*1000);
+    if (sha256 != calculateSha256(tempname.string())) {
+      fs::remove(tempname);
+      throw Module::ProcessingError(lth_loc::format("The downloaded file {1} has a SHA that differs from the provided SHA", filename));
+    }
+    fs::rename(tempname, destination);
+    return destination;
+  }
 
-            try {
-                lth_curl::response resp;
-                client.download_file(req, file_path.string(), resp, NIX_TASK_FILE_PERMS);
-                if (resp.status_code() >= 400) {
-                    throw lth_curl::http_file_download_exception(
-                        req,
-                        file_path.string(),
-                        lth_loc::format("{1} returned a response with HTTP status {2}. Response body: {3}", url, resp.status_code(), resp.body()));
-                }
-            } catch (lth_curl::http_file_download_exception& e) {
-                // Server-side error, do nothing here -- we want to try the next master-uri.
-                LOG_WARNING("Downloading the task file from the master-uri '{1}' failed. Reason: {2}", master_uri, e.what());
-                std::get<1>(result) = e.what();
-            } catch (lth_curl::http_request_exception& e) {
-                // For http_curl_setup and http_file_operation exceptions
-                throw Module::ProcessingError(lth_loc::format("Downloading the task file failed. Reason: {1}", e.what()));
-            }
+  // Downloads the file at the specified url into the provided path.
+  // The downloaded task file's permissions will be set to rwx for user and rx for
+  // group for non-Windows OSes.
+  //
+  // The method returns a tuple (success, err_msg). success is true if the file was downloaded;
+  // false otherwise. err_msg contains the most recent http_file_download_exception's error
+  // message; it is initially empty.
+  std::tuple<bool, std::string> downloadFileWithCurl(const std::vector<std::string>& master_uris,
+                            uint32_t connect_timeout_s,
+                            uint32_t timeout_s,
+                            lth_curl::client& client,
+                            const fs::path& file_path,
+                            const lth_jc::JsonContainer& uri) {
+    auto endpoint = createUrlEndpoint(uri);
+    std::tuple<bool, std::string> result = std::make_tuple(false, "");
+    for (auto& master_uri : master_uris) {
+      auto url = master_uri + endpoint;
+      lth_curl::request req(url);
 
-            if (fs::exists(file_path)) {
-                std::get<0>(result) = true;
-                return result;
-            }
+      // Request timeouts expect milliseconds.
+      req.connection_timeout(connect_timeout_s*1000);
+      req.timeout(timeout_s*1000);
+
+      try {
+        lth_curl::response resp;
+        client.download_file(req, file_path.string(), resp, NIX_DOWNLOADED_FILE_PERMS);
+        if (resp.status_code() >= 400) {
+          throw lth_curl::http_file_download_exception(
+            req,
+            file_path.string(),
+            lth_loc::format("{1} returned a response with HTTP status {2}. Response body: {3}", url, resp.status_code(), resp.body()));
         }
+      } catch (lth_curl::http_file_download_exception& e) {
+        // Server-side error, do nothing here -- we want to try the next master-uri.
+        LOG_WARNING("Downloading the task file from the master-uri '{1}' failed. Reason: {2}", master_uri, e.what());
+        std::get<1>(result) = e.what();
+      } catch (lth_curl::http_request_exception& e) {
+        // For http_curl_setup and http_file_operation exceptions
+        throw Module::ProcessingError(lth_loc::format("Downloading the task file failed. Reason: {1}", e.what()));
+      }
 
+      if (fs::exists(file_path)) {
+        std::get<0>(result) = true;
         return result;
+      }
     }
 
-    std::string createUrlEndpoint(const lth_jc::JsonContainer& uri) {
-        std::string url = uri.get<std::string>("path");
-        auto params = uri.getWithDefault<lth_jc::JsonContainer>("params", lth_jc::JsonContainer());
-        if (params.empty()) {
-            return url;
-        }
-        auto curl_handle = lth_curl::curl_handle();
-        url += "?";
-        for (auto& key : params.keys()) {
-            auto escaped_key = std::string(lth_curl::curl_escaped_string(curl_handle, key));
-            auto escaped_val = std::string(lth_curl::curl_escaped_string(curl_handle, params.get<std::string>(key)));
-            url += escaped_key + "=" + escaped_val + "&";
-        }
-        // Remove trailing ampersand (&)
-        url.pop_back();
-        return url;
+    return result;
+  }
+
+  std::string createUrlEndpoint(const lth_jc::JsonContainer& uri) {
+    std::string url = uri.get<std::string>("path");
+    auto params = uri.getWithDefault<lth_jc::JsonContainer>("params", lth_jc::JsonContainer());
+    if (params.empty()) {
+      return url;
     }
+    auto curl_handle = lth_curl::curl_handle();
+    url += "?";
+    for (auto& key : params.keys()) {
+      auto escaped_key = std::string(lth_curl::curl_escaped_string(curl_handle, key));
+      auto escaped_val = std::string(lth_curl::curl_escaped_string(curl_handle, params.get<std::string>(key)));
+      url += escaped_key + "=" + escaped_val + "&";
+    }
+    // Remove trailing ampersand (&)
+    url.pop_back();
+    return url;
+  }
 
-    // Computes the sha256 of the file denoted by path. Assumes that
-    // the file designated by "path" exists.
-    std::string calculateSha256(const std::string& path) {
-        auto mdctx = EVP_MD_CTX_create();
+  // Computes the sha256 of the file denoted by path. Assumes that
+  // the file designated by "path" exists.
+  std::string calculateSha256(const std::string& path) {
+    auto mdctx = EVP_MD_CTX_create();
 
-        EVP_DigestInit_ex(mdctx, EVP_sha256(), nullptr);
-        {
-            constexpr std::streamsize CHUNK_SIZE = 0x8000;  // 32 kB
-            char buffer[CHUNK_SIZE];
-            boost::nowide::ifstream ifs(path, std::ios::binary);
+    EVP_DigestInit_ex(mdctx, EVP_sha256(), nullptr);
+    {
+      constexpr std::streamsize CHUNK_SIZE = 0x8000;  // 32 kB
+      char buffer[CHUNK_SIZE];
+      boost::nowide::ifstream ifs(path, std::ios::binary);
 
-            while (ifs.read(buffer, CHUNK_SIZE)) {
-                EVP_DigestUpdate(mdctx, buffer, CHUNK_SIZE);
-            }
-            if (!ifs.eof()) {
-                EVP_MD_CTX_destroy(mdctx);
-                throw Module::ProcessingError(lth_loc::format("Error while reading {1}", path));
-            }
-            EVP_DigestUpdate(mdctx, buffer, ifs.gcount());
-        }
-
-        unsigned char md_value[EVP_MAX_MD_SIZE];
-        unsigned int md_len;
-
-        EVP_DigestFinal_ex(mdctx, md_value, &md_len);
+      while (ifs.read(buffer, CHUNK_SIZE)) {
+        EVP_DigestUpdate(mdctx, buffer, CHUNK_SIZE);
+      }
+      if (!ifs.eof()) {
         EVP_MD_CTX_destroy(mdctx);
-
-        std::string md_value_hex;
-
-        md_value_hex.reserve(2*md_len);
-        // TODO use boost::algorithm::hex_lower and drop the std::transform below when we upgrade to boost 1.62.0 or newer
-        alg::hex(md_value, md_value+md_len, std::back_inserter(md_value_hex));
-        std::transform(md_value_hex.begin(), md_value_hex.end(), md_value_hex.begin(), ::tolower);
-
-        return md_value_hex;
+        throw Module::ProcessingError(lth_loc::format("Error while reading {1}", path));
+      }
+      EVP_DigestUpdate(mdctx, buffer, ifs.gcount());
     }
+
+    unsigned char md_value[EVP_MAX_MD_SIZE];
+    unsigned int md_len;
+
+    EVP_DigestFinal_ex(mdctx, md_value, &md_len);
+    EVP_MD_CTX_destroy(mdctx);
+
+    std::string md_value_hex;
+
+    md_value_hex.reserve(2*md_len);
+    // TODO use boost::algorithm::hex_lower and drop the std::transform below when we upgrade to boost 1.62.0 or newer
+    alg::hex(md_value, md_value+md_len, std::back_inserter(md_value_hex));
+    std::transform(md_value_hex.begin(), md_value_hex.end(), md_value_hex.begin(), ::tolower);
+
+    return md_value_hex;
+  }
+
+
+  void createDir(const fs::path& dir) {
+    fs::create_directories(dir);
+    fs::permissions(dir, NIX_DIR_PERMS);
+  }
+
 
 }  // namespace Util
 }  // namespace PXPAgent

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ set(COMMON_TEST_SOURCES
     unit/configuration_test.cc
     unit/external_module_test.cc
     unit/module_test.cc
+    unit/module_cache_dir_test.cc
     unit/pxp_connector_v1_test.cc
     unit/pxp_connector_v2_test.cc
     unit/request_processor_test.cc

--- a/lib/tests/unit/module_cache_dir_test.cc
+++ b/lib/tests/unit/module_cache_dir_test.cc
@@ -1,0 +1,114 @@
+#include "root_path.hpp"
+
+#include <pxp-agent/module_cache_dir.hpp>
+#include <pxp-agent/module.hpp>
+#include <pxp-agent/configuration.hpp>
+
+#include <leatherman/json_container/json_container.hpp>
+#include <leatherman/util/scope_exit.hpp>
+#include <leatherman/file_util/file.hpp>
+
+#include <boost/filesystem.hpp>
+#include <boost/algorithm/string/trim.hpp>
+#include <boost/algorithm/string/predicate.hpp>
+#include <boost/algorithm/string/erase.hpp>
+#include <boost/date_time/posix_time/posix_time_types.hpp>
+
+#include <catch.hpp>
+
+#include <string>
+#include <vector>
+#include <unistd.h>
+
+
+using namespace PXPAgent;
+
+namespace fs = boost::filesystem;
+namespace pt = boost::posix_time;
+namespace lth_jc = leatherman::json_container;
+namespace lth_util = leatherman::util;
+namespace lth_file = leatherman::file_util;
+
+static const std::string CACHE_DIR { std::string { PXP_AGENT_ROOT_PATH }
+                                          + "/lib/tests/resources/cache_dir" };
+// Disable cache ttl so we don't delete fixtures.
+static const std::string CACHE_TTL { "0d" };
+
+TEST_CASE("ModuleCacheDir::ModuleCacheDir", "[modules]") {
+    SECTION("can successfully instantiate") {
+        REQUIRE_NOTHROW(ModuleCacheDir(CACHE_DIR, CACHE_TTL));
+    }
+
+    SECTION("Properly sets public vars") {
+        ModuleCacheDir mod_cd { CACHE_DIR, CACHE_TTL };
+        REQUIRE(mod_cd.cache_dir_ == CACHE_DIR);
+        REQUIRE(mod_cd.purge_ttl_ == CACHE_TTL);
+    }
+}
+
+// Present in Boost 1.58. That's currently not required, so reproducing it here since it's simple.
+static std::time_t my_to_time_t(pt::ptime t)
+{
+    return (t - pt::ptime(boost::gregorian::date(1970, 1, 1))).total_seconds();
+}
+
+TEST_CASE("ModuleCacheDir::createCacheDir", "[modules]") {
+    fs::remove(CACHE_DIR + "/TESTSHA");
+    ModuleCacheDir mod_cd { CACHE_DIR, CACHE_TTL };
+    SECTION("Creates cache dir for new SHA") {
+        REQUIRE_NOTHROW(mod_cd.createCacheDir("TESTSHA"));
+        REQUIRE(fs::exists(CACHE_DIR + "/TESTSHA"));
+    }
+    SECTION("Does not fail if cache dir already exists") {
+        REQUIRE_NOTHROW(mod_cd.createCacheDir("TESTSHA"));
+        REQUIRE(fs::exists(CACHE_DIR + "/TESTSHA"));
+    }
+    // open an output stream that will collide with the attempt to create
+    // a directory and cause an exception.
+    boost::nowide::ofstream(CACHE_DIR + "/TESTSHA");
+    SECTION("Throws Module::ProcessingError if the attempt to create the dir throws") {
+        REQUIRE_THROWS_AS(mod_cd.createCacheDir("TESTSHA"), Module::ProcessingError);
+    }
+}
+
+TEST_CASE("ModuleCacheDir::purgeCache", "[modules]") {
+    const std::string PURGE_TASK_CACHE { std::string { PXP_AGENT_ROOT_PATH }
+        + "/lib/tests/resources/purge_test" };
+
+    const std::string OLD_TRANSACTION { "valid_old" };
+    const std::string RECENT_TRANSACTION { "valid_recent" };
+
+    // Start with 0 TTL to prevent initial cleanup
+    ModuleCacheDir mod_cd { PURGE_TASK_CACHE, CACHE_TTL };
+
+    unsigned int num_purged_results { 0 };
+    auto purgeCallback =
+        [&num_purged_results](const std::string&) -> void { num_purged_results++; };
+
+    SECTION("Purges only the old results based on ttl") {
+        num_purged_results = 0;
+        auto now = pt::second_clock::universal_time();
+        auto recent = now - pt::minutes(50);
+        auto old = now - pt::minutes(61);
+        fs::last_write_time(fs::path(PURGE_TASK_CACHE)/OLD_TRANSACTION, my_to_time_t(old));
+        fs::last_write_time(fs::path(PURGE_TASK_CACHE)/RECENT_TRANSACTION, my_to_time_t(recent));
+
+        auto results = mod_cd.purgeCache("1h", {}, purgeCallback);
+        REQUIRE(results == 1);
+        REQUIRE(num_purged_results == 1);
+    }
+
+    auto failedCallback =
+        [&](const std::string&) -> void { throw std::runtime_error("error"); };
+
+    SECTION("Does not throw when purge function throws") {
+        num_purged_results = 0;
+        auto now = pt::second_clock::universal_time();
+        auto recent = now - pt::minutes(50);
+        auto old = now - pt::minutes(61);
+        fs::last_write_time(fs::path(PURGE_TASK_CACHE)/OLD_TRANSACTION, my_to_time_t(old));
+        fs::last_write_time(fs::path(PURGE_TASK_CACHE)/RECENT_TRANSACTION, my_to_time_t(recent));
+
+        REQUIRE_NOTHROW(mod_cd.purgeCache("1h", {}, failedCallback));
+    }
+}

--- a/lib/tests/unit/modules/task_test.cc
+++ b/lib/tests/unit/modules/task_test.cc
@@ -48,6 +48,8 @@ static const std::string TASK_CACHE_DIR { std::string { PXP_AGENT_ROOT_PATH }
 // Disable cache ttl so we don't delete fixtures.
 static const std::string TASK_CACHE_TTL { "0d" };
 
+static const auto MODULE_CACHE_DIR = std::make_shared<ModuleCacheDir>(TASK_CACHE_DIR, TASK_CACHE_TTL);
+
 static const std::string TEMP_TASK_CACHE_DIR { TASK_CACHE_DIR + "/temp" };
 
 static const std::vector<std::string> MASTER_URIS { { "https://_master1", "https://_master2", "https://_master3" } };
@@ -78,12 +80,12 @@ static const PCPClient::ParsedChunks NON_BLOCKING_CONTENT {
 
 TEST_CASE("Modules::Task", "[modules]") {
     SECTION("can successfully instantiate") {
-        REQUIRE_NOTHROW(Modules::Task(PXP_AGENT_BIN_PATH, TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, "", 10, 20, STORAGE));
+        REQUIRE_NOTHROW(Modules::Task(PXP_AGENT_BIN_PATH, MASTER_URIS, CA, CRT, KEY, "", 10, 20, MODULE_CACHE_DIR, STORAGE));
     }
 }
 
 TEST_CASE("Modules::Task::features", "[modules]") {
-    Modules::Task mod { PXP_AGENT_BIN_PATH, TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, "", 10, 20, STORAGE };
+    Modules::Task mod { PXP_AGENT_BIN_PATH, MASTER_URIS, CA, CRT, KEY, "", 10, 20, MODULE_CACHE_DIR, STORAGE };
 
     SECTION("reports available features") {
         REQUIRE(mod.features().size() > 1);
@@ -97,7 +99,7 @@ TEST_CASE("Modules::Task::features", "[modules]") {
 }
 
 TEST_CASE("Modules::Task::hasAction", "[modules]") {
-    Modules::Task mod { PXP_AGENT_BIN_PATH, TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, "", 10, 20, STORAGE };
+    Modules::Task mod { PXP_AGENT_BIN_PATH, MASTER_URIS, CA, CRT, KEY, "", 10, 20, MODULE_CACHE_DIR, STORAGE };
 
     SECTION("correctly reports false") {
         REQUIRE(!mod.hasAction("foo"));
@@ -133,7 +135,8 @@ static void resetTest() {
 TEST_CASE("Modules::Task::callAction", "[modules]") {
     configureTest();
     lth_util::scope_exit config_cleaner { resetTest };
-    Modules::Task e_m { PXP_AGENT_BIN_PATH, TEMP_TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, "", 10, 20, STORAGE };
+    static const auto temp_module_cache_dir = std::make_shared<ModuleCacheDir>(TEMP_TASK_CACHE_DIR, TASK_CACHE_TTL);
+    Modules::Task e_m { PXP_AGENT_BIN_PATH, MASTER_URIS, CA, CRT, KEY, "", 10, 20, temp_module_cache_dir, STORAGE };
 
     SECTION("throws module processing error when a file system error is thrown") {
         auto existent_sha = "existent";
@@ -153,14 +156,14 @@ TEST_CASE("Modules::Task::callAction", "[modules]") {
         REQUIRE_FALSE(response.action_metadata.includes("results"));
         REQUIRE_FALSE(response.action_metadata.get<bool>("results_are_valid"));
         REQUIRE(response.action_metadata.includes("execution_error"));
-        REQUIRE_THAT(response.action_metadata.get<std::string>("execution_error"), Catch::EndsWith("A file matching the name of the provided sha already exists"));
+        REQUIRE(response.action_metadata.get<std::string>("execution_error").find("Failed to create cache dir to download file to"));
     }
 }
 
 TEST_CASE("Modules::Task::callAction - non blocking", "[modules]") {
     configureTest();
     lth_util::scope_exit config_cleaner { resetTest };
-    Modules::Task e_m { PXP_AGENT_BIN_PATH, TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, "", 10, 20, STORAGE };
+    Modules::Task e_m { PXP_AGENT_BIN_PATH, MASTER_URIS, CA, CRT, KEY, "", 10, 20, MODULE_CACHE_DIR, STORAGE };
 
     SECTION("the pid is written to file") {
         ActionRequest request { RequestType::NonBlocking, NON_BLOCKING_CONTENT };
@@ -185,7 +188,7 @@ TEST_CASE("Modules::Task::callAction - non blocking", "[modules]") {
 TEST_CASE("Modules::Task::executeAction", "[modules][output]") {
     configureTest();
     lth_util::scope_exit config_cleaner { resetTest };
-    Modules::Task e_m { PXP_AGENT_BIN_PATH, TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, "", 10, 20, STORAGE };
+    Modules::Task e_m { PXP_AGENT_BIN_PATH, MASTER_URIS, CA, CRT, KEY, "", 10, 20, MODULE_CACHE_DIR, STORAGE };
 
     SECTION("passes input as json") {
         auto echo_txt =
@@ -404,7 +407,7 @@ TEST_CASE("Modules::Task::executeAction", "[modules][output]") {
     }
 
     SECTION("errors on download when no master-uri is provided") {
-        Modules::Task e_m { PXP_AGENT_BIN_PATH, TEMP_TASK_CACHE_DIR, TASK_CACHE_TTL, {}, CA, CRT, KEY, "", 10, 20, STORAGE };
+        Modules::Task e_m { PXP_AGENT_BIN_PATH, {}, CA, CRT, KEY, "", 10, 20, MODULE_CACHE_DIR, STORAGE };
         auto task_txt = (DATA_FORMAT % "\"0632\""
                                      % "\"task\""
                                      % "\"run\""
@@ -425,7 +428,8 @@ TEST_CASE("Modules::Task::executeAction", "[modules][output]") {
     }
 
     SECTION("if a master-uri has a server-side error, then it proceeds to try the next master-uri. if they all fail, it errors on download and removes all temporary files") {
-        Modules::Task e_m { PXP_AGENT_BIN_PATH, TEMP_TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, "", 10, 20, STORAGE };
+        static const auto temp_module_cache_dir = std::make_shared<ModuleCacheDir>(TEMP_TASK_CACHE_DIR, TASK_CACHE_TTL);
+        Modules::Task e_m { PXP_AGENT_BIN_PATH, MASTER_URIS, CA, CRT, KEY, "", 10, 20, temp_module_cache_dir, STORAGE };
         auto cache = fs::path(TEMP_TASK_CACHE_DIR) / "some_sha";
         auto task_txt = (DATA_FORMAT % "\"0632\""
                                      % "\"task\""
@@ -451,13 +455,14 @@ TEST_CASE("Modules::Task::executeAction", "[modules][output]") {
     }
 
     SECTION("creates the tasks-cache/<sha> directory with ower/group read and write permissions") {
-        Modules::Task e_m { PXP_AGENT_BIN_PATH, TEMP_TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, "", 10, 20, STORAGE };
+        static const auto temp_module_cache_dir = std::make_shared<ModuleCacheDir>(TEMP_TASK_CACHE_DIR, TASK_CACHE_TTL);
+        Modules::Task e_m { PXP_AGENT_BIN_PATH, MASTER_URIS, CA, CRT, KEY, "", 10, 20, temp_module_cache_dir, STORAGE };
         auto cache = fs::path(TEMP_TASK_CACHE_DIR) / "some_other_sha";
         auto task_txt = (DATA_FORMAT % "\"0632\""
                                      % "\"task\""
                                      % "\"run\""
                                      % "{\"task\": \"unparseable\", \"input\":{\"message\":\"hello\"}, "
-                                       "\"files\" : [{\"sha256\": \"some_other_sha\"}]}").str();
+                                       "\"files\" : [{\"sha256\": \"some_other_sha\",  \"filename\": \"some_file\"}]}").str();
         PCPClient::ParsedChunks task_content {
             lth_jc::JsonContainer(ENVELOPE_TXT),
             lth_jc::JsonContainer(task_txt),
@@ -476,7 +481,8 @@ TEST_CASE("Modules::Task::executeAction", "[modules][output]") {
     }
 
     SECTION("succeeds even if tasks-cache was deleted") {
-        Modules::Task e_m { PXP_AGENT_BIN_PATH, TEMP_TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, "", 10, 20, STORAGE };
+        static const auto temp_module_cache_dir = std::make_shared<ModuleCacheDir>(TEMP_TASK_CACHE_DIR, TASK_CACHE_TTL);
+        Modules::Task e_m { PXP_AGENT_BIN_PATH, MASTER_URIS, CA, CRT, KEY, "", 10, 20, temp_module_cache_dir, STORAGE };
         fs::remove_all(TEMP_TASK_CACHE_DIR);
 
         auto cache = fs::path(TEMP_TASK_CACHE_DIR) / "some_other_sha";
@@ -518,7 +524,7 @@ static ActionRequest getEchoRequest(T& metadata)
 TEST_CASE("Modules::Task::executeAction implementations", "[modules][output]") {
     configureTest();
     lth_util::scope_exit config_cleaner { resetTest };
-    Modules::Task e_m { PXP_AGENT_BIN_PATH, TASK_CACHE_DIR, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, "", 10, 20, STORAGE };
+    Modules::Task e_m { PXP_AGENT_BIN_PATH, MASTER_URIS, CA, CRT, KEY, "", 10, 20, MODULE_CACHE_DIR, STORAGE };
 
     SECTION("uses a matching implementation") {
         auto impls = "["
@@ -617,8 +623,10 @@ TEST_CASE("purge old tasks", "[modules]") {
     const std::string OLD_TRANSACTION { "valid_old" };
     const std::string RECENT_TRANSACTION { "valid_recent" };
 
+    static const auto PURGE_MODULE_CACHE_DIR = std::make_shared<ModuleCacheDir>(PURGE_TASK_CACHE, TASK_CACHE_TTL);
+
     // Start with 0 TTL to prevent initial cleanup
-    Modules::Task e_m { PXP_AGENT_BIN_PATH, PURGE_TASK_CACHE, TASK_CACHE_TTL, MASTER_URIS, CA, CRT, KEY, "", 10, 20, STORAGE };
+    Modules::Task e_m { PXP_AGENT_BIN_PATH, MASTER_URIS, CA, CRT, KEY, "", 10, 20, PURGE_MODULE_CACHE_DIR, STORAGE };
 
     unsigned int num_purged_results { 0 };
     auto purgeCallback =


### PR DESCRIPTION
This commit adds a new class, ModuleCacheDir, which will provide methods for
creating and purging cache dirs. A single ModuleCacheDir object will be shared
between all pxp bolt modules.

The shared object allows bolt modules to share the same mutex for creating and
purging the cache dirs.