### PR TITLE
(maint) Increase time/attempts for waiting for concurrent puppet runs

### DIFF
--- a/acceptance/tests/pxp-module-puppet/run_puppet_twice.rb
+++ b/acceptance/tests/pxp-module-puppet/run_puppet_twice.rb
@@ -78,7 +78,7 @@ test_name 'Run Puppet while a Puppet Agent run is in-progress, wait for completi
 
       satisfied = false
       pid_counting_attempts = 0
-      MAX_PID_COUNTING_ATTEMPTS = 30
+      MAX_PID_COUNTING_ATTEMPTS = 60
       concurrent_samples_of_1_pid = 0
       REQUIRED_SAMPLES_OF_1_PID = 10
       at_least_two_pids_observed = false


### PR DESCRIPTION
With the addition of https://github.com/puppetlabs/puppet/commit/939ab7ee958e82974f199f84ccb2d2bd1b2c72fc we need to wait a bit longer in the run_puppet_twice test.