### PR TITLE
(PCP-902) use Ruby from Puppet bin

### DIFF
--- a/acceptance/lib/pxp-agent/test_helper.rb
+++ b/acceptance/lib/pxp-agent/test_helper.rb
@@ -431,7 +431,7 @@ def get_process_pids(host, process)
       # Need to check ruby's command line string to check it is actually puppet agent
       # because pxp-module-puppet will also appear in ps as Ruby.exe
       command = "cmd.exe /C WMIC path win32_process WHERE Name=\\\"Ruby.exe\\\" get CommandLine,ProcessId | "\
-        "grep 'puppet agent' | egrep -o '[0-9]+\s*$'"
+        "grep 'puppet(\")? agent' | egrep -o '[0-9]+\s*$'"
     else
       command = "ps -eW | grep -E '\\\\#{process}\(.exe\)' | sed 's/^[^0-9]*//g' | cut -d\\  -f1"
     end

--- a/modules/pxp-module-puppet.bat
+++ b/modules/pxp-module-puppet.bat
@@ -3,4 +3,4 @@ SETLOCAL
 
 call "%~dp0..\..\bin\environment.bat" %0 %*
 
-ruby -S -- "%~dp0\pxp-module-puppet" %*
+"%PUPPET_DIR%\bin\ruby.exe" -S -- "%~dp0\pxp-module-puppet" %*


### PR DESCRIPTION
https://github.com/puppetlabs/puppet-agent/pull/1973 removes `INSTALLDIR\puppet\bin`
form PATH on Windows. This commit updates
pxp-module-puppet to use the full path to Ruby

The process will run under something like:
`"C:\Program Files\Puppet Labs\Puppet\puppet\bin\ruby.exe" -S -- "C:\Program Files\Puppet Labs\Puppet\puppet\bin\puppet" agent`

Note: I think we might want to set a `main` branch for this and update the components promotion.