### PR TITLE
(PE-28827) Update max-message-size test with fixes

### DIFF
--- a/acceptance/lib/pxp-agent/test_helper.rb
+++ b/acceptance/lib/pxp-agent/test_helper.rb
@@ -326,7 +326,7 @@ def rpc_request(broker, targets,
     client.send(message)
   end
 
-  rpc_action_expiry = 60 # Seconds for the entire RPC action to be considered failed
+  rpc_action_expiry = 360 # Seconds for the entire RPC action to be considered failed
 
   begin
     Timeout::timeout(rpc_action_expiry) do
@@ -566,7 +566,7 @@ def get_package_manager(host)
       pkg_manager = 'apt-get'
   end
   pkg_manager
-end  
+end
 
 def setup_squid_proxy(host)
   pkg_manager = get_package_manager(host)


### PR DESCRIPTION
This commit updates the max-message-size test and the test utils in the
following ways:

1. The test itself is updated to change execution such that a large file is
created using beaker, rather than generated as part of the command execution.
Then the command that's actually run just echos that file.

2. The test utils have been updated such that the timeout for pcp operations
is 6 minutes instead of 1. We don't expect the command to take all 6 minutes,
but the test was failing because the output takes at least 1 minute to
process.