### PR TITLE
(PCP-890) Update Solaris and OSX service scripts to use wrapper script

### DIFF
--- a/ext/osx/pxp-agent.plist
+++ b/ext/osx/pxp-agent.plist
@@ -13,7 +13,7 @@
         <true/>
         <key>ProgramArguments</key>
         <array>
-                <string>/opt/puppetlabs/puppet/bin/pxp-agent</string>
+                <string>/opt/puppetlabs/bin/pxp-agent</string>
                 <string>--foreground</string>
         </array>
         <key>RunAtLoad</key>

--- a/ext/solaris/smf/pxp-agent.xml
+++ b/ext/solaris/smf/pxp-agent.xml
@@ -19,7 +19,7 @@
       <service_fmri value="svc:/system/filesystem/local"/>
     </dependency>
 
-    <exec_method type="method" name="start" exec="/opt/puppetlabs/puppet/bin/pxp-agent" timeout_seconds="60"/>
+    <exec_method type="method" name="start" exec="/opt/puppetlabs/bin/pxp-agent" timeout_seconds="60"/>
 
     <exec_method type="method" name="stop" exec=":kill" timeout_seconds="60"/>
 


### PR DESCRIPTION
This was something we forgot to do as part of PA-437. Note that we only
do this for Solaris and OSX to be consistent with how things are
currently done for Puppet.

Signed-off-by: Enis Inan <enis.inan@puppet.com>