### PR TITLE
(maint) Merge 1.9.x to master

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ install:
   - choco install -y pl-openssl-x64 -Version 1.0.24.1 -source https://www.myget.org/F/puppetlabs
   - choco install -y pl-curl-x64 -Version 7.46.0.1 -source https://www.myget.org/F/puppetlabs
   - choco install -y pl-zlib-x64 -Version 1.2.8.1 -source https://www.myget.org/F/puppetlabs
-  - choco install -y pester
+  - choco install -y pester -Version 4.10.1
 
     # Minimize environment polution; previously we were linking against the wrong OpenSSL DLLs.
     # Include Ruby and Powershell for unit tests.

--- a/lib/tests/unit/modules/task_test.cc
+++ b/lib/tests/unit/modules/task_test.cc
@@ -292,6 +292,35 @@ TEST_CASE("Modules::Task::executeAction", "[modules][output]") {
 #endif
     }
 
+    SECTION("passes input on both stdin and env when method is both") {
+        auto echo_txt =
+#ifndef _WIN32
+            (DATA_FORMAT % "\"0632\""
+                         % "\"task\""
+                         % "\"run\""
+                         % "{\"task\":\"test::both\", \"input\":{\"message\":\"hello\"}, \"input_method\": \"both\", \"files\" : [{\"sha256\": \"823c013467ce03b12dbe005757a6c842894373e8bcfb0cf879329afb5abcd543\", \"filename\": \"multi\"}]}").str();
+#else
+            (DATA_FORMAT % "\"0632\""
+                         % "\"task\""
+                         % "\"run\""
+                         % "{\"task\":\"test::both\", \"input\":{\"message\":\"hello\"}, \"input_method\": \"both\", \"files\" : [{\"sha256\": \"88a07e5b672aa44a91aa7d63e22c91510af5d4707e12f75e0d5de2dfdbde1dec\", \"filename\": \"multi.bat\"}]}").str();
+#endif
+        PCPClient::ParsedChunks echo_content {
+            lth_jc::JsonContainer(ENVELOPE_TXT),
+            lth_jc::JsonContainer(echo_txt),
+            {},
+            0 };
+        ActionRequest request { RequestType::Blocking, echo_content };
+
+        auto output = e_m.executeAction(request).action_metadata.get<std::string>({ "results", "stdout" });
+        boost::trim(output);
+#ifdef _WIN32
+        REQUIRE(output == "hello\r\n{\"message\":\"hello\",\"_task\":\"test::both\"}");
+#else
+        REQUIRE(output == "hello\n{\"message\":\"hello\",\"_task\":\"test::both\"}");
+#endif
+    }
+
     SECTION("passes input as env variables") {
         auto echo_txt =
 #ifndef _WIN32


### PR DESCRIPTION
* commit '40a666c4a7b5cea133892a3be6f24b51e164f791':
  (maint) Pin back pester version
  (PE-30708) Support `both` as valid task input method
  (packaging) Bump to version '1.9.15' [no-promote]

 * lib/tests/unit/modules/task_test.cc - manually adapted

Conflicts:
 * CMakeLists.txt - keep main version
 * appveyor.yml - pin pester version
 * lib/src/modules/task.cc - manually solved conflicts