### PR TITLE
(PE-26709) Restart Solaris 11 pxp-agent service on package upgrade

### DIFF
--- a/ext/solaris/smf/pxp-agent.xml
+++ b/ext/solaris/smf/pxp-agent.xml
@@ -23,6 +23,8 @@
 
     <exec_method type="method" name="stop" exec=":kill" timeout_seconds="60"/>
 
+    <exec_method type="method" name="refresh" exec=":kill" timeout_seconds="60"/>
+
     <stability value="Evolving"/>
 
     <template>


### PR DESCRIPTION
Prior to this commit, the `refresh` action was executed by SMF when the package manifest changed. However, no action was implemented for `refresh`, hence the pxp-agent service did not automatically restart
when the puppet-agent package was upgraded.

This commit adds functionality to the `refresh` action, killing the service for it to be restarted automatically by SMF, which is the intended behavior.