### PR TITLE
(PE-30624) Deprecate master_uris, add primary_uris

### DIFF
--- a/lib/inc/pxp-agent/configuration.hpp
+++ b/lib/inc/pxp-agent/configuration.hpp
@@ -134,7 +134,7 @@ class Configuration
     {
         std::string modules_dir;
         std::vector<std::string> broker_ws_uris;
-        std::vector<std::string> master_uris;
+        std::vector<std::string> primary_uris;
         std::string pcp_version;
         std::string ca;
         std::string crt;
@@ -222,9 +222,9 @@ class Configuration
     }
 
     /// Return the list of configured masters.
-    std::vector<std::string> get_master_uris()
+    std::vector<std::string> get_primary_uris()
     {
-        return master_uris_;
+        return primary_uris_;
     }
 
     /// Set the specified value for a given configuration flag.
@@ -283,7 +283,7 @@ class Configuration
     std::vector<std::string> broker_ws_uris_;
 
     // List of masters
-    std::vector<std::string> master_uris_;
+    std::vector<std::string> primary_uris_;
 
     // Path to the logfile
     std::string logfile_;

--- a/lib/inc/pxp-agent/modules/apply.hpp
+++ b/lib/inc/pxp-agent/modules/apply.hpp
@@ -15,7 +15,7 @@ namespace Modules {
 class Apply : public PXPAgent::Util::BoltModule, public PXPAgent::Util::Purgeable {
     public:
         Apply(const boost::filesystem::path& exec_prefix,
-              const std::vector<std::string>& master_uris,
+              const std::vector<std::string>& primary_uris,
               const std::string& ca,
               const std::string& crt,
               const std::string& key,
@@ -37,7 +37,7 @@ class Apply : public PXPAgent::Util::BoltModule, public PXPAgent::Util::Purgeabl
     private:
       boost::filesystem::path exec_prefix_;
 
-      std::vector<std::string> master_uris_;
+      std::vector<std::string> primary_uris_;
       std::string ca_;
       std::string crt_;
       std::string key_;

--- a/lib/inc/pxp-agent/modules/task.hpp
+++ b/lib/inc/pxp-agent/modules/task.hpp
@@ -17,7 +17,7 @@ namespace Modules {
 class Task : public PXPAgent::Util::BoltModule, public PXPAgent::Util::Purgeable {
   public:
     Task(const boost::filesystem::path& exec_prefix,
-         const std::vector<std::string>& master_uris,
+         const std::vector<std::string>& primary_uris,
          const std::string& ca,
          const std::string& crt,
          const std::string& key,
@@ -42,7 +42,7 @@ class Task : public PXPAgent::Util::BoltModule, public PXPAgent::Util::Purgeable
   private:
     boost::filesystem::path exec_prefix_;
 
-    std::vector<std::string> master_uris_;
+    std::vector<std::string> primary_uris_;
 
     uint32_t task_download_connect_timeout_, task_download_timeout_;
 

--- a/lib/src/modules/apply.cc
+++ b/lib/src/modules/apply.cc
@@ -75,7 +75,7 @@ cli_base.concat([
 ])
 # There will always be at least a single master URI
 # TODO: make sure comma separated is what --server_list expects
-server_list = args['master_uris'].map { |uri| URI.parse(uri).host }.join(',')
+server_list = args['primary_uris'].map { |uri| URI.parse(uri).host }.join(',')
 
 # These settings are required for communication with puppetserver. This is primarily for
 # pluginsync but it is also required if a catalog requires files from modules served by 
@@ -187,7 +187,7 @@ exit exit_code
 )" };
 
     Apply::Apply(const fs::path& exec_prefix,
-                 const std::vector<std::string>& master_uris,
+                 const std::vector<std::string>& primary_uris,
                  const std::string& ca,
                  const std::string& crt,
                  const std::string& key,
@@ -197,7 +197,7 @@ exit exit_code
                  std::shared_ptr<ResultsStorage> storage) :
         BoltModule { exec_prefix, std::move(storage), std::move(module_cache_dir) },
         Purgeable { module_cache_dir_->purge_ttl_ },
-        master_uris_ { master_uris },
+        primary_uris_ { primary_uris },
         ca_ { ca },
         crt_ { crt },
         key_ { key },
@@ -265,7 +265,7 @@ exit exit_code
 
         const auto plugin_cache = module_cache_dir_->createCacheDir(plugin_cache_name);
         params.set<std::string>("plugin_cache", plugin_cache.string());
-        params.set<std::vector<std::string>>("master_uris", master_uris_);
+        params.set<std::vector<std::string>>("primary_uris", primary_uris_);
         Util::CommandObject cmd {
             "",  // Executable will be detremined by findExecutableAndArguments
             {},  // No args for invoking shim

--- a/lib/src/modules/task.cc
+++ b/lib/src/modules/task.cc
@@ -133,7 +133,7 @@ static const std::string TASK_RUN_ACTION_INPUT_SCHEMA { R"(
 )" };
 
 Task::Task(const fs::path& exec_prefix,
-           const std::vector<std::string>& master_uris,
+           const std::vector<std::string>& primary_uris,
            const std::string& ca,
            const std::string& crt,
            const std::string& key,
@@ -146,7 +146,7 @@ Task::Task(const fs::path& exec_prefix,
     BoltModule { exec_prefix, std::move(storage), std::move(module_cache_dir) },
     Purgeable { module_cache_dir_->purge_ttl_ },
     exec_prefix_ { exec_prefix },
-    master_uris_ { master_uris },
+    primary_uris_ { primary_uris },
     task_download_connect_timeout_ { task_download_connect_timeout },
     task_download_timeout_ { task_download_timeout },
 #ifdef _WIN32
@@ -257,7 +257,7 @@ fs::path Task::downloadMultiFile(std::vector<lth_jc::JsonContainer> const& files
         auto file_object = selectLibFile(files, file_name);
 
         // get file from cache, download if necessary
-        auto lib_file = module_cache_dir_->getCachedFile(master_uris_,
+        auto lib_file = module_cache_dir_->getCachedFile(primary_uris_,
                                                          task_download_connect_timeout_,
                                                          task_download_timeout_,
                                                          client_,
@@ -375,7 +375,7 @@ Util::CommandObject Task::buildCommandObject(const ActionRequest& request)
 
     auto files = task_execution_params.get<std::vector<lth_jc::JsonContainer>>("files");
     auto file = selectTaskFile(files, implementation);
-    auto task_file = module_cache_dir_->getCachedFile(master_uris_,
+    auto task_file = module_cache_dir_->getCachedFile(primary_uris_,
                                                       task_download_connect_timeout_,
                                                       task_download_timeout_,
                                                       client_,

--- a/lib/src/request_processor.cc
+++ b/lib/src/request_processor.cc
@@ -877,7 +877,9 @@ void RequestProcessor::loadInternalModules(const Configuration::Agent& agent_con
     registerModule(command);
     auto task = std::make_shared<Modules::Task>(
         Configuration::Instance().getExecPrefix(),
-        agent_configuration.master_uris,
+        agent_configuration.task_cache_dir,
+        agent_configuration.task_cache_dir_purge_ttl,
+        agent_configuration.primary_uris,
         agent_configuration.ca,
         agent_configuration.crt,
         agent_configuration.key,

--- a/lib/src/request_processor.cc
+++ b/lib/src/request_processor.cc
@@ -877,8 +877,6 @@ void RequestProcessor::loadInternalModules(const Configuration::Agent& agent_con
     registerModule(command);
     auto task = std::make_shared<Modules::Task>(
         Configuration::Instance().getExecPrefix(),
-        agent_configuration.task_cache_dir,
-        agent_configuration.task_cache_dir_purge_ttl,
         agent_configuration.primary_uris,
         agent_configuration.ca,
         agent_configuration.crt,
@@ -892,7 +890,7 @@ void RequestProcessor::loadInternalModules(const Configuration::Agent& agent_con
     registerModule(task);
     registerPurgeable(task);
     auto dl_file = std::make_shared<Modules::File>(
-        agent_configuration.master_uris,
+        agent_configuration.primary_uris,
         agent_configuration.ca,
         agent_configuration.crt,
         agent_configuration.key,
@@ -906,7 +904,7 @@ void RequestProcessor::loadInternalModules(const Configuration::Agent& agent_con
     registerPurgeable(dl_file);
     auto script = std::make_shared<Modules::Script>(
         Configuration::Instance().getExecPrefix(),
-        agent_configuration.master_uris,
+        agent_configuration.primary_uris,
         agent_configuration.ca,
         agent_configuration.crt,
         agent_configuration.key,
@@ -920,7 +918,7 @@ void RequestProcessor::loadInternalModules(const Configuration::Agent& agent_con
     registerPurgeable(script);
     auto apply = std::make_shared<Modules::Apply>(
         Configuration::Instance().getExecPrefix(),
-        agent_configuration.master_uris,
+        agent_configuration.primary_uris,
         agent_configuration.ca,
         agent_configuration.crt,
         agent_configuration.key,

--- a/lib/tests/resources/config/bad-master.conf
+++ b/lib/tests/resources/config/bad-master.conf
@@ -1,1 +1,1 @@
-master-uris: ["http://test_master"]
+primary-uris: ["http://test_master"]

--- a/lib/tests/resources/config/multi-broker-both-uris.conf
+++ b/lib/tests/resources/config/multi-broker-both-uris.conf
@@ -1,0 +1,3 @@
+broker-ws-uris: ["wss://test_pcp_broker", "wss://alt_pcp_broker"]
+primary-uris: ["test_master:8140", "https://alt_master_one", "https://alt_master_two"]
+master-uris: ["test_master:8140", "https://alt_master_one"]

--- a/lib/tests/resources/config/multi-broker-master-uris.conf
+++ b/lib/tests/resources/config/multi-broker-master-uris.conf
@@ -1,2 +1,2 @@
 broker-ws-uris: ["wss://test_pcp_broker", "wss://alt_pcp_broker"]
-primary-uris: ["test_master:8140", "https://alt_master"]
+master-uris: ["test_master:8140", "https://alt_master"]


### PR DESCRIPTION
This commit updates pxp-agent as part of the work to deprecate the
`master_uris` parameter. As of this commit, using `master_uris` should
still work, but using the new `primary_uris` should also now work.
pxp-agent will now look for both of those config values when setting
that param.