### PR TITLE
(PE-31415) Set apply ruby shim environment to passed-in environment

### DIFF
--- a/lib/src/modules/apply.cc
+++ b/lib/src/modules/apply.cc
@@ -113,6 +113,7 @@ begin
   Puppet.initialize_settings(cli_base + cli_settings_pluginsync)
 
   remote_env_for_plugins = Puppet::Node::Environment.remote(args['environment'])
+  Puppet[:environment] = remote_env_for_plugins.name.to_s
   downloader = Puppet::Configurer::Downloader.new(
     "plugin",
     Puppet[:plugindest],


### PR DESCRIPTION
This ensures that spurious messages of the form 'Local environment..
doesn't match...' are not printed when the apply ruby shim is executed
and the passed-in environment is different from production.

Signed-off-by: Enis Inan <enis.inan@puppet.com>