### PR TITLE
(PCP-874) Add functionality for recursive downloads in download_file

### DIFF
--- a/acceptance/lib/pxp-agent/bolt_pxp_module_helper.rb
+++ b/acceptance/lib/pxp-agent/bolt_pxp_module_helper.rb
@@ -5,8 +5,8 @@ def task_file_entry(filename, sha256, path = 'foo')
   {:uri => {:path => path, :params => {}}, :filename => filename, :sha256 => sha256}
 end
 
-def download_file_entry(sha256, path, destination, file_type)
-  {:uri => {:path => path, :params => {}}, :sha256 => sha256, :destination => destination, :file_type => file_type}
+def download_file_entry(sha256, path, link_source, destination, file_type)
+  {:uri => {:path => path, :params => {}}, :sha256 => sha256, :link_source => link_source, :destination => destination, :file_type => file_type}
 end
 
 # Selects only the agents (not masters) from a set of beaker hosts and produces an array of PCP

--- a/acceptance/lib/pxp-agent/bolt_pxp_module_helper.rb
+++ b/acceptance/lib/pxp-agent/bolt_pxp_module_helper.rb
@@ -5,8 +5,8 @@ def task_file_entry(filename, sha256, path = 'foo')
   {:uri => {:path => path, :params => {}}, :filename => filename, :sha256 => sha256}
 end
 
-def download_file_entry(sha256, path, destination)
-  {:uri => {:path => path, :params => {}}, :sha256 => sha256, :destination => destination}
+def download_file_entry(sha256, path, destination, file_type)
+  {:uri => {:path => path, :params => {}}, :sha256 => sha256, :destination => destination, :file_type => file_type}
 end
 
 # Selects only the agents (not masters) from a set of beaker hosts and produces an array of PCP

--- a/acceptance/lib/pxp-agent/bolt_pxp_module_helper.rb
+++ b/acceptance/lib/pxp-agent/bolt_pxp_module_helper.rb
@@ -5,8 +5,8 @@ def task_file_entry(filename, sha256, path = 'foo')
   {:uri => {:path => path, :params => {}}, :filename => filename, :sha256 => sha256}
 end
 
-def download_file_entry(sha256, path, link_source, destination, file_type)
-  {:uri => {:path => path, :params => {}}, :sha256 => sha256, :link_source => link_source, :destination => destination, :file_type => file_type}
+def download_file_entry(sha256, path, link_source, destination, kind)
+  {:uri => {:path => path, :params => {}}, :sha256 => sha256, :link_source => link_source, :destination => destination, :kind => kind}
 end
 
 # Selects only the agents (not masters) from a set of beaker hosts and produces an array of PCP

--- a/acceptance/tests/pxp_module_bolt_download_file/download_file.rb
+++ b/acceptance/tests/pxp_module_bolt_download_file/download_file.rb
@@ -68,7 +68,7 @@ test_name 'download file tests' do
     on master, puppet('resource service puppetserver ensure=running')
   end
 
-  step 'execute successful download_file with files and directories' do
+  step 'execute successful download_file with files,symlinks,directories' do
     suts.each do |agent|
       test_dir = test_dir_destination(agent)
       test_symlink = test_file_destination(agent)
@@ -93,6 +93,8 @@ test_name 'download file tests' do
       test_file_resource_exists(agent, test_symlink, 'link')
       teardown {
         clean_files(agent, test_files)
+        assert_match(/ensure => 'absent'/, on(agent, puppet("resource file #{test_dir} ensure=absent force=true")).stdout)
+        assert_match(/ensure => 'absent'/, on(agent, puppet("resource file #{test_symlink} ensure=absent force=true")).stdout)
       }
     end
   end

--- a/lib/inc/pxp-agent/modules/download_file.hpp
+++ b/lib/inc/pxp-agent/modules/download_file.hpp
@@ -55,6 +55,11 @@ namespace Modules {
       // files.
       ActionResponse callAction(const ActionRequest& request) override;
 
+      // Creates an ActionResponse representing a failure.
+      ActionResponse failure_response(const ActionRequest& request,
+                                      const boost::filesystem::path& results_dir,
+                                      const std::string& message);
+
       // Since DownloadFile overrides callAction there's no reason to define
       // buildCommandObject (since it will never be called)
       Util::CommandObject buildCommandObject(const ActionRequest& request) override {

--- a/lib/inc/pxp-agent/util/bolt_helpers.hpp
+++ b/lib/inc/pxp-agent/util/bolt_helpers.hpp
@@ -26,6 +26,8 @@ namespace Util {
   std::string createUrlEndpoint(const leatherman::json_container::JsonContainer& uri);
   std::string calculateSha256(const std::string& path);
   void createDir(const boost::filesystem::path& dir);
+  void createSymLink(const boost::filesystem::path& destination, const boost::filesystem::path& source);
+
 }  // namespace Util
 }  // namespace PXPAgent
 

--- a/lib/src/modules/download_file.cc
+++ b/lib/src/modules/download_file.cc
@@ -36,6 +36,9 @@ namespace Modules {
             "destination": {
               "type": "string"
             },
+            "link_source": {
+              "type":"string"
+            },
             "uri": {
               "type": "object",
               "properties": {
@@ -55,7 +58,7 @@ namespace Modules {
               "type": "string"
             }
           },
-          "required": ["destination", "uri", "sha256", "file_type"]
+          "required": ["link_source", "destination", "uri", "sha256", "file_type"]
         }
       }
     }
@@ -164,6 +167,14 @@ namespace Modules {
           } catch (fs::filesystem_error& e) {
             return failure_response(request, results_dir, lth_loc::format("Failed to create directory {1}; {2}", destination, e.what()));
           }
+        }
+      } else if (file_type == "symlink") {
+        if (fs::exists(destination)) {
+          if (!fs::is_symlink(destination)) {
+            return failure_response(request, results_dir, lth_loc::format("Destination {1} already exists and is not a symlink!", destination));
+          }
+        } else {
+          Util::createSymLink(fs::path(this_file.get<std::string>("link_source")), destination);
         }
       } else {
           return failure_response(request, results_dir, lth_loc::format("Not a valid file type! {1}", file_type));

--- a/lib/src/modules/download_file.cc
+++ b/lib/src/modules/download_file.cc
@@ -153,6 +153,18 @@ namespace Modules {
         } catch (Module::ProcessingError& e) {
           return failure_response(request, results_dir, lth_loc::format("Failed to download {1}; {2}", destination, e.what()));
         }
+      } else if (file_type == "directory"){
+        if (fs::exists(destination)) {
+          if (!fs::is_directory(destination)) {
+            return failure_response(request, results_dir, lth_loc::format("Destination {1} already exists and is not a directory!", destination));
+          }
+        } else {
+          try {
+            Util::createDir(destination);
+          } catch (fs::filesystem_error& e) {
+            return failure_response(request, results_dir, lth_loc::format("Failed to create directory {1}; {2}", destination, e.what()));
+          }
+        }
       } else {
           return failure_response(request, results_dir, lth_loc::format("Not a valid file type! {1}", file_type));
       }

--- a/lib/src/modules/download_file.cc
+++ b/lib/src/modules/download_file.cc
@@ -54,11 +54,11 @@ namespace Modules {
             "sha256": {
               "type": "string"
             },
-            "file_type": {
+            "kind": {
               "type": "string"
             }
           },
-          "required": ["link_source", "destination", "uri", "sha256", "file_type"]
+          "required": ["link_source", "destination", "uri", "sha256", "kind"]
         }
       }
     }
@@ -143,8 +143,8 @@ namespace Modules {
     lth_jc::JsonContainer result;
     for (auto this_file : files) {
       auto destination = fs::path(this_file.get<std::string>("destination"));
-      auto file_type = this_file.get<std::string>("file_type");
-      if (file_type == "file") {
+      auto kind = this_file.get<std::string>("kind");
+      if (kind == "file") {
         try {
           Util::downloadFileFromMaster(master_uris_,
                         file_download_connect_timeout_,
@@ -156,7 +156,7 @@ namespace Modules {
         } catch (Module::ProcessingError& e) {
           return failure_response(request, results_dir, lth_loc::format("Failed to download {1}; {2}", destination, e.what()));
         }
-      } else if (file_type == "directory"){
+      } else if (kind == "directory"){
         if (fs::exists(destination)) {
           if (!fs::is_directory(destination)) {
             return failure_response(request, results_dir, lth_loc::format("Destination {1} already exists and is not a directory!", destination));
@@ -168,7 +168,7 @@ namespace Modules {
             return failure_response(request, results_dir, lth_loc::format("Failed to create directory {1}; {2}", destination, e.what()));
           }
         }
-      } else if (file_type == "symlink") {
+      } else if (kind == "symlink") {
         if (fs::exists(destination)) {
           if (!fs::is_symlink(destination)) {
             return failure_response(request, results_dir, lth_loc::format("Destination {1} already exists and is not a symlink!", destination));
@@ -177,7 +177,7 @@ namespace Modules {
           Util::createSymLink(fs::path(this_file.get<std::string>("link_source")), destination);
         }
       } else {
-          return failure_response(request, results_dir, lth_loc::format("Not a valid file type! {1}", file_type));
+          return failure_response(request, results_dir, lth_loc::format("Not a valid file type! {1}", kind));
       }
     }
     response.output = write_download_results(results_dir, EXIT_SUCCESS, "downloaded", "");

--- a/lib/src/util/bolt_helpers.cc
+++ b/lib/src/util/bolt_helpers.cc
@@ -191,6 +191,11 @@ namespace Util {
     fs::permissions(dir, NIX_DIR_PERMS);
   }
 
+  void createSymLink(const fs::path& destination, const fs::path& source) {
+    fs::create_symlink(destination, source);
+    fs::permissions(destination, NIX_DIR_PERMS);
+  }
+
 
 }  // namespace Util
 }  // namespace PXPAgent

--- a/lib/src/util/bolt_helpers.cc
+++ b/lib/src/util/bolt_helpers.cc
@@ -73,6 +73,9 @@ namespace Util {
       fs::remove(tempname);
       throw Module::ProcessingError(lth_loc::format("The downloaded file {1} has a SHA that differs from the provided SHA", filename));
     }
+    if (!fs::exists(destination.parent_path())) {
+      Util::createDir(destination.parent_path());
+    }
     fs::rename(tempname, destination);
     return destination;
   }

--- a/lib/src/util/bolt_helpers.cc
+++ b/lib/src/util/bolt_helpers.cc
@@ -191,6 +191,14 @@ namespace Util {
     fs::permissions(dir, NIX_DIR_PERMS);
   }
 
+  // It looks like there are ways for POSIX nodes to specify umask of the pxp-agent service, which means any file/symlink/dir
+  // created with boost should match the umask of the service process. That means between the file being created and the call
+  // to fs::permissions it looks like the user can still control the security of the files/symlinks/dirs.
+
+  // For windows: all permissions are inherited by the containing directory, meaning there is no scenario where files/symlinks
+  // will have perms more open than the containing directories.
+
+  // The above info should mean the links are safe between symlink creation and permissions setting.
   void createSymLink(const fs::path& destination, const fs::path& source) {
     fs::create_symlink(destination, source);
     fs::permissions(destination, NIX_DIR_PERMS);

--- a/lib/tests/unit/modules/download_file_test.cc
+++ b/lib/tests/unit/modules/download_file_test.cc
@@ -75,7 +75,7 @@ static auto success_params = boost::format("{\"files\": ["
                                                                     "\"sha256\":\"94CBA5396781C06EFB4237730751532CBEFEA4C637D17A61B2E78598F08732C2\","
                                                                     "\"destination\":\"%1%/file.txt\","
                                                                     "\"link_source\":\"\","
-                                                                    "\"file_type\":\"file\""
+                                                                    "\"kind\":\"file\""
                                                                 "},"
                                                                 "{"
                                                                     "\"uri\":{"
@@ -85,12 +85,12 @@ static auto success_params = boost::format("{\"files\": ["
                                                                     "\"sha256\":\"\","
                                                                     "\"destination\":\"%2%\","
                                                                     "\"link_source\":\"\","
-                                                                    "\"file_type\":\"directory\""
+                                                                    "\"kind\":\"directory\""
                                                                 "}"
                                                             "]"
                                                 "}") % TEST_FILE_DIR % TEST_NEW_DIR;
 
-// Create a failure scenario by using a request with a "directory" file type where
+// Create a failure scenario by using a request with a "directory" content type where
 // the destination already exists as a file
 static auto dir_already_exists_params = boost::format("{\"files\": ["
                                                                 "{"
@@ -101,12 +101,12 @@ static auto dir_already_exists_params = boost::format("{\"files\": ["
                                                                     "\"sha256\":\"\","
                                                                     "\"destination\":\"%1%/file.txt\","
                                                                     "\"link_source\":\"\","
-                                                                    "\"file_type\":\"directory\""
+                                                                    "\"kind\":\"directory\""
                                                                 "}"
                                                             "]"
                                                        "}") % TEST_FILE_DIR;
 
-// Create a failure scenario by using a request with a "directory" file type where
+// Create a failure scenario by using a request with a "directory" content type where
 // the destination already exists as a file
 static auto symlink_already_exists_params = boost::format("{\"files\": ["
                                                                           "{"
@@ -118,7 +118,7 @@ static auto symlink_already_exists_params = boost::format("{\"files\": ["
                                                                               "\"filename\":\"\","
                                                                               "\"destination\":\"%1%/file.txt\","
                                                                               "\"link_source\":\"\","
-                                                                              "\"file_type\":\"directory\""
+                                                                              "\"kind\":\"symlink\""
                                                                           "}"
                                                                       "]"
                                                            "}") % TEST_FILE_DIR;
@@ -136,7 +136,7 @@ static auto failure_params = boost::format("{\"files\": [{"
                                                 "\"sha256\":\"FAKESHA256\","
                                                 "\"destination\":\"%1%/does_not_exist.txt\","
                                                 "\"link_source\":\"\","
-                                                "\"file_type\":\"file\""
+                                                "\"kind\":\"file\""
                                              "}]"
                                     "}") % TEST_FILE_DIR;
 

--- a/lib/tests/unit/modules/download_file_test.cc
+++ b/lib/tests/unit/modules/download_file_test.cc
@@ -66,7 +66,8 @@ static auto success_params = boost::format("{\"files\": [{"
                                                         "}"
                                                 "},"
                                                 "\"sha256\":\"94CBA5396781C06EFB4237730751532CBEFEA4C637D17A61B2E78598F08732C2\","
-                                                "\"destination\":\"%1%/file.txt\""
+                                                "\"destination\":\"%1%/file.txt\","
+                                                "\"file_type\":\"file\""
                                              "}]"
                                     "}") % TEST_FILE_DIR;
 
@@ -81,7 +82,8 @@ static auto failure_params = boost::format("{\"files\": [{"
                                                         "}"
                                                 "},"
                                                 "\"sha256\":\"FAKESHA256\","
-                                                "\"destination\":\"%1%/does_not_exist.txt\""
+                                                "\"destination\":\"%1%/does_not_exist.txt\","
+                                                "\"file_type\":\"file\""
                                              "}]"
                                     "}") % TEST_FILE_DIR;
 


### PR DESCRIPTION
This work should expand the download_file module in pxp-agent to implement taking an array of files/directories/symlinks and creating them all on the system.

The schema for download_file already takes an array (previously it just operated on the first element), so the only update required for the schema is a field to differentiate between files/dirs/symlinks.