### PR TITLE
(PCP-897) allow setting of http proxy when running as a service

### DIFF
--- a/ext/debian/pxp-agent.default
+++ b/ext/debian/pxp-agent.default
@@ -2,3 +2,5 @@
 
 # Startup options
 #PXP_AGENT_OPTIONS=--loglevel=debug
+#http_proxy="http://10.0.0.1:3128"
+#https_proxy="http://10.0.0.1:3128"

--- a/ext/debian/pxp-agent.init
+++ b/ext/debian/pxp-agent.init
@@ -28,6 +28,8 @@ reload_pxp_agent() {
 
 start_pxp_agent() {
     mkdir -p $piddir $logdir
+    [ -n "$http_proxy" ] && export http_proxy=$http_proxy
+    [ -n "$https_proxy" ] && export https_proxy=$https_proxy
     start-stop-daemon --start --quiet --pidfile $pidfile --startas $exec -- $PXP_AGENT_OPTIONS
 }
 

--- a/ext/redhat/pxp-agent.init
+++ b/ext/redhat/pxp-agent.init
@@ -37,6 +37,8 @@ fi
 start() {
     echo -n $"Starting PXP agent: "
     mkdir -p $piddir $logdir
+    [ -n "$http_proxy" ] && export http_proxy=$http_proxy
+    [ -n "$https_proxy" ] && export https_proxy=$https_proxy
     daemon $daemonopts $exec ${PXP_AGENT_OPTIONS}
     RETVAL=$?
     echo

--- a/ext/redhat/pxp-agent.sysconfig
+++ b/ext/redhat/pxp-agent.sysconfig
@@ -1,2 +1,4 @@
 # You may specify parameters to the PXP Agent here
 #PXP_AGENT_OPTIONS=--loglevel=debug
+#http_proxy="http://10.0.0.1:3128"
+#https_proxy="http://10.0.0.1:3128"


### PR DESCRIPTION
 Before this commit, when running pxp-agent as a service
 it was not possible to specify a http proxy

 With this change, `http_proxy` and `https_proxy` variables are passed from
 /etc/sysconfig/pxp-agent(RedHat) or /etc/default/pxp-agent(Debian) to `pxp-agent`
 process environment while running as a service