### PR TITLE
(maint) Fix tests after nssm name change - 1.9.x

### DIFF
--- a/acceptance/lib/pxp-agent/test_helper.rb
+++ b/acceptance/lib/pxp-agent/test_helper.rb
@@ -433,7 +433,7 @@ def get_process_pids(host, process)
       command = "cmd.exe /C WMIC path win32_process WHERE Name=\\\"Ruby.exe\\\" get CommandLine,ProcessId | "\
         "grep 'puppet agent' | egrep -o '[0-9]+\s*$'"
     else
-      command = "ps -eW | grep '#{process}' | sed 's/^[^0-9]*//g' | cut -d\\  -f1"
+      command = "ps -eW | grep -E '\\\\#{process}\(.exe\)' | sed 's/^[^0-9]*//g' | cut -d\\  -f1"
     end
   else
     command = "ps -ef | grep '#{process}' | grep -v 'grep' | grep -v 'true' | sed 's/^[^0-9]*//g' | cut -d\\  -f1"

--- a/acceptance/tests/validate_file_paths.rb
+++ b/acceptance/tests/validate_file_paths.rb
@@ -42,7 +42,7 @@ def config_options(host)
     logdir = "#{vardir}/log"
     spooldir = "#{vardir}/spool"
     rundir = "#{vardir}/run"
-    nssm =  "#{pupdir}/service/nssm.exe"
+    nssm =  "#{pupdir}/service/nssm-pxp-agent.exe"
 
   else
     bindir = '/opt/puppetlabs/puppet/bin'


### PR DESCRIPTION
https://github.com/puppetlabs/puppet-agent/pull/1912 changed the naming of nssm, causing 2 tests to fail.

Update the expected file path of nssm, and make the get_process_pids grep more strict.