### PR TITLE
(maint) Update max-message-size calculation

### DIFF
--- a/acceptance/tests/pxp_module_bolt_command/run_command.rb
+++ b/acceptance/tests/pxp_module_bolt_command/run_command.rb
@@ -27,7 +27,7 @@ test_name 'run_command task' do
     end
   end # test step
 
-  step 'Responses that create large output which exceedes max-message-size error' do
+  step 'Responses that create large output which exceeds max-message-size error' do
     suts.each do |agent|
       # This test takes a bunch of resources to process correctly (and
       # not produce false positive failures). Platforms like MacOS, AIX
@@ -37,7 +37,7 @@ test_name 'run_command task' do
         teardown do
           on(agent, 'rm /tmp/test.out')
         end
-        on(agent, '/opt/puppetlabs/puppet/bin/ruby -e "puts \'a\'* 70 * 1012 * 1012" > /tmp/test.out')
+        on(agent, '/opt/puppetlabs/puppet/bin/ruby -e "puts \'a\'* 70 * 1024 * 1024" > /tmp/test.out')
         cmd = 'cat /tmp/test.out'
         run_errored_command(master, [agent], cmd) do |stdout|
           assert_match(/exceeded max-message-size/, stdout)

--- a/lib/src/configuration.cc
+++ b/lib/src/configuration.cc
@@ -749,7 +749,7 @@ void Configuration::defineDefaultValues()
                     "",
                     lth_loc::translate("Maximum size in Bytes of messages to send to pcp-broker"),
                     Types::Int,
-                    64 * 1012 * 1012) } });
+                    64 * 1024 * 1024) } });
 
 #ifndef _WIN32
     // NOTE(ale): we don't daemonize on Windows; we rely NSSM to start

--- a/lib/tests/common/mock_connector.hpp
+++ b/lib/tests/common/mock_connector.hpp
@@ -55,7 +55,7 @@ static Configuration::Agent AGENT_CONFIGURATION { MODULES,
                                                   15,    // ping interval
                                                   30,    // task download connection timeout
                                                   120,   // task download timeout
-                                                  64 * 1012 * 1012 };  // default max-message-size
+                                                  64 * 1024 * 1024 };  // default max-message-size
 
 static const std::string VALID_ENVELOPE_TXT {
     " { \"id\" : \"123456\","


### PR DESCRIPTION
This commit updates the max-message-size to be 64*1024*1024 rather than
64*1012*1012 in order to more accurately calculate the number of bytes
in 64 megabytes.