### PR TITLE
(PCP-883) Allow powershell task parameters with `type` in the name

### DIFF
--- a/acceptance/files/complex-args.json
+++ b/acceptance/files/complex-args.json
@@ -23,5 +23,6 @@
   "argtimespan": "12:34:56",
   "argguid": "74be6039-e777-45fe-aa56-3d356443e096",
   "argregex": "^http:\\/\\/",
-  "argswitch": true
+  "argswitch": true,
+  "types": "foo"
 }

--- a/acceptance/files/complex-output
+++ b/acceptance/files/complex-output
@@ -45,3 +45,5 @@ hello all
 True
 * ArgTimeSpan (timespan):
 12:34:56
+* types (string):
+foo

--- a/acceptance/files/complex-task.ps1
+++ b/acceptance/files/complex-task.ps1
@@ -46,7 +46,12 @@ param(
 
   [Parameter(Mandatory = $False)]
   [Switch]
-  $ArgSwitch
+  $ArgSwitch,
+
+  # Parameters may have the string `type` in them, but not have the name `type`
+  [Parameter(Mandatory = $False)]
+  [String]
+  $types
 )
 
 function ConvertTo-String

--- a/exe/PowershellShim-Helper.ps1
+++ b/exe/PowershellShim-Helper.ps1
@@ -61,7 +61,7 @@ Function ConvertFrom-Xml {
       return $xml.Objects | ConvertFrom-Xml
     }
     $propbag = @{}
-    foreach ($name in Get-Member -InputObject $xml -MemberType Properties | Where-Object{$_.Name -notmatch "^__|type"} | Select-Object -ExpandProperty name) {
+    foreach ($name in Get-Member -InputObject $xml -MemberType Properties | Where-Object{$_.Name -notmatch "^(__.*|type)$"} | Select-Object -ExpandProperty name) {
       Write-Debug "$Name Type: $($xml.$Name.type)" -Debug:$false
       $propbag."$Name" = Convert-Properties $xml."$name"
     }


### PR DESCRIPTION
Previously, when parsing xml in the `Get-ContentAsJson` implementation a regex used to filter out xml elements with whos `MemberType` `Properties` had a name that was preceeded with `__` or contained the string `type`. Filtering on the string `type` caused task parameters that contain that string to be ignored, preventing users from being able to effectively pass powershell task paramters with the `type` in the name. Unfortunately, with the current implementation powershell parameters with the name `type` will be clobbered by a `Property` called type. However this commit updates the regex to *only* filter out the property that exactly matches `type`. Note that this work allows powershell task parameters with `type` in the name, but not the name `type` and only affects powershell <= 2.