### PR TITLE
(maint) Allow plan for dev build to not use bundler

### DIFF
--- a/Boltdir/site-modules/pxp_dev/plans/build.pp
+++ b/Boltdir/site-modules/pxp_dev/plans/build.pp
@@ -3,9 +3,10 @@ plan pxp_dev::build (
   String $agent_ref,
   String $target_host_type,
   Optional[String] $winrm_pass = undef,
+  Optional[Boolean] $no_bundler = false,
 ) {
   $pxp_root = pxp_root()
-  $vanagon_builder_hostname = run_task('pxp_dev::build_deps_with_vanagon', localhost, agent_ref => $agent_ref, os_type => $target_host_type).first().value()['build_host']
+  $vanagon_builder_hostname = run_task('pxp_dev::build_deps_with_vanagon', localhost, agent_ref => $agent_ref, os_type => $target_host_type, no_bundler => $no_bundler).first().value()['build_host']
   if $target_host_type =~ /^win/ {
     $build_host_opts_hash = {'uri' => $vanagon_builder_hostname,
                              'name' => 'build_host',

--- a/Boltdir/site-modules/pxp_dev/tasks/build_deps_with_vanagon.rb
+++ b/Boltdir/site-modules/pxp_dev/tasks/build_deps_with_vanagon.rb
@@ -12,8 +12,12 @@ Dir.chdir(workdir) do
   `git clone git@github.com:puppetlabs/puppet-agent.git 1>&2`
   Dir.chdir('puppet-agent') do
     `git checkout #{params['agent_ref']} 1>&2`
-    `bundle install 1>&2`
-    `bundle exec build puppet-agent #{params['os_type']} --preserve --only_build=cpp-pcp-client,cpp-hocon 1>&2`
+    if params['no_bundler']
+      `build puppet-agent #{params['os_type']} --preserve --only_build=cpp-pcp-client,cpp-hocon 1>&2`
+    else
+      `bundle install 1>&2`
+      `bundle exec build puppet-agent #{params['os_type']} --preserve --only_build=cpp-pcp-client,cpp-hocon 1>&2`
+    end
     build_host = File.read('vanagon_hosts.log').match(/Reserving\s[A-Za-z\-\.]*\s/).to_s.gsub('Reserving', '').strip
   end
 end


### PR DESCRIPTION
This commit updates the dev build plan to include an optional no_bundler
parameter that will ignore use of bundler when attempting the agent build