### PR TITLE
(PCP-844) Update the command module to use a shell

### DIFF
--- a/acceptance/tests/pxp_module_bolt_command/run_command.rb
+++ b/acceptance/tests/pxp_module_bolt_command/run_command.rb
@@ -14,7 +14,7 @@ test_name 'run_command task' do
 
   step 'Run a command (`echo`) on agent hosts' do
     agents.each do |agent|
-      cmd = agent.platform =~ /windows/ ? 'cmd /c echo hello' : 'echo hello'
+      cmd = agent.platform =~ /windows/ ? 'write-host hello' : 'echo hello'
       run_successful_command(master, [agent], cmd) do |stdout|
         assert_equal('hello', stdout.chomp)
       end


### PR DESCRIPTION
This commit updates the "run" action in the command pxp-agent module to wrap
all commands to run in a shell. This feature mistakenly assumed that bolt
commands ran with no shell, when that's not the case, thus we need to change
the implementation to wrap everything in a shell.

This commit wraps everything in a shell by creating the command structure with
the shell as the command to execute in leatherman. Then the arguments will
include the actual command passed from the PCP message.

For windows:
Bolt uses WinRM, which defaults to powershell as the shell (and that isn't
believed to be configurable) so we default to powershell.exe

For Posix systems:
We use the posix defined getpwuid (https://linux.die.net/man/3/getpwuid) to
find the default shell for the calling pxp-agent processes user.