### PR TITLE
(maint) Change lein profile for pcp-broker in acceptance

### DIFF
--- a/acceptance/lib/pxp-agent/test_helper.rb
+++ b/acceptance/lib/pxp-agent/test_helper.rb
@@ -16,7 +16,7 @@ PXP_LOG_DIR_CYGPATH = '/cygdrive/c/ProgramData/PuppetLabs/pxp-agent/var/log'
 PXP_LOG_DIR_POSIX = '/var/log/puppetlabs/pxp-agent'
 
 # Set lein profile based on configuration to access puppet.net internal network or not.
-LEIN_PROFILE = (ENV['GEM_SOURCE'] =~ /puppetlabs.net/) ? 'internal-mirrors' : 'integration'
+LEIN_PROFILE = (ENV['GEM_SOURCE'] =~ /puppetlabs.net/) ? 'internal-integration' : 'integration'
 
 def logdir(host)
   windows?(host)?


### PR DESCRIPTION
Due to FIPS enablement work in Lovejoy, how we handle the bouncycastle
dependency has changed. This necessitated some tweaks to the
pcp-broker development profiles.