### PR TITLE
(maint) Remove unused Apply constructor params

### DIFF
--- a/lib/inc/pxp-agent/modules/apply.hpp
+++ b/lib/inc/pxp-agent/modules/apply.hpp
@@ -8,7 +8,6 @@
 #include <pxp-agent/module_cache_dir.hpp>
 
 #include <leatherman/locale/locale.hpp>
-#include <leatherman/curl/client.hpp>
 
 namespace PXPAgent {
 namespace Modules {
@@ -22,8 +21,6 @@ class Apply : public PXPAgent::Util::BoltModule, public PXPAgent::Util::Purgeabl
               const std::string& key,
               const std::string& crl,
               const std::string& proxy,
-              uint32_t download_connect_timeout,
-              uint32_t download_timeout,
               std::shared_ptr<ModuleCacheDir> module_cache_dir,
               std::shared_ptr<ResultsStorage> storage);
 
@@ -46,10 +43,6 @@ class Apply : public PXPAgent::Util::BoltModule, public PXPAgent::Util::Purgeabl
       std::string key_;
       std::string crl_;
       std::string proxy_;
-
-      uint32_t download_connect_timeout_, download_timeout_;
-
-      leatherman::curl::client client_;
 };
 
 }  // namespace Modules

--- a/lib/src/modules/apply.cc
+++ b/lib/src/modules/apply.cc
@@ -194,8 +194,6 @@ exit exit_code
                  const std::string& key,
                  const std::string& crl,
                  const std::string& proxy,
-                 uint32_t download_connect_timeout,
-                 uint32_t download_timeout,
                  std::shared_ptr<ModuleCacheDir> module_cache_dir,
                  std::shared_ptr<ResultsStorage> storage) :
         BoltModule { exec_prefix, std::move(storage), std::move(module_cache_dir) },
@@ -205,9 +203,7 @@ exit exit_code
         crt_ { crt },
         key_ { key },
         crl_ { crl },
-        proxy_ { proxy },
-        download_connect_timeout_ { download_connect_timeout },
-        download_timeout_ { download_timeout }
+        proxy_ { proxy }
     {
         module_name = "apply";
         actions.push_back(apply_ACTION);

--- a/lib/src/request_processor.cc
+++ b/lib/src/request_processor.cc
@@ -885,8 +885,6 @@ void RequestProcessor::loadInternalModules(const Configuration::Agent& agent_con
         agent_configuration.key,
         agent_configuration.crl,
         agent_configuration.master_proxy,
-        agent_configuration.task_download_connect_timeout_s,
-        agent_configuration.task_download_timeout_s,
         module_cache_dir_,
         storage_ptr_);
     registerModule(apply);

--- a/lib/tests/unit/modules/apply_test.cc
+++ b/lib/tests/unit/modules/apply_test.cc
@@ -64,12 +64,12 @@ static const std::string DATA_TXT {
 
 TEST_CASE("Modules::Apply", "[modules]") {
     SECTION("can successfully instantiate") {
-        REQUIRE_NOTHROW(Modules::Apply(PXP_AGENT_BIN_PATH, MASTER_URIS, CA, CRT, KEY, CRL, "", 10, 20, MODULE_CACHE_DIR, STORAGE));
+        REQUIRE_NOTHROW(Modules::Apply(PXP_AGENT_BIN_PATH, MASTER_URIS, CA, CRT, KEY, CRL, "", MODULE_CACHE_DIR, STORAGE));
     }
 }
 
 TEST_CASE("Modules::Apply::hasAction", "[modules]") {
-    Modules::Apply mod { PXP_AGENT_BIN_PATH, MASTER_URIS, CA, CRT, KEY, CRL, "", 10, 20, MODULE_CACHE_DIR, STORAGE };
+    Modules::Apply mod { PXP_AGENT_BIN_PATH, MASTER_URIS, CA, CRT, KEY, CRL, "", MODULE_CACHE_DIR, STORAGE };
     SECTION("correctly reports false") {
         REQUIRE(!mod.hasAction("foo"));
     }
@@ -95,7 +95,7 @@ TEST_CASE("Modules::Apply::purge purges old cached files", "[modules]") {
     static const auto PURGE_MODULE_CACHE_DIR = std::make_shared<ModuleCacheDir>(PURGE_CACHE, CACHE_TTL);
 
     // Start with 0 TTL to prevent initial cleanup
-    Modules::Apply mod { PXP_AGENT_BIN_PATH, MASTER_URIS, CA, CRT, KEY, CRL, "", 10, 20, PURGE_MODULE_CACHE_DIR, STORAGE };
+    Modules::Apply mod { PXP_AGENT_BIN_PATH, MASTER_URIS, CA, CRT, KEY, CRL, "", PURGE_MODULE_CACHE_DIR, STORAGE };
 
     unsigned int num_purged_results { 0 };
     auto purgeCallback =
@@ -125,7 +125,7 @@ TEST_CASE("Modules::buildCommandObject", "[modules]") {
         std::vector<lth_jc::JsonContainer> debug {};
         const PCPClient::ParsedChunks p_c { envelope, data, debug, 0 };
 
-        Modules::Apply mod { PXP_AGENT_BIN_PATH, MASTER_URIS, CA, CRT, KEY, "", "", 10, 20, MODULE_CACHE_DIR, STORAGE };
+        Modules::Apply mod { PXP_AGENT_BIN_PATH, MASTER_URIS, CA, CRT, KEY, "", "", MODULE_CACHE_DIR, STORAGE };
 
         REQUIRE_THROWS_AS(mod.buildCommandObject(ActionRequest(RequestType::Blocking, p_c)), Configuration::Error);
     }


### PR DESCRIPTION
The `Apply` module does not need to use the curl client to download anything from master/puppetserver. this commit removes the client and it's configuration params.