### PR TITLE
(PA-3491) Add newsyslog config for pxp-agent

### DIFF
--- a/ext/osx/pxp-agent.newsyslog.conf
+++ b/ext/osx/pxp-agent.newsyslog.conf
@@ -1,0 +1,2 @@
+# logfilename                               [owner:group] mode count size when flags [/pid_file]                       [sig_num]
+/var/log/puppetlabs/pxp-agent/pxp-agent.log :             640  30    *    $D0  BZ    /var/run/puppetlabs/pxp-agent.pid 31


### PR DESCRIPTION
OS X uses newsyslog to rotate log files. By default it's configured to
run every 30 minutes. Add a configuration file for the pxp-agent log
file, similar to the logrotate one.

The configuration file does the following:
- rotate logs every day
- keep a maximum of 30 files
- send SIGUSR2 to pxp-agent after rotating
- don't write specific headers when rotating (may interfere with
  external log analysis tools)