### PR TITLE
(PCP-889) Fixing syntax error when more than one pxp-agent process is running

### DIFF
--- a/ext/suse/pxp-agent.init
+++ b/ext/suse/pxp-agent.init
@@ -71,10 +71,15 @@ case "$1" in
         ## force a process start
         if [ -f "${pidfile}" ]; then
             PID=$(cat "$pidfile")
-            if [ "$PID" -eq $(pgrep -f "$exec") ] ; then
-                rc_status -v
-                rc_exit
-            fi
+            procs=$(pgrep -f "$exec")
+            for running_pid in $procs; do
+                if [ "$PID" -eq "$running_pid" ] ; then
+                    rc_status -v
+                    rc_exit
+                else
+                    kill $running_pid
+                fi
+            done
         fi
         mkdir -p $piddir $logdir
         startproc -f -w -p "${pidfile}" "${exec}" ${PXP_AGENT_OPTIONS} && touch "${lockfile}"
@@ -96,11 +101,16 @@ case "$1" in
         ## killproc may succeed or manual intervention is required.
         if [ -f "${pidfile}" ]; then
             PID=$(cat "$pidfile")
-            if [ "$PID" -eq $(pgrep -f "$exec") ] ; then
-                kill -QUIT "${PID}" && rm -f "${lockfile}" "${pidfile}"
-                rc_status -v
-                rc_exit
-            fi
+            procs=$(pgrep -f "$exec")
+            for running_pid in $procs; do
+                if [ "$PID" -eq "$running_pid" ] ; then
+                    kill -QUIT "${PID}" && rm -f "${lockfile}" "${pidfile}"
+                    rc_status -v
+                    rc_exit
+                else
+                    kill $running_pid
+                fi
+            done
         fi
 
         if [ ! $done ]; then
@@ -176,11 +186,16 @@ case "$1" in
         ## checkproc may succeed or manual intervention is required.
         if [ -f "${pidfile}" ]; then
             PID=$(cat "$pidfile")
-            if [ "$PID" -eq $(pgrep -f "$exec") ] ; then
-                rc_reset
-                rc_status -v
-                rc_exit
-            fi
+            procs=$(pgrep -f "$exec")
+            for running_pid in $procs; do
+                if [ "$PID" -eq "$running_pid" ] ; then
+                    rc_reset
+                    rc_status -v
+                    rc_exit
+                else
+                    kill $running_pid
+                fi
+            done
         fi
 
         if [ -f "${pidfile}" ]; then


### PR DESCRIPTION
In the current state, SLES boxes that has more than one PXP agent process running at a time will cause a syntax error on the pxp-agent init script. In the correct manner, and what happens when only one pxp-agent process is running, the bash tests in the script behave like so:

```
[ x -eq y ]
```

However, in the event of more than one process, the tests in the script become this:

```
[ x -eq y z ]
```

which is syntactically incorrect, and causes control of the process through the system to fail due to the bad syntax. What I am proposing is to loop over the results of the same `pgrep` command already being used, matching the PID that is in the PID file, and killing the extraneous one(s). I have tested this on several SLES boxes in my enterprise that were impacted by this, and each of them were able to function correctly with the loops I introduced.

The impact here is that the extra pxp agent processes are causing unnecessarily high CPU usage and wait time on all servers that have more than one process, whatever reason that may be. On top of that, upon attempting to restart the service, stop the service, or even attempt to start the service, the control will fail due to the the syntax error in the init script. This forces Ops teams to escalate to higher support levels as well as an increased influx of automated ticket generation due to the nature of the CPU spikes.

Steps to reproduce:

- Have a SLES box
- Have more than one pxp-agent process running
- Attempt to stop, restart, or start the pxp-agent service with `service pxp-agent <action>`.

My associated Jira ticket is located [here](https://tickets.puppetlabs.com/browse/PCP-889).

Thanks,
Blake Smreker