### PR TITLE
(maint) Add bolt plans for building/rebuild pxp-agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 /acceptance/junit
 /acceptance/.beaker
 /acceptance/sut-files.tgz
+/Boltdir/inventory.yaml

--- a/Boltdir/site-modules/pxp_dev/lib/puppet/functions/pxp_root.rb
+++ b/Boltdir/site-modules/pxp_dev/lib/puppet/functions/pxp_root.rb
@@ -1,0 +1,5 @@
+Puppet::Functions.create_function(:'pxp_root') do
+  def pxp_root
+    File.absolute_path(File.join(__dir__, "..", "..", "..", "..", "..", ".."))
+  end
+end

--- a/Boltdir/site-modules/pxp_dev/lib/puppet/functions/replace_inventory.rb
+++ b/Boltdir/site-modules/pxp_dev/lib/puppet/functions/replace_inventory.rb
@@ -1,0 +1,12 @@
+Puppet::Functions.create_function(:'replace_inventory') do
+  def replace_inventory(target_hash, path_to_inventory)
+    contents = { 'version' => 2,
+                 'targets' => [target_hash] }.to_yaml
+    if File.exists?(path_to_inventory)
+      File.delete(path_to_inventory)
+    end
+    File.open(path_to_inventory,"w") do |f|
+     f.write(contents)
+    end
+  end
+end

--- a/Boltdir/site-modules/pxp_dev/plans/build.pp
+++ b/Boltdir/site-modules/pxp_dev/plans/build.pp
@@ -1,0 +1,39 @@
+plan pxp_dev::build (
+  TargetSpec $target_agents,
+  String $agent_ref,
+  String $target_host_type,
+  Optional[String] $winrm_pass = undef,
+) {
+  $pxp_root = pxp_root()
+  $vanagon_builder_hostname = run_task('pxp_dev::build_deps_with_vanagon', localhost, agent_ref => $agent_ref, os_type => $target_host_type).first().value()['build_host']
+  if $target_host_type =~ /^win/ {
+    $build_host_opts_hash = {'uri' => $vanagon_builder_hostname,
+                             'name' => 'build_host',
+                             'config' => {
+                               'transport' => 'winrm',
+                               'winrm' => {
+                                 'user' => 'Administrator',
+                                 'password' => $winrm_pass,
+                                 'ssh' => false,
+                               }
+                             }
+                           }
+  } else {
+    $build_host_opts_hash = {'uri' => $vanagon_builder_hostname,
+                             'name' => 'build_host',
+                             'config' => {
+                               'transport' => 'ssh',
+                               'ssh' => {
+                                 'host-key-check' => false
+                               }
+                             }
+                           }
+  }
+  $build_host = Target.new($build_host_opts_hash)
+  replace_inventory($build_host_opts_hash, file::join($pxp_root, 'Boltdir', 'inventory.yaml'))
+
+  $build_location = strip(run_command('dirname $(find /var/tmp/ -maxdepth 2 -name cpp-pcp-client)', $build_host).first().value()['stdout'])
+  upload_file($pxp_root, file::join($build_location, 'pxp-agent'), $build_host)
+  run_task('pxp_dev::run_pxp_make', $build_host, run_cmake => true)
+  run_plan('pxp_dev::upload_to_agent',target_agents => $target_agents, target_host_type => $target_agents, winrm_pass => $winrm_pass)
+}

--- a/Boltdir/site-modules/pxp_dev/plans/rebuild.pp
+++ b/Boltdir/site-modules/pxp_dev/plans/rebuild.pp
@@ -1,0 +1,18 @@
+plan pxp_dev::rebuild (
+  TargetSpec $target_agents,
+  String $target_host_type,
+  Optional[Boolean] $run_cmake = false,
+  Optional[String] $winrm_pass = undef,
+) {
+  $pxp_root = pxp_root()
+  $build_host = get_target('build_host')
+  $build_location = strip(run_command('find /var/tmp/ -maxdepth 2 -name pxp-agent', $build_host).first().value()['stdout'])
+  if $target_host_type =~ /^win/ {
+    upload_file($pxp_root, file::join($build_location, 'pxp-agent'), $build_host)
+  } else {
+    $build_hostname = $build_host.host()
+    run_command("rsync ${pxp_root} ${build_hostname}:${build_location}", localhost)
+  }
+  run_task('pxp_dev::run_pxp_make', $build_host, run_cmake => $run_cmake)
+  run_plan('pxp_dev::upload_to_agent', target_agents => $target_agents, target_host_type => $target_agents, winrm_pass => $winrm_pass)
+}

--- a/Boltdir/site-modules/pxp_dev/plans/upload_to_agent.pp
+++ b/Boltdir/site-modules/pxp_dev/plans/upload_to_agent.pp
@@ -1,0 +1,18 @@
+plan pxp_dev::upload_to_agent (
+  TargetSpec $target_agents,
+  String $target_host_type,
+  Optional[String] $winrm_pass = undef,
+) {
+  $status = run_task('service', $target_agents, action => 'status', name => 'pxp-agent')
+  $running_agents = $status.filter |$status_result| {
+    $status_result.value()['enabled'] == 'enabled'
+  }
+  # Stop any running pxp-agents before replacing the executable
+  run_task('service', $running_agents, action => 'stop', name => 'pxp-agent')
+
+  $build_host = get_target('build_host')
+  run_task('pxp_dev::upload_from_builder_to_agent', $build_host, agents => $target_agents)
+
+  # restart any previously stopped agents
+  run_task('service', $running_agents, action => 'start', name => 'pxp-agent')
+}

--- a/Boltdir/site-modules/pxp_dev/tasks/build_deps_with_vanagon.json
+++ b/Boltdir/site-modules/pxp_dev/tasks/build_deps_with_vanagon.json
@@ -1,0 +1,14 @@
+
+{
+  "description": "Build pxp-agent on a new pooler VM",
+  "parameters": {
+    "agent_ref": {
+      "description": "Git reference for the puppet-agent repo that will build the pxp-agent, can be a branch, SHA, or tag",
+      "type": "String"
+    },
+    "os_type": {
+      "description": "The type of operating system to build for, i.e. redhat-7-x86_64 or ubuntu-18.04-amd64",
+      "type": "String"
+    }
+  }
+}

--- a/Boltdir/site-modules/pxp_dev/tasks/build_deps_with_vanagon.rb
+++ b/Boltdir/site-modules/pxp_dev/tasks/build_deps_with_vanagon.rb
@@ -1,0 +1,21 @@
+#!/usr/bin/env ruby
+
+require 'json'
+require 'tmpdir'
+require 'fileutils'
+
+params = JSON.parse(STDIN.read)
+
+workdir = Dir.mktmpdir
+build_host = ''
+Dir.chdir(workdir) do
+  `git clone git@github.com:puppetlabs/puppet-agent.git 1>&2`
+  Dir.chdir('puppet-agent') do
+    `git checkout #{params['agent_ref']} 1>&2`
+    `bundle install 1>&2`
+    `bundle exec build puppet-agent #{params['os_type']} --preserve --only_build=cpp-pcp-client,cpp-hocon 1>&2`
+    build_host = File.read('vanagon_hosts.log').match(/Reserving\s[A-Za-z\-\.]*\s/).to_s.gsub('Reserving', '').strip
+  end
+end
+
+$stdout.puts JSON.generate({'build_host' => build_host})

--- a/Boltdir/site-modules/pxp_dev/tasks/run_pxp_make.json
+++ b/Boltdir/site-modules/pxp_dev/tasks/run_pxp_make.json
@@ -1,0 +1,10 @@
+
+{
+  "description": "re-build pxp-agent on a an existing build host",
+  "parameters": {
+    "run_cmake": {
+      "description": "set to true to run the cmake command before make",
+      "type": "Boolean"
+    }
+  }
+}

--- a/Boltdir/site-modules/pxp_dev/tasks/run_pxp_make.sh
+++ b/Boltdir/site-modules/pxp_dev/tasks/run_pxp_make.sh
@@ -1,0 +1,16 @@
+#/usr/bin/env sh
+
+pushd $(find /var/tmp/ -maxdepth 2 -name pxp-agent) >/dev/null 1>&2
+if [[ $PT_run_cmake == "true" ]]; then
+  export PATH="/opt/puppetlabs/puppet/bin:/opt/pl-build-tools/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin" && \
+  /opt/pl-build-tools/bin/cmake -DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/pl-build-toolchain.cmake \
+                                -DLEATHERMAN_GETTEXT=ON \
+                                -DCMAKE_VERBOSE_MAKEFILE=ON \
+                                -DCMAKE_PREFIX_PATH=/opt/puppetlabs/puppet \
+                                -DCMAKE_INSTALL_RPATH=/opt/puppetlabs/puppet/lib \
+                                -DCMAKE_SYSTEM_PREFIX_PATH=/opt/puppetlabs/puppet \
+                                -DMODULES_INSTALL_PATH=/opt/puppetlabs/pxp-agent/modules \
+                                -DCMAKE_INSTALL_PREFIX=/opt/puppetlabs/puppet
+fi
+make -j8 install
+popd >/dev/null 1>&2

--- a/Boltdir/site-modules/pxp_dev/tasks/upload_from_builder_to_agent.sh
+++ b/Boltdir/site-modules/pxp_dev/tasks/upload_from_builder_to_agent.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+
+for AGENT in $PT_agents
+do
+  scp -o StrictHostKeyChecking=no /opt/puppetlabs/puppet/bin/pxp-agent "$AGENT:/opt/puppetlabs/puppet/bin/pxp-agent"
+  scp -o StrictHostKeyChecking=no -r /opt/puppetlabs/pxp-agent "$AGENT:/opt/puppetlabs/pxp-agent"
+done

--- a/Boltdir/site-modules/pxp_dev/tasks/upload_from_builder_to_agents.json
+++ b/Boltdir/site-modules/pxp_dev/tasks/upload_from_builder_to_agents.json
@@ -1,0 +1,10 @@
+
+{
+  "description": "Build pxp-agent on a new pooler VM",
+  "parameters": {
+    "agents": {
+      "description": "An array of agents to upload the new pxp-agent to",
+      "type": "Array[String]"
+    }
+  }
+}


### PR DESCRIPTION
This commit adds a new Boltdir and two plans for building and rebuilding
pxp-agent. Both plans take a host as input where an agent is installed,
and will update the host's pxp-agent binary (and pxp-agent modules dir)
with changes built using the files currently in the local checkout of
pxp-agent.

The plans to use are:

* pxp_dev::build
* pxp_dev::rebuild