### PR TITLE
(PCP-869) Add script module to pxp-agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 /dev-resources/
 /lib/tests/resources/test_spool/
 /lib/tests/resources/cache_dir/
+/lib/tests/resources/scripts_cache/FAILINGSHA256
+/lib/tests/resources/scripts_cache/SCRIPT_FAILING_SHA
 /lib/tests/resources/tmp/
 /lib/tests/resources/cache_dir/
 .idea/

--- a/acceptance/tests/pxp_module_bolt_script/run_script.rb
+++ b/acceptance/tests/pxp_module_bolt_script/run_script.rb
@@ -1,0 +1,83 @@
+require 'pxp-agent/bolt_pxp_module_helper.rb'
+require 'pxp-agent/config_helper.rb'
+require 'puppet/acceptance/environment_utils.rb'
+
+PUPPETSERVER_CONFIG_FILE = '/etc/puppetlabs/puppetserver/conf.d/webserver.conf'
+
+suts = agents.reject { |host| host['roles'].include?('master') }
+
+def clean_files(agent)
+  tasks_cache = get_tasks_cache(agent)
+  assert_match(/ensure => 'absent'/, on(agent, puppet("resource file #{tasks_cache}/#{@sha256} ensure=absent force=true")).stdout)
+end
+
+test_name 'run script tests' do
+  extend Puppet::Acceptance::EnvironmentUtils
+  step 'Ensure each agent host has pxp-agent running and associated' do
+    agents.each do |agent|
+      on agent, puppet('resource service pxp-agent ensure=stopped')
+      create_remote_file(agent, pxp_agent_config_file(agent), pxp_config_hocon_using_puppet_certs(master, agent))
+      on agent, puppet('resource service pxp-agent ensure=running')
+
+      assert(is_associated?(master, "pcp://#{agent}/agent"),
+             "Agent #{agent} with PCP identity pcp://#{agent}/agent should be associated with pcp-broker")
+    end
+  end
+
+  step 'Create the downloadable scripts on the master' do
+    # Make the static content path
+    env_name = File.basename(__FILE__, '.*')
+    @static_content_path = File.join(environmentpath, mk_tmp_environment(env_name))
+    # Create a linux script
+    unix_file_body = "#!/usr/bin/env bash\necho \"TEST SCRIPT: $1\"\nexit 0"
+    unix_filename = 'unix_test.sh'
+    win_file_body = "Write-Output \"TEST SCRIPT: $($Args[0])\"\nexit 0"
+    win_filename = 'win_test.ps1'
+    @unix_sha256, @win_sha256 = { unix_filename => unix_file_body, win_filename => win_file_body }.map do |filename, file_body|
+      filepath = "#{@static_content_path}/#{filename}"
+      create_remote_file(master, filepath, file_body)
+      on master, "chmod 1777 #{filepath}"
+      Digest::SHA256.hexdigest(file_body + "\n")
+    end
+    @win_source = "/download-test-files/#{win_filename}"
+    @unix_source = "/download-test-files/#{unix_filename}"
+  end
+
+  step 'Setup the static script file mount on puppetserver' do
+    on master, puppet('resource service puppetserver ensure=stopped')
+    hocon_file_edit_in_place_on(master, PUPPETSERVER_CONFIG_FILE) do |host, doc|
+      doc.set_config_value("webserver.static-content", Hocon::ConfigValueFactory.from_any_ref([{
+        "path" => "/download-test-files",
+        "resource" => @static_content_path
+      }]))
+    end
+    on master, puppet('resource service puppetserver ensure=running')
+  end
+
+
+  # Spec testing can cover most of the functionality for running a script,
+  # we only really require one test to ensure the script module is correctly
+  # connected through the agent and is able to execute on a message actually
+  # sent from a broker.
+  step 'Execute a script run' do
+    suts.each do |agent|
+      if windows?(agent)
+        test_file = 'win_test.ps1'
+        test_source = @win_source
+        test_sha = @win_sha256
+      else
+        test_file = 'unix_test.sh'
+        test_source = @unix_source
+        test_sha = @unix_sha256
+      end
+
+      run_successful_script(master, agent, script_file_entry(test_file, test_sha, test_source), 'ARGS_TEST') do |std_out|
+        assert(std_out.include?("TEST SCRIPT: ARGS_TEST"))
+      end
+
+      teardown {
+        clean_files(agent)
+      }
+    end
+  end
+end

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -34,6 +34,7 @@ set(LIBRARY_COMMON_SOURCES
     src/modules/ping.cc
     src/modules/task.cc
     src/modules/download_file.cc
+    src/modules/script.cc
     src/util/bolt_helpers.cc
     src/util/bolt_module.cc
     src/util/utf8.cc

--- a/lib/inc/pxp-agent/modules/script.hpp
+++ b/lib/inc/pxp-agent/modules/script.hpp
@@ -1,0 +1,52 @@
+#ifndef SRC_MODULES_SCRIPT_H_
+#define SRC_MODULES_SCRIPT_H_
+
+#include <pxp-agent/module.hpp>
+#include <pxp-agent/results_storage.hpp>
+#include <pxp-agent/util/bolt_module.hpp>
+#include <pxp-agent/util/purgeable.hpp>
+#include <pxp-agent/module_cache_dir.hpp>
+
+#include <leatherman/locale/locale.hpp>
+#include <leatherman/curl/client.hpp>
+
+namespace PXPAgent {
+namespace Modules {
+
+class Script : public PXPAgent::Util::BoltModule, public PXPAgent::Util::Purgeable {
+    public:
+        Script(const boost::filesystem::path& exec_prefix,
+               const std::vector<std::string>& master_uris,
+               const std::string& ca,
+               const std::string& crt,
+               const std::string& key,
+               const std::string& proxy,
+               uint32_t download_connect_timeout,
+               uint32_t download_timeout,
+               std::shared_ptr<ModuleCacheDir> module_cache_dir,
+               std::shared_ptr<ResultsStorage> storage);
+
+        Util::CommandObject buildCommandObject(const ActionRequest& request) override;
+
+        /// Utility to purge files from the cache_dir that have surpassed the ttl.
+        /// If a purge_callback is not specified, the boost filesystem's remove_all() will be used.
+        /// Returns number of directories purged.
+        unsigned int purge(
+            const std::string& ttl,
+            std::vector<std::string> ongoing_transactions,
+            std::function<void(const std::string& dir_path)> purge_callback = nullptr) override;
+
+    private:
+      boost::filesystem::path exec_prefix_;
+
+      std::vector<std::string> master_uris_;
+
+      uint32_t download_connect_timeout_, download_timeout_;
+
+      leatherman::curl::client client_;
+};
+
+}  // namespace Modules
+}  // namespace PXPAgent
+
+#endif  // SRC_MODULES_SCRIPT_H_

--- a/lib/inc/pxp-agent/modules/task.hpp
+++ b/lib/inc/pxp-agent/modules/task.hpp
@@ -49,12 +49,6 @@ class Task : public PXPAgent::Util::BoltModule, public PXPAgent::Util::Purgeable
 
     leatherman::curl::client client_;
 
-    boost::filesystem::path getCachedTaskFile(const std::vector<std::string>& master_uris,
-                               uint32_t connect_timeout,
-                               uint32_t timeout,
-                               leatherman::curl::client& client,
-                               leatherman::json_container::JsonContainer& file);
-
     boost::filesystem::path downloadMultiFile(std::vector<leatherman::json_container::JsonContainer> const& files,
         std::set<std::string> const& download_set,
         boost::filesystem::path const& spool_dir);

--- a/lib/inc/pxp-agent/util/bolt_helpers.hpp
+++ b/lib/inc/pxp-agent/util/bolt_helpers.hpp
@@ -4,11 +4,31 @@
 #include <leatherman/locale/locale.hpp>
 #include <leatherman/curl/client.hpp>
 #include <leatherman/json_container/json_container.hpp>
+#include <pxp-agent/util/bolt_module.hpp>
 
 #include <tuple>
 
 namespace PXPAgent {
 namespace Util {
+
+  // Hard-code interpreters on Windows. On non-Windows, we still rely on permissions and #!
+  const std::map<std::string, std::function<std::pair<std::string, std::vector<std::string>>(std::string)>> BUILTIN_INTERPRETERS {
+  #ifdef _WIN32
+      {".rb",  [](std::string filename) { return std::pair<std::string, std::vector<std::string>> {
+          "ruby", { filename }
+      }; }},
+      {".pp",  [](std::string filename) { return std::pair<std::string, std::vector<std::string>> {
+          "puppet", { "apply", filename }
+      }; }},
+      {".ps1", [](std::string filename) { return std::pair<std::string, std::vector<std::string>> {
+          "powershell",
+          { "-NoProfile", "-NonInteractive", "-NoLogo", "-ExecutionPolicy", "Bypass", "-File", filename }
+      }; }}
+  #endif
+  };
+
+  void findExecutableAndArguments(const boost::filesystem::path& file, Util::CommandObject& cmd);
+
   boost::filesystem::path downloadFileFromMaster(const std::vector<std::string>& master_uris,
                                                 uint32_t connect_timeout,
                                                 uint32_t timeout,

--- a/lib/inc/pxp-agent/util/bolt_helpers.hpp
+++ b/lib/inc/pxp-agent/util/bolt_helpers.hpp
@@ -54,7 +54,7 @@ namespace Util {
   std::string calculateSha256(const std::string& path);
   void createDir(const boost::filesystem::path& dir);
   void createSymLink(const boost::filesystem::path& destination, const boost::filesystem::path& source);
-
+  std::vector<std::string> splitArguments(const std::string& raw_arg_list);
 }  // namespace Util
 }  // namespace PXPAgent
 

--- a/lib/inc/pxp-agent/util/bolt_helpers.hpp
+++ b/lib/inc/pxp-agent/util/bolt_helpers.hpp
@@ -29,6 +29,13 @@ namespace Util {
 
   void findExecutableAndArguments(const boost::filesystem::path& file, Util::CommandObject& cmd);
 
+  boost::filesystem::path getCachedFile(const std::vector<std::string>& master_uris,
+                                  uint32_t connect_timeout,
+                                  uint32_t timeout,
+                                  leatherman::curl::client& client,
+                                  const boost::filesystem::path& cache_dir,
+                                  leatherman::json_container::JsonContainer& file);
+
   boost::filesystem::path downloadFileFromMaster(const std::vector<std::string>& master_uris,
                                                 uint32_t connect_timeout,
                                                 uint32_t timeout,

--- a/lib/src/modules/script.cc
+++ b/lib/src/modules/script.cc
@@ -1,0 +1,128 @@
+#include <pxp-agent/modules/script.hpp>
+#include <pxp-agent/util/bolt_helpers.hpp>
+#include <pxp-agent/configuration.hpp>
+#include <boost/filesystem/path.hpp>
+#include <boost/algorithm/string.hpp>
+#include <boost/tokenizer.hpp>
+#include <leatherman/json_container/json_container.hpp>
+#include <leatherman/file_util/file.hpp>
+
+
+namespace fs = boost::filesystem;
+namespace lth_jc = leatherman::json_container;
+namespace lth_file = leatherman::file_util;
+
+namespace PXPAgent {
+namespace Modules {
+
+    static const std::string script_ACTION { "run" };
+    static const std::string script_ACTION_INPUT_SCHEMA { R"(
+    {
+        "type": "object",
+        "properties": {
+            "script": {
+                "type": "object",
+                "properties": {
+                    "filename": {
+                        "type": "string"
+                    },
+                    "uri": {
+                        "type": "object",
+                        "properties": {
+                            "path": {
+                                "type": "string"
+                            },
+                            "params": {
+                                "type": "object"
+                            }
+                        },
+                        "required": ["path", "params"]
+                    },
+                    "sha256": {
+                        "type": "string"
+                    }
+                },
+                "required": ["filename", "uri", "sha256"]
+            },
+            "arguments": {
+                "type": "string"
+            }
+        },
+        "required": ["script", "arguments"]
+    }
+    )" };
+
+    Script::Script(const fs::path& exec_prefix,
+                         const std::vector<std::string>& master_uris,
+                         const std::string& ca,
+                         const std::string& crt,
+                         const std::string& key,
+                         const std::string& proxy,
+                         uint32_t download_connect_timeout,
+                         uint32_t download_timeout,
+                         std::shared_ptr<ModuleCacheDir> module_cache_dir,
+                         std::shared_ptr<ResultsStorage> storage) :
+        BoltModule { exec_prefix, std::move(storage), std::move(module_cache_dir) },
+        Purgeable { module_cache_dir_->purge_ttl_ },
+        master_uris_ { master_uris },
+        download_connect_timeout_ { download_connect_timeout },
+        download_timeout_ { download_timeout }
+    {
+        module_name = "script";
+        actions.push_back(script_ACTION);
+
+        PCPClient::Schema input_schema { script_ACTION, lth_jc::JsonContainer { script_ACTION_INPUT_SCHEMA } };
+        PCPClient::Schema output_schema { script_ACTION };
+
+        input_validator_.registerSchema(input_schema);
+        results_validator_.registerSchema(output_schema);
+
+        client_.set_ca_cert(ca);
+        client_.set_client_cert(crt, key);
+        client_.set_supported_protocols(CURLPROTO_HTTPS);
+        client_.set_proxy(proxy);
+    }
+
+    Util::CommandObject Script::buildCommandObject(const ActionRequest& request)
+    {
+        const auto params = request.params();
+        auto script = params.get<lth_jc::JsonContainer>("script");
+         // Arguments needs to be split for leatherman::execute to work
+        auto raw_arguments = params.get<std::string>("arguments");
+        auto arguments = Util::splitArguments(raw_arguments);
+        const fs::path& results_dir { request.resultsDir() };
+
+        // get script from cache, download if necessary
+        auto script_file = Util::getCachedFile(master_uris_,
+                                               download_connect_timeout_,
+                                               download_timeout_,
+                                               client_,
+                                               module_cache_dir_->createCacheDir(script.get<std::string>("sha256")),
+                                               script);
+        Util::CommandObject cmd {
+            "",         // Executable will be detremined by findExecutableAndArguments
+            arguments,  // Arguments
+            {},         // Environment
+            "",         // Input
+            [results_dir](size_t pid) {
+                auto pid_file = (results_dir / "pid").string();
+                lth_file::atomic_write_to_file(std::to_string(pid) + "\n", pid_file,
+                                            NIX_FILE_PERMS, std::ios::binary);
+            }  // PID Callback
+        };
+        Util::findExecutableAndArguments(script_file, cmd);
+
+        return cmd;
+    }
+
+    unsigned int Script::purge(
+        const std::string& ttl,
+        std::vector<std::string> ongoing_transactions,
+        std::function<void(const std::string& dir_path)> purge_callback)
+    {
+        if (purge_callback == nullptr)
+            purge_callback = &Purgeable::defaultDirPurgeCallback;
+        return module_cache_dir_->purgeCache(ttl, ongoing_transactions, purge_callback);
+    }
+}  // namespace Modules
+}  // namespace PXPAgent

--- a/lib/src/request_processor.cc
+++ b/lib/src/request_processor.cc
@@ -12,6 +12,7 @@
 #include <pxp-agent/modules/ping.hpp>
 #include <pxp-agent/modules/task.hpp>
 #include <pxp-agent/modules/download_file.hpp>
+#include <pxp-agent/modules/script.hpp>
 #include <pxp-agent/util/process.hpp>
 
 #include <leatherman/json_container/json_container.hpp>
@@ -859,6 +860,19 @@ void RequestProcessor::loadInternalModules(const Configuration::Agent& agent_con
         storage_ptr_);
     registerModule(dl_file);
     registerPurgeable(dl_file);
+    auto script = std::make_shared<Modules::Script>(
+        Configuration::Instance().getExecPrefix(),
+        agent_configuration.master_uris,
+        agent_configuration.ca,
+        agent_configuration.crt,
+        agent_configuration.key,
+        agent_configuration.master_proxy,
+        agent_configuration.task_download_connect_timeout_s,
+        agent_configuration.task_download_timeout_s,
+        module_cache_dir_,
+        storage_ptr_);
+    registerModule(script);
+    registerPurgeable(script);
 }
 
 void RequestProcessor::loadExternalModulesFrom(fs::path dir_path)

--- a/lib/src/util/bolt_helpers.cc
+++ b/lib/src/util/bolt_helpers.cc
@@ -19,6 +19,19 @@ namespace lth_loc  = leatherman::locale;
 namespace PXPAgent {
 namespace Util {
 
+  void findExecutableAndArguments(const fs::path& file, Util::CommandObject& cmd)
+  {
+      auto builtin = BUILTIN_INTERPRETERS.find(file.extension().string());
+
+      if (builtin != BUILTIN_INTERPRETERS.end()) {
+          auto details = builtin->second(file.string());
+          cmd.executable = details.first;
+          cmd.arguments = details.second;
+      } else {
+          cmd.executable = file.string();
+      }
+  }
+
 
   // NIX_DIR_PERMS is defined in pxp-agent/configuration
   #define NIX_DOWNLOADED_FILE_PERMS NIX_DIR_PERMS

--- a/lib/src/util/bolt_helpers.cc
+++ b/lib/src/util/bolt_helpers.cc
@@ -4,6 +4,8 @@
 
 #include <boost/algorithm/hex.hpp>
 #include <boost/algorithm/string.hpp>
+#include <boost/tokenizer.hpp>
+
 
 #define LEATHERMAN_LOGGING_NAMESPACE "puppetlabs.pxp_agent.util.bolt_helpers"
 #include <leatherman/logging/logging.hpp>
@@ -239,6 +241,19 @@ namespace Util {
     fs::permissions(destination, NIX_DIR_PERMS);
   }
 
+  // Try to split the raw command text into executable and arguments, as leatherman::execution
+  // expects, taking care to retain spaces within quoted executables or argument names.
+  // This approach is borrowed from boost's `program_options::split_unix`.
+  std::vector<std::string> splitArguments(const std::string& raw_arg_list) {
+    boost::escaped_list_separator<char> e_l_s {
+        "",     // don't parse any escaped characters here,
+                //   just get quote-aware space-separated chunks
+        " ",    // split fields on spaces
+        "\"\'"  // double or single quotes will group multiple fields as one
+    };
+    boost::tokenizer<boost::escaped_list_separator<char>> tok(raw_arg_list, e_l_s);
+    return { tok.begin(), tok.end() };
+  }
 
 }  // namespace Util
 }  // namespace PXPAgent

--- a/lib/src/util/bolt_helpers.cc
+++ b/lib/src/util/bolt_helpers.cc
@@ -28,7 +28,15 @@ namespace Util {
       if (builtin != BUILTIN_INTERPRETERS.end()) {
           auto details = builtin->second(file.string());
           cmd.executable = details.first;
-          cmd.arguments = details.second;
+          // cmd.arguments may already have values, so instead of setting
+          // cmd.arguments directly: fetch the prefix arguments (that should
+          // go before the user provided ones), then insert the user provided
+          // ones in to prefix_args to create a flattened vector that will be:
+          // { prefix_args, cmd.arguments }
+          std::vector<std::string> prefix_args = details.second;
+          std::vector<std::string> provided_args = cmd.arguments;
+          prefix_args.insert(prefix_args.end(), provided_args.begin(), provided_args.end());
+          cmd.arguments = prefix_args;
       } else {
           cmd.executable = file.string();
       }

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -31,6 +31,7 @@ set(COMMON_TEST_SOURCES
     unit/modules/ping_test.cc
     unit/modules/task_test.cc
     unit/modules/download_file_test.cc
+    unit/modules/script_test.cc
     unit/util/process_test.cc
 )
 

--- a/lib/tests/resources/scripts_cache/3D57FCC5FBDC53E667D16493D38621F36B2CF7DB244986B07A4FBCFECE9E19BD/test script.ps1
+++ b/lib/tests/resources/scripts_cache/3D57FCC5FBDC53E667D16493D38621F36B2CF7DB244986B07A4FBCFECE9E19BD/test script.ps1
@@ -1,0 +1,13 @@
+if ($Args.count -eq 0) {
+  Write-Output "TESTING"
+  exit
+} elseif ($Args[0] -eq "FAIL") {
+  Write-Error "FAIL TESTING"
+  exit 5
+} else {
+  $str=""
+  foreach ($arg in $Args) {
+    $str += "| $arg "
+  }
+  Write-Output $str
+}

--- a/lib/tests/resources/scripts_cache/3D57FCC5FBDC53E667D16493D38621F36B2CF7DB244986B07A4FBCFECE9E19BD/test_script.ps1
+++ b/lib/tests/resources/scripts_cache/3D57FCC5FBDC53E667D16493D38621F36B2CF7DB244986B07A4FBCFECE9E19BD/test_script.ps1
@@ -1,0 +1,13 @@
+if ($Args.count -eq 0) {
+  Write-Output "TESTING"
+  exit
+} elseif ($Args[0] -eq "FAIL") {
+  Write-Error "FAIL TESTING"
+  exit 5
+} else {
+  $str=""
+  foreach ($arg in $Args) {
+    $str += "| $arg "
+  }
+  Write-Output $str
+}

--- a/lib/tests/resources/scripts_cache/71A2725F36221AAE75AF076D01D18744DA461A02DD2AB746447BC41C71248562/test_script.sh
+++ b/lib/tests/resources/scripts_cache/71A2725F36221AAE75AF076D01D18744DA461A02DD2AB746447BC41C71248562/test_script.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+if [ -z $1 ]; then
+  echo 'TESTING'
+elif [ "$1" = "FAIL" ]; then
+  echo 'FAIL TESTING' >&2
+  exit 5
+else
+  str=""
+  for VAR in "$@"
+  do
+    str="$str | $VAR"
+  done
+  echo $str
+fi

--- a/lib/tests/unit/modules/download_file_test.cc
+++ b/lib/tests/unit/modules/download_file_test.cc
@@ -143,7 +143,7 @@ static auto failure_params = boost::format("{\"files\": [{"
 static const PCPClient::ParsedChunks SUCCESS_NON_BLOCKING_CONTENT {
                     lth_jc::JsonContainer(ENVELOPE_TXT),           // envelope
                     lth_jc::JsonContainer(std::string { (NON_BLOCKING_DATA_FORMAT % "\"1988\""
-                                                                                  % "\"downloadfile\""
+                                                                                  % "\"download_file\""
                                                                                   % "\"download\""
                                                                                   % success_params
                                                                                   % "false").str() }),  // data
@@ -173,7 +173,7 @@ static const PCPClient::ParsedChunks FAILURE_SYMLINK_EXISTS_AS_FILE_CONTENT {
 static const PCPClient::ParsedChunks FAILURE_NON_BLOCKING_CONTENT {
                     lth_jc::JsonContainer(ENVELOPE_TXT),           // envelope
                     lth_jc::JsonContainer(std::string { (NON_BLOCKING_DATA_FORMAT % "\"1988\""
-                                                                                  % "\"downloadfile\""
+                                                                                  % "\"download_file\""
                                                                                   % "\"download\""
                                                                                   % failure_params
                                                                                   % "false").str() }),  // data

--- a/lib/tests/unit/modules/script_test.cc
+++ b/lib/tests/unit/modules/script_test.cc
@@ -1,0 +1,200 @@
+#include "root_path.hpp"
+#include "../../common/content_format.hpp"
+
+#include <pxp-agent/modules/script.hpp>
+#include <pxp-agent/configuration.hpp>
+#include <pxp-agent/util/process.hpp>
+
+#include <cpp-pcp-client/protocol/chunks.hpp>       // ParsedChunks
+
+#include <leatherman/json_container/json_container.hpp>
+#include <leatherman/util/scope_exit.hpp>
+#include <leatherman/file_util/file.hpp>
+
+#include <boost/filesystem.hpp>
+#include <boost/algorithm/string/trim.hpp>
+#include <boost/algorithm/string/predicate.hpp>
+#include <boost/algorithm/string/erase.hpp>
+#include <boost/date_time/posix_time/posix_time_types.hpp>
+
+#include <catch.hpp>
+
+#include <string>
+#include <vector>
+#include <unistd.h>
+
+using namespace PXPAgent;
+
+namespace fs = boost::filesystem;
+namespace pt = boost::posix_time;
+namespace lth_jc = leatherman::json_container;
+namespace lth_util = leatherman::util;
+namespace lth_file = leatherman::file_util;
+
+#ifdef _WIN32
+    static const std::string TESTING_SCRIPT = "test_script.ps1";
+    static const std::string TESTING_SCRIPT_SHA265 = "3D57FCC5FBDC53E667D16493D38621F36B2CF7DB244986B07A4FBCFECE9E19BD";
+#else
+    static const std::string TESTING_SCRIPT = "test_script.sh";
+    static const std::string TESTING_SCRIPT_SHA265 = "71A2725F36221AAE75AF076D01D18744DA461A02DD2AB746447BC41C71248562";
+#endif
+
+static const std::string SPOOL_DIR { std::string { PXP_AGENT_ROOT_PATH }
+                                     + "/lib/tests/resources/test_spool" };
+
+static const auto STORAGE = std::make_shared<ResultsStorage>(SPOOL_DIR, "0d");
+
+static const std::string CACHE_DIR { std::string { PXP_AGENT_ROOT_PATH }
+                                          + "/lib/tests/resources/scripts_cache" };
+
+// Disable cache ttl so we don't delete fixtures.
+static const std::string CACHE_TTL { "0d" };
+
+static const auto MODULE_CACHE_DIR = std::make_shared<ModuleCacheDir>(CACHE_DIR, CACHE_TTL);
+
+static const std::string TEMP_CACHE_DIR { CACHE_DIR + "/temp" };
+
+static const std::vector<std::string> MASTER_URIS { { "https://_master1", "https://_master2", "https://_master3" } };
+
+static const std::string CA { "mock_ca" };
+
+static const std::string CRT { "mock_crt" };
+
+static const std::string KEY { "mock_key" };
+
+static const ActionRequest script_request(const std::string& destination, const std::string& sha, const std::string& args) {
+    auto params = boost::format("{\"script\": {"
+                                                        "\"uri\":{"
+                                                                "\"path\":\"/dl_files/fake-request-file.txt\","
+                                                                "\"params\":{"
+                                                                    "\"environment\":\"production\""
+                                                                "}"
+                                                        "},"
+                                                        "\"sha256\":\"%1%\","
+                                                        "\"filename\":\"%2%\""
+                                                    "},"
+                                        "\"arguments\":\"%3%\""
+                                        "}") % sha % destination % args;
+    const PCPClient::ParsedChunks non_blocking_content {
+        lth_jc::JsonContainer(ENVELOPE_TXT),           // envelope
+        lth_jc::JsonContainer(std::string { (NON_BLOCKING_DATA_FORMAT % "\"1988\""
+                                                                        % "\"script\""
+                                                                        % "\"run\""
+                                                                        % params
+                                                                        % "false").str() }),  // data
+        {},   // debug
+        0 };
+    ActionRequest request { RequestType::NonBlocking, non_blocking_content };
+    fs::path spool_path { SPOOL_DIR };
+    auto results_dir = (spool_path / request.transactionId()).string();
+    fs::create_directories(results_dir);
+    request.setResultsDir(results_dir);
+
+    return request;
+}
+
+TEST_CASE("Modules::Script", "[modules]") {
+    SECTION("can successfully instantiate") {
+        REQUIRE_NOTHROW(Modules::Script(PXP_AGENT_BIN_PATH, MASTER_URIS, CA, CRT, KEY, "", 10, 20, MODULE_CACHE_DIR, STORAGE));
+    }
+}
+
+TEST_CASE("Modules::Script::hasAction", "[modules]") {
+    Modules::Script mod { PXP_AGENT_BIN_PATH, MASTER_URIS, CA, CRT, KEY, "", 10, 20, MODULE_CACHE_DIR, STORAGE };
+    SECTION("correctly reports false") {
+        REQUIRE(!mod.hasAction("foo"));
+    }
+
+    SECTION("correctly reports true") {
+        REQUIRE(mod.hasAction("run"));
+    }
+}
+
+TEST_CASE("Modules::Script can execute a script", "[modules]") {
+    Modules::Script mod { PXP_AGENT_BIN_PATH, MASTER_URIS, CA, CRT, KEY, "", 10, 20, MODULE_CACHE_DIR, STORAGE };
+    SECTION("script executes and writes to stdout") {
+        auto response = mod.executeAction(script_request(TESTING_SCRIPT, TESTING_SCRIPT_SHA265, ""));
+        boost::trim(response.output.std_out);
+        REQUIRE(response.output.std_out == "TESTING");
+        REQUIRE(response.output.std_err == "");
+        REQUIRE(response.output.exitcode == 0);
+    }
+    SECTION("script executes with multiple parameters") {
+        auto response = mod.executeAction(script_request(TESTING_SCRIPT, TESTING_SCRIPT_SHA265, "THREE TEST ARGS"));
+        boost::trim(response.output.std_out);
+        REQUIRE(response.output.std_out == "| THREE | TEST | ARGS");
+        REQUIRE(response.output.std_err == "");
+        REQUIRE(response.output.exitcode == 0);
+    }
+    SECTION("script executes with params with quotes and spaces") {
+        auto response = mod.executeAction(script_request(TESTING_SCRIPT, TESTING_SCRIPT_SHA265, "TWO \\\"TEST ARGS\\\""));
+        boost::trim(response.output.std_out);
+        REQUIRE(response.output.std_out == "| TWO | TEST ARGS");
+        REQUIRE(response.output.std_err == "");
+        REQUIRE(response.output.exitcode == 0);
+    }
+#ifdef _WIN32
+    SECTION("script executes with a filename that has spaces") {
+        auto response = mod.executeAction(script_request("test script.ps1", TESTING_SCRIPT_SHA265, ""));
+        boost::trim(response.output.std_out);
+        REQUIRE(response.output.std_out == "TESTING");
+        REQUIRE(response.output.std_err == "");
+        REQUIRE(response.output.exitcode == 0);
+    }
+#endif
+}
+
+TEST_CASE("Modules::Script correctly reports failures", "[modules]") {
+    Modules::Script mod { PXP_AGENT_BIN_PATH, MASTER_URIS, CA, CRT, KEY, "", 10, 20, MODULE_CACHE_DIR, STORAGE };
+    SECTION("Reports exit code 1 when the script fails") {
+        auto response = mod.executeAction(script_request(TESTING_SCRIPT, TESTING_SCRIPT_SHA265, "FAIL"));
+        boost::trim(response.output.std_err);
+        REQUIRE(response.output.std_out == "");
+        REQUIRE(response.output.std_err.find("FAIL TESTING") != std::string::npos);
+        REQUIRE(response.output.exitcode == 5);
+    }
+
+    // This will produce a failure because the file does not exist yet, so the module
+    // will attempt the download from master URIs that aren't real.
+    SECTION("Reports invalid results on failed file download") {
+        auto response = mod.executeAction(script_request("script_failure.rb", "SCRIPT_FAILING_SHA", "FAIL"));
+        REQUIRE_FALSE(response.action_metadata.get<bool>("results_are_valid"));
+        REQUIRE(response.action_metadata.includes("execution_error"));
+    }
+}
+
+// Present in Boost 1.58. That's currently not required, so reproducing it here since it's simple.
+static std::time_t my_to_time_t(pt::ptime t)
+{
+    return (t - pt::ptime(boost::gregorian::date(1970, 1, 1))).total_seconds();
+}
+
+TEST_CASE("Modules::Script::purge purges old cached files", "[modules]") {
+    const std::string PURGE_CACHE { std::string { PXP_AGENT_ROOT_PATH }
+        + "/lib/tests/resources/purge_test" };
+
+    const std::string OLD_TRANSACTION { "valid_old" };
+    const std::string RECENT_TRANSACTION { "valid_recent" };
+
+    static const auto PURGE_MODULE_CACHE_DIR = std::make_shared<ModuleCacheDir>(PURGE_CACHE, CACHE_TTL);
+
+    // Start with 0 TTL to prevent initial cleanup
+    Modules::Script mod { PXP_AGENT_BIN_PATH, MASTER_URIS, CA, CRT, KEY, "", 10, 20, PURGE_MODULE_CACHE_DIR, STORAGE };
+
+    unsigned int num_purged_results { 0 };
+    auto purgeCallback =
+        [&num_purged_results](const std::string&) -> void { num_purged_results++; };
+
+    SECTION("Purges only the old results based on ttl") {
+        num_purged_results = 0;
+        auto now = pt::second_clock::universal_time();
+        auto recent = now - pt::minutes(50);
+        auto old = now - pt::minutes(61);
+        fs::last_write_time(fs::path(PURGE_CACHE)/OLD_TRANSACTION, my_to_time_t(old));
+        fs::last_write_time(fs::path(PURGE_CACHE)/RECENT_TRANSACTION, my_to_time_t(recent));
+
+        auto results = mod.purge("1h", {}, purgeCallback);
+        REQUIRE(results == 1);
+        REQUIRE(num_purged_results == 1);
+    }
+}

--- a/lib/tests/unit/modules/task_test.cc
+++ b/lib/tests/unit/modules/task_test.cc
@@ -424,7 +424,7 @@ TEST_CASE("Modules::Task::executeAction", "[modules][output]") {
         REQUIRE_FALSE(response.action_metadata.includes("results"));
         REQUIRE_FALSE(response.action_metadata.get<bool>("results_are_valid"));
         REQUIRE(response.action_metadata.includes("execution_error"));
-        REQUIRE(boost::contains(response.action_metadata.get<std::string>("execution_error"), "Cannot download task. No master-uris were provided"));
+        REQUIRE(boost::contains(response.action_metadata.get<std::string>("execution_error"), "Cannot download file. No master-uris were provided"));
     }
 
     SECTION("if a master-uri has a server-side error, then it proceeds to try the next master-uri. if they all fail, it errors on download and removes all temporary files") {


### PR DESCRIPTION
This PR adds a new module to pxp-agent: script. The script module will take a PCP message with script file information and any arguments to send. After receiving the message the pxp-agent will download and execute the script with any provided arguments.