### PR TITLE
(PE-30708) Support `both` as valid task input method

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ install:
   - choco install -y pl-openssl-x64 -Version 1.0.24.1 -source https://www.myget.org/F/puppetlabs
   - choco install -y pl-curl-x64 -Version 7.46.0.1 -source https://www.myget.org/F/puppetlabs
   - choco install -y pl-zlib-x64 -Version 1.2.8.1 -source https://www.myget.org/F/puppetlabs
-  - choco install -y pester --pre
+  - choco install -y pester -Version 4.10.1
 
     # Minimize environment polution; previously we were linking against the wrong OpenSSL DLLs.
     # Include Ruby and Powershell for unit tests.


### PR DESCRIPTION
The default input method is already `both` (when there is no entry for input_method). This commit adds support for explicitly specifying `both` in task metadata.