### PR TITLE
(PE-31871) Extract apply shim to a file

### DIFF
--- a/exe/CMakeLists.txt
+++ b/exe/CMakeLists.txt
@@ -9,6 +9,9 @@ add_executable(pxp-agent main.cc)
 target_link_libraries(pxp-agent libpxp-agent)
 install(TARGETS pxp-agent DESTINATION bin)
 
+install(FILES apply_ruby_shim.rb DESTINATION bin
+    PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+
 set(EXECUTION_WRAPPER_LIBS ${Boost_LIBRARIES} ${LEATHERMAN_LIBRARIES})
 if (CMAKE_SYSTEM_NAME MATCHES "AIX")
     find_package(Threads)

--- a/exe/apply_ruby_shim.rb
+++ b/exe/apply_ruby_shim.rb
@@ -1,0 +1,148 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'json'
+require 'puppet'
+require 'puppet/configurer'
+require 'securerandom'
+require 'tempfile'
+require 'uri'
+
+## TODO: Option to read from a file is for debugging. Only read from stdin in production.
+args = JSON.parse(ARGV[0] ? File.read(ARGV[0]) : STDIN.read)
+
+# Create temporary directories for all core Puppet settings so we don't clobber
+# existing state or read from puppet.conf. Also create a temporary modulepath.
+# Additionally include rundir, which gets its own initialization.
+puppet_root = Dir.mktmpdir
+moduledir = File.join(puppet_root, 'modules')
+Dir.mkdir(moduledir)
+plugin_cache = args['plugin_cache']
+plugin_dest = File.join(plugin_cache, 'plugins')
+pluginfact_dest = File.join(plugin_cache, 'pluginfacts')
+# Use isolated directories in puppet_root
+setting_keys = Puppet::Settings::REQUIRED_APP_SETTINGS.append(:rundir)
+cli_base = (setting_keys).flat_map do |setting|
+  ["--#{setting}", File.join(puppet_root, setting.to_s.chomp('dir'))]
+end
+cli_base.concat([
+  '--modulepath',
+  moduledir,
+  '--plugindest',
+  plugin_dest,
+  '--pluginfactdest',
+  pluginfact_dest
+])
+# There will always be at least a single master URI
+# TODO: make sure comma separated is what --server_list expects
+server_list = args['primary_uris'].map { |uri| URI.parse(uri).host }.join(',')
+
+# These settings are required for communication with puppetserver. This is primarily for
+# pluginsync but it is also required if a catalog requires files from modules served by 
+# puppetserver (Puppet[:default_file_terminus] = rest by default)
+cli_settings_pluginsync = [
+  '--localcacert',
+  args['ca'],
+  '--hostcert',
+  args['crt'],
+  '--hostprivkey',
+  args['key'],
+  '--hostcrl',
+  args['crl'],
+  '--server_list',
+  server_list
+]
+
+# Break apart proxy and extract individual settings
+proxy_flags = {
+  user: '--http_proxy_user',
+  password: '--http_proxy_password',
+  port: '--http_proxy_port',
+  host: '--http_proxy_host'
+}
+# Proxy will always be a string (even if its empty)
+parsed_proxy = URI.parse(args['proxy'])
+proxy_flags.each do |uri_method, setting_flag|
+  val = parsed_proxy.send(uri_method)
+  cli_settings_pluginsync << setting_flag << val unless val.nil?
+end
+
+exit_code = 0
+begin
+
+  Puppet.initialize_settings(cli_base + cli_settings_pluginsync)
+
+  remote_env_for_plugins = Puppet::Node::Environment.remote(args['environment'])
+  Puppet[:environment] = remote_env_for_plugins.name.to_s
+  downloader = Puppet::Configurer::Downloader.new(
+    "plugin",
+    Puppet[:plugindest],
+    Puppet[:pluginsource],
+    Puppet[:pluginsignore],
+    remote_env_for_plugins
+  )
+  downloader.evaluate
+
+  source_permissions = Puppet::Util::Platform.windows? ? :ignore : :use
+  plugin_fact_downloader = Puppet::Configurer::Downloader.new(
+    "pluginfacts",
+    Puppet[:pluginfactdest],
+    Puppet[:pluginfactsource],
+    Puppet[:pluginsignore],
+    remote_env_for_plugins,
+    source_permissions
+  )
+  plugin_fact_downloader.evaluate
+
+  # Append the newe paths to the load path (copying them over to the new vardir takes time and seems unneeded)
+  $LOAD_PATH << plugin_dest << pluginfact_dest
+
+  # Avoid extraneous output
+  Puppet[:report] = false
+
+  # apply_settings will always be a hash (even if it empty) who's keys are puppet settings
+  # For example: `noop` or `show_diff`. (only applies to apply action)
+  args['apply_options'].each { |setting, value| Puppet[setting.to_sym] = value } if args['action'] == 'apply'
+
+  # This happens implicitly when running the Configurer, but we make it explicit here. It creates the
+  # directories we configured earlier.
+  Puppet.settings.use(:main)
+
+  # Ensure custom facts are available for provider suitability tests
+  facts = Puppet::Node::Facts.indirection.find(SecureRandom.uuid, environment: remote_env_for_plugins)
+
+  if args['action'] == 'apply'
+
+    report = Puppet::Transaction::Report.new
+
+    overrides = { current_environment: remote_env_for_plugins,
+                  loaders: Puppet::Pops::Loaders.new(remote_env_for_plugins) }
+
+    Puppet.override(overrides) do
+      catalog = Puppet::Resource::Catalog.from_data_hash(args['catalog'])
+      catalog.environment = remote_env_for_plugins.name.to_s
+      catalog.environment_instance = remote_env_for_plugins
+      Puppet::Pops::Evaluator::DeferredResolver.resolve_and_replace(facts, catalog)
+
+      catalog = catalog.to_ral
+
+      configurer = Puppet::Configurer.new
+      configurer.run(catalog: catalog, report: report, pluginsync: false)
+    end
+
+    puts JSON.pretty_generate(report.to_data_hash)
+    exit_code = report.exit_status != 1
+  else
+    facts.name = facts.values['clientcert']
+    puts facts.values.to_json
+  end
+ensure
+  begin
+    FileUtils.remove_dir(puppet_root)
+  rescue Errno::ENOTEMPTY => e
+    STDERR.puts("Could not cleanup temporary directory: #{e}")
+  end
+end
+
+exit exit_code

--- a/lib/inc/pxp-agent/modules/apply.hpp
+++ b/lib/inc/pxp-agent/modules/apply.hpp
@@ -35,8 +35,6 @@ class Apply : public PXPAgent::Util::BoltModule, public PXPAgent::Util::Purgeabl
             std::function<void(const std::string& dir_path)> purge_callback = nullptr) override;
 
     private:
-      boost::filesystem::path exec_prefix_;
-
       std::vector<std::string> primary_uris_;
       std::string ca_;
       std::string crt_;

--- a/lib/inc/pxp-agent/modules/file.hpp
+++ b/lib/inc/pxp-agent/modules/file.hpp
@@ -39,8 +39,6 @@ namespace Modules {
           std::function<void(const std::string& dir_path)> purge_callback = nullptr) override;
 
     private:
-      boost::filesystem::path exec_prefix_;
-
       std::vector<std::string> master_uris_;
 
       uint32_t file_download_connect_timeout_, file_download_timeout_;

--- a/lib/inc/pxp-agent/modules/script.hpp
+++ b/lib/inc/pxp-agent/modules/script.hpp
@@ -38,8 +38,6 @@ class Script : public PXPAgent::Util::BoltModule, public PXPAgent::Util::Purgeab
             std::function<void(const std::string& dir_path)> purge_callback = nullptr) override;
 
     private:
-      boost::filesystem::path exec_prefix_;
-
       std::vector<std::string> master_uris_;
 
       uint32_t download_connect_timeout_, download_timeout_;

--- a/lib/inc/pxp-agent/modules/task.hpp
+++ b/lib/inc/pxp-agent/modules/task.hpp
@@ -40,8 +40,6 @@ class Task : public PXPAgent::Util::BoltModule, public PXPAgent::Util::Purgeable
     std::set<std::string> const& features() const;
 
   private:
-    boost::filesystem::path exec_prefix_;
-
     std::vector<std::string> primary_uris_;
 
     uint32_t task_download_connect_timeout_, task_download_timeout_;

--- a/lib/src/modules/apply.cc
+++ b/lib/src/modules/apply.cc
@@ -34,159 +34,6 @@ namespace Modules {
 
     static const std::string prep_ACTION { "prep" };
 
-    // TODO: Actually manage this file in packaging (or perhaps fetch it from puppetserver).
-    // For now just copy it to the cache dir each time unless there is already a copy
-    static const std::string APPLY_RUBY_SHIM {
-R"(#! /opt/puppetlabs/puppet/bin/ruby
-# frozen_string_literal: true
-
-require 'fileutils'
-require 'json'
-require 'puppet'
-require 'puppet/configurer'
-require 'securerandom'
-require 'tempfile'
-require 'uri'
-
-## TODO: Option to read from a file is for debugging. Only read from stdin in production.
-args = JSON.parse(ARGV[0] ? File.read(ARGV[0]) : STDIN.read)
-
-# Create temporary directories for all core Puppet settings so we don't clobber
-# existing state or read from puppet.conf. Also create a temporary modulepath.
-# Additionally include rundir, which gets its own initialization.
-puppet_root = Dir.mktmpdir
-moduledir = File.join(puppet_root, 'modules')
-Dir.mkdir(moduledir)
-plugin_cache = args['plugin_cache']
-plugin_dest = File.join(plugin_cache, 'plugins')
-pluginfact_dest = File.join(plugin_cache, 'pluginfacts')
-# Use isolated directories in puppet_root
-setting_keys = Puppet::Settings::REQUIRED_APP_SETTINGS.append(:rundir)
-cli_base = (setting_keys).flat_map do |setting|
-  ["--#{setting}", File.join(puppet_root, setting.to_s.chomp('dir'))]
-end
-cli_base.concat([
-  '--modulepath',
-  moduledir,
-  '--plugindest',
-  plugin_dest,
-  '--pluginfactdest',
-  pluginfact_dest
-])
-# There will always be at least a single master URI
-# TODO: make sure comma separated is what --server_list expects
-server_list = args['primary_uris'].map { |uri| URI.parse(uri).host }.join(',')
-
-# These settings are required for communication with puppetserver. This is primarily for
-# pluginsync but it is also required if a catalog requires files from modules served by 
-# puppetserver (Puppet[:default_file_terminus] = rest by default)
-cli_settings_pluginsync = [
-  '--localcacert',
-  args['ca'],
-  '--hostcert',
-  args['crt'],
-  '--hostprivkey',
-  args['key'],
-  '--hostcrl',
-  args['crl'],
-  '--server_list',
-  server_list
-]
-
-# Break apart proxy and extract individual settings
-proxy_flags = {
-  user: '--http_proxy_user',
-  password: '--http_proxy_password',
-  port: '--http_proxy_port',
-  host: '--http_proxy_host'
-}
-# Proxy will always be a string (even if its empty)
-parsed_proxy = URI.parse(args['proxy'])
-proxy_flags.each do |uri_method, setting_flag|
-  val = parsed_proxy.send(uri_method)
-  cli_settings_pluginsync << setting_flag << val unless val.nil?
-end
-
-exit_code = 0
-begin
-
-  Puppet.initialize_settings(cli_base + cli_settings_pluginsync)
-
-  remote_env_for_plugins = Puppet::Node::Environment.remote(args['environment'])
-  Puppet[:environment] = remote_env_for_plugins.name.to_s
-  downloader = Puppet::Configurer::Downloader.new(
-    "plugin",
-    Puppet[:plugindest],
-    Puppet[:pluginsource],
-    Puppet[:pluginsignore],
-    remote_env_for_plugins
-  )
-  downloader.evaluate
-
-  source_permissions = Puppet::Util::Platform.windows? ? :ignore : :use
-  plugin_fact_downloader = Puppet::Configurer::Downloader.new(
-    "pluginfacts",
-    Puppet[:pluginfactdest],
-    Puppet[:pluginfactsource],
-    Puppet[:pluginsignore],
-    remote_env_for_plugins,
-    source_permissions
-  )
-  plugin_fact_downloader.evaluate
-
-  # Append the newe paths to the load path (copying them over to the new vardir takes time and seems unneeded)
-  $LOAD_PATH << plugin_dest << pluginfact_dest
-
-  # Avoid extraneous output
-  Puppet[:report] = false
-
-  # apply_settings will always be a hash (even if it empty) who's keys are puppet settings
-  # For example: `noop` or `show_diff`. (only applies to apply action)
-  args['apply_options'].each { |setting, value| Puppet[setting.to_sym] = value } if args['action'] == 'apply'
-
-  # This happens implicitly when running the Configurer, but we make it explicit here. It creates the
-  # directories we configured earlier.
-  Puppet.settings.use(:main)
-
-  # Ensure custom facts are available for provider suitability tests
-  facts = Puppet::Node::Facts.indirection.find(SecureRandom.uuid, environment: remote_env_for_plugins)
-
-  if args['action'] == 'apply'
-
-    report = Puppet::Transaction::Report.new
-
-    overrides = { current_environment: remote_env_for_plugins,
-                  loaders: Puppet::Pops::Loaders.new(remote_env_for_plugins) }
-
-    Puppet.override(overrides) do
-      catalog = Puppet::Resource::Catalog.from_data_hash(args['catalog'])
-      catalog.environment = remote_env_for_plugins.name.to_s
-      catalog.environment_instance = remote_env_for_plugins
-      Puppet::Pops::Evaluator::DeferredResolver.resolve_and_replace(facts, catalog)
-
-      catalog = catalog.to_ral
-
-      configurer = Puppet::Configurer.new
-      configurer.run(catalog: catalog, report: report, pluginsync: false)
-    end
-
-    puts JSON.pretty_generate(report.to_data_hash)
-    exit_code = report.exit_status != 1
-  else
-    facts.name = facts.values['clientcert']
-    puts facts.values.to_json
-  end
-ensure
-  begin
-    FileUtils.remove_dir(puppet_root)
-  rescue Errno::ENOTEMPTY => e
-    STDERR.puts("Could not cleanup temporary directory: #{e}")
-  end
-end
-
-exit exit_code
-)" };
-
     Apply::Apply(const fs::path& exec_prefix,
                  const std::vector<std::string>& primary_uris,
                  const std::string& ca,
@@ -243,17 +90,10 @@ exit exit_code
 
         const fs::path& results_dir { request.resultsDir() };
 
-        const std::string ruby_shim_cache_dir = "apply_ruby_shim";
-        const fs::path& cache_dir = module_cache_dir_->createCacheDir(ruby_shim_cache_dir);
-
         std::string plugin_cache_name;
 
         const std::string ruby_shim_script_name = "apply_ruby_shim.rb";
-        auto apply_ruby_shim_path = cache_dir / ruby_shim_script_name;
-
-        if (!fs::exists(apply_ruby_shim_path)) {
-          lth_file::atomic_write_to_file(APPLY_RUBY_SHIM, apply_ruby_shim_path.string(), NIX_DOWNLOADED_FILE_PERMS, std::ios::binary);
-        }
+        auto apply_ruby_shim_path = exec_prefix_ / ruby_shim_script_name;
 
         if (action == "apply") {
             plugin_cache_name = params.get<std::string>({"catalog", "environment"});

--- a/lib/src/modules/task.cc
+++ b/lib/src/modules/task.cc
@@ -145,7 +145,6 @@ Task::Task(const fs::path& exec_prefix,
            std::shared_ptr<ResultsStorage> storage) :
     BoltModule { exec_prefix, std::move(storage), std::move(module_cache_dir) },
     Purgeable { module_cache_dir_->purge_ttl_ },
-    exec_prefix_ { exec_prefix },
     primary_uris_ { primary_uris },
     task_download_connect_timeout_ { task_download_connect_timeout },
     task_download_timeout_ { task_download_timeout },


### PR DESCRIPTION
Previously, this shim existed only as a hardcoded Ruby string in a C++ 
source file. That file would be written when needed and purged after a 
period of disuse. But changes to the content weren't necessarily picked up,
as it would only be rewritten after being purged for inactivity. That led
to a problem where pxp-agent installations which had been upgraded would
fail to run apply/apply_prep, because they had an old copy of the shim. The
old version expected to receive a master_uris argument but pxp-agent had
been updated to pass primary_uris instead.

We now manage this file as a regular file and include it during the 
build/packaging process so that it will be automatically upgraded by the 
package manager.