### PR TITLE
(PE-31216) Disallow null bytes in task output

### DIFF
--- a/lib/src/util/bolt_module.cc
+++ b/lib/src/util/bolt_module.cc
@@ -74,11 +74,8 @@ void BoltModule::processOutputAndUpdateMetadata(PXPAgent::ActionResponse &respon
                   response.prettyRequestLabel(), output);
         std::string execution_error {
                 lth_loc::format("The task executed for the {1} returned invalid "
-                                "UTF-8 on stdout - stderr:{2}",
-                                response.prettyRequestLabel(),
-                                (response.output.std_err.empty()
-                                 ? lth_loc::translate(" (empty)")
-                                 : "\n" + response.output.std_err)) };
+                                "UTF-8 on stdout",
+                                response.prettyRequestLabel()) };
         response.setBadResultsAndEnd(execution_error);
     }
 }

--- a/lib/src/util/utf8.cc
+++ b/lib/src/util/utf8.cc
@@ -4,6 +4,7 @@
 #include <rapidjson/stream.h>
 #endif
 
+#include <algorithm>
 #include <string>
 
 namespace PXPAgent {
@@ -18,7 +19,15 @@ namespace Util {
                 return false;
             }
         }
-        return true;
+
+        // rapidjson::UTF8<char>::Validate accepts null bytes as valid UTF-8.
+        // They technically are valid since they're the null character. But
+        // null characters aren't valid in a string, so we want to disallow
+        // them regardless.
+        bool has_null = std::any_of(s.begin(), s.end(), [](char c) {
+                            return c == 0;
+                        });
+        return !has_null;
     }
 }  // namespace Util
 }  // namespace PXPAgent

--- a/lib/tests/resources/tasks-cache/b26e34bc50c88ca5ee2bfcbcaff5c23b0124db9479e66390539f2715b675b7e7/null_byte
+++ b/lib/tests/resources/tasks-cache/b26e34bc50c88ca5ee2bfcbcaff5c23b0124db9479e66390539f2715b675b7e7/null_byte
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+printf "foo\0bar"


### PR DESCRIPTION
Previously, pxp-agent would accept task output containing null bytes and
would return it to orchestrator. This caused a database error as null
bytes cannot be written to postgres. These null bytes are also not
allowed by the task spec, so this behavior was incorrect.

The root issue is that the isValidUTF8 helper, which uses rapidjson to
validate each character, considers null bytes to be valid. Technically
this isn't wrong, as the null character is a UTF-8 character, but it's
not a valid character in a null-terminated string.

We now supplement the regular validity check with an additional check
that the string doesn't contain any null bytes.

This also fixes a bug where we could return a result containing invalid
UTF-8 in the case where both stdout and stderr had invalid UTF-8 output.
We would validate that stdout had invalid UTF-8 and would generate an
error including the value from stderr without validating it as UTF-8. We
now simply omit the stderr output as it's unlikely to be useful in this
case.