### PR TITLE
(PCP-850) Add delaycompress to logrotate settings

### DIFF
--- a/ext/pxp-agent.logrotate
+++ b/ext/pxp-agent.logrotate
@@ -3,6 +3,7 @@
     missingok
     rotate 30
     compress
+    delaycompress
     notifempty
     sharedscripts
     postrotate

--- a/ext/systemd/pxp-agent.logrotate
+++ b/ext/systemd/pxp-agent.logrotate
@@ -3,6 +3,7 @@
     missingok
     rotate 30
     compress
+    delaycompress
     notifempty
     sharedscripts
     postrotate


### PR DESCRIPTION
When the logs are rotated, gzip can throw the error
`gzip: stdin: file size changed while zipping`.
This happends if new logs are added to the file when the same file
is gzipped.

Adding delaycompress to logrotate configurations postpones compression
of the previous log file to the next rotation cycle, so that the
compression will not happen to the current log file.