### PR TITLE
(PCP-906) Configure WebSocket++ loggers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ script:
 env:
   global:
     - LEATHERMAN_VERSION=1.11.0
-    - CPP_PCP_CLIENT_VERSION=1.7.1
+    - CPP_PCP_CLIENT_VERSION=1.7.6
     - CPP_HOCON_VERSION=0.2.0
   matrix:
     - TARGET=cpplint

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 environment:
   LEATHERMAN_VERSION: 1.11.0
-  CPP_PCP_CLIENT_VERSION: 1.7.1
+  CPP_PCP_CLIENT_VERSION: 1.7.6
   CPPHOCON_VERSION: 0.2.0
 install:
   - choco install -y mingw-w64 -Version 5.2.0 -source https://www.myget.org/F/puppetlabs

--- a/lib/inc/pxp-agent/configuration.hpp
+++ b/lib/inc/pxp-agent/configuration.hpp
@@ -16,6 +16,13 @@
 #include <stdexcept>
 #include <cstdint>
 
+// Forward declaration for leatherman::logging::log_level
+namespace leatherman {
+  namespace logging {
+    enum class log_level;
+  }
+}
+
 namespace PXPAgent {
 
 //
@@ -157,6 +164,7 @@ class Configuration
         uint32_t task_download_connect_timeout_s;
         uint32_t task_download_timeout_s;
         uint32_t max_message_size;
+        leatherman::logging::log_level loglevel;
     };
 
     /// Reset the HorseWhisperer singleton.
@@ -225,6 +233,12 @@ class Configuration
     std::vector<std::string> get_primary_uris()
     {
         return primary_uris_;
+    }
+
+    /// Return the stream abstraction object for the logfile
+    boost::nowide::ofstream* get_logfile_fstream()
+    {
+        return &logfile_fstream_;
     }
 
     /// Set the specified value for a given configuration flag.

--- a/lib/inc/pxp-agent/pxp_connector_v1.hpp
+++ b/lib/inc/pxp-agent/pxp_connector_v1.hpp
@@ -13,7 +13,7 @@ namespace PXPAgent {
 
 class PXPConnectorV1 : public PCPClient::v1::Connector, public PXPConnector {
   public:
-    PXPConnectorV1(const Configuration::Agent& agent_configuration);
+    PXPConnectorV1(const Configuration::Agent& agent_configuration, boost::nowide::ofstream* logstream);
 
     void sendPCPError(const std::string& request_id,
                       const std::string& description,

--- a/lib/inc/pxp-agent/pxp_connector_v2.hpp
+++ b/lib/inc/pxp-agent/pxp_connector_v2.hpp
@@ -11,7 +11,7 @@ namespace PXPAgent {
 
 class PXPConnectorV2 : public PCPClient::v2::Connector, public PXPConnector {
   public:
-    PXPConnectorV2(const Configuration::Agent& agent_configuration);
+    PXPConnectorV2(const Configuration::Agent& agent_configuration, boost::nowide::ofstream* logstream);
 
     void sendPCPError(const std::string& request_id,
                       const std::string& description,

--- a/lib/src/agent.cc
+++ b/lib/src/agent.cc
@@ -20,20 +20,20 @@ namespace pcp_util = PCPClient::Util;
 // Pause between PCP connection attempts after Association errors
 static const uint32_t ASSOCIATE_SESSION_TIMEOUT_PAUSE_S { 5 };
 
-static std::shared_ptr<PXPConnector> make_connector(const Configuration::Agent& agent_configuration) {
+static std::shared_ptr<PXPConnector> make_connector(const Configuration::Agent& agent_configuration, boost::nowide::ofstream* logstream) {
     if (agent_configuration.pcp_version == "1") {
         LOG_INFO("Connecting using PCP v1");
-        return std::make_shared<PXPConnectorV1>(agent_configuration);
+        return std::make_shared<PXPConnectorV1>(agent_configuration, logstream);
     } else {
         assert(agent_configuration.pcp_version == "2");
         LOG_INFO("Connecting using PCP v2");
-        return std::make_shared<PXPConnectorV2>(agent_configuration);
+        return std::make_shared<PXPConnectorV2>(agent_configuration, logstream);
     }
 }
 
 Agent::Agent(const Configuration::Agent& agent_configuration)
         try
-            : connector_ptr_ { make_connector(agent_configuration) },
+            : connector_ptr_ { make_connector(agent_configuration, Configuration::Instance().get_logfile_fstream()) },
               request_processor_ { connector_ptr_, agent_configuration },
               ping_interval_s_ { agent_configuration.ping_interval_s } {
 } catch (const PCPClient::connection_config_error& e) {

--- a/lib/src/configuration.cc
+++ b/lib/src/configuration.cc
@@ -462,7 +462,8 @@ const Configuration::Agent& Configuration::getAgentConfiguration() const
         static_cast<uint32_t >(HW::GetFlag<int>("ping-interval")),
         static_cast<uint32_t >(HW::GetFlag<int>("task-download-connect-timeout")),
         static_cast<uint32_t >(HW::GetFlag<int>("task-download-timeout")),
-        HW::GetFlag<uint32_t>("max-message-size") };
+        HW::GetFlag<uint32_t>("max-message-size"),
+        string_to_log_level(HW::GetFlag<std::string>("loglevel")) };
     return agent_configuration_;
 }
 

--- a/lib/src/pxp_connector_v1.cc
+++ b/lib/src/pxp_connector_v1.cc
@@ -35,7 +35,7 @@ wrapDebug(const PCPClient::ParsedChunks& parsed_chunks)
     return debug;
 }
 
-PXPConnectorV1::PXPConnectorV1(const Configuration::Agent& agent_configuration)
+PXPConnectorV1::PXPConnectorV1(const Configuration::Agent& agent_configuration, boost::nowide::ofstream* logstream)
         : PCPClient::v1::Connector(agent_configuration.broker_ws_uris,
                                    agent_configuration.client_type,
                                    agent_configuration.ca,
@@ -43,6 +43,8 @@ PXPConnectorV1::PXPConnectorV1(const Configuration::Agent& agent_configuration)
                                    agent_configuration.key,
                                    agent_configuration.crl,
                                    agent_configuration.broker_ws_proxy,
+                                   agent_configuration.loglevel,
+                                   logstream,
                                    agent_configuration.ws_connection_timeout_ms,
                                    agent_configuration.association_timeout_s,
                                    agent_configuration.association_request_ttl_s,

--- a/lib/src/pxp_connector_v2.cc
+++ b/lib/src/pxp_connector_v2.cc
@@ -16,7 +16,7 @@ namespace lth_jc = leatherman::json_container;
 // PXPConnector V2
 //
 
-PXPConnectorV2::PXPConnectorV2(const Configuration::Agent& agent_configuration)
+PXPConnectorV2::PXPConnectorV2(const Configuration::Agent& agent_configuration, boost::nowide::ofstream* logstream)
         : PCPClient::v2::Connector(agent_configuration.broker_ws_uris,
                                    agent_configuration.client_type,
                                    agent_configuration.ca,
@@ -24,6 +24,8 @@ PXPConnectorV2::PXPConnectorV2(const Configuration::Agent& agent_configuration)
                                    agent_configuration.key,
                                    agent_configuration.crl,
                                    agent_configuration.broker_ws_proxy,
+                                   agent_configuration.loglevel,
+                                   logstream,
                                    agent_configuration.ws_connection_timeout_ms,
                                    agent_configuration.allowed_keepalive_timeouts+1)
 {

--- a/lib/tests/common/mock_connector.hpp
+++ b/lib/tests/common/mock_connector.hpp
@@ -8,6 +8,10 @@
 #include <pxp-agent/action_request.hpp>
 #include <pxp-agent/action_response.hpp>
 
+#define LEATHERMAN_LOGGING_NAMESPACE "puppetlabs.pxp_agent.test"
+
+#include <leatherman/logging/logging.hpp>
+
 #include <atomic>
 #include <vector>
 #include <string>
@@ -55,7 +59,8 @@ static Configuration::Agent AGENT_CONFIGURATION { MODULES,
                                                   15,    // ping interval
                                                   30,    // task download connection timeout
                                                   120,   // task download timeout
-                                                  64 * 1024 * 1024 };  // default max-message-size
+                                                  64 * 1024 * 1024,  // default max-message-size
+                                                  leatherman::logging::log_level::none };
 
 static const std::string VALID_ENVELOPE_TXT {
     " { \"id\" : \"123456\","

--- a/lib/tests/unit/action_request_test.cc
+++ b/lib/tests/unit/action_request_test.cc
@@ -39,7 +39,7 @@ TEST_CASE("ActionRequest::ActionRequest", "[request]") {
     }
 
     SECTION("throw a ActionRequest::Error if binary data") {
-        const PCPClient::ParsedChunks p_c { envelope, "bin data", debug, 0 };
+        const PCPClient::ParsedChunks p_c { envelope, std::string{"bin data"}, debug, 0 };
 
         REQUIRE_THROWS_AS(ActionRequest(RequestType::Blocking, p_c),
                           ActionRequest::Error);

--- a/lib/tests/unit/agent_test.cc
+++ b/lib/tests/unit/agent_test.cc
@@ -5,6 +5,10 @@
 #include <pxp-agent/agent.hpp>
 #include <pxp-agent/configuration.hpp>
 
+#define LEATHERMAN_LOGGING_NAMESPACE "puppetlabs.pxp_agent.test"
+
+#include <leatherman/logging/logging.hpp>
+
 #include <catch.hpp>
 
 #include <boost/filesystem.hpp>
@@ -35,7 +39,8 @@ TEST_CASE("Agent::Agent", "[agent]") {
                                                "test_agent",
                                                "",    // don't set broker proxy
                                                "",    // don't set master proxy
-                                               5000, 10, 5, 5, 2, 15, 30, 120 };
+                                               5000, 10, 5, 5, 2, 15, 30, 120, 1024,
+                                               leatherman::logging::log_level::none };
 
     SECTION("does not throw if it fails to find the external modules directory") {
         agent_configuration.modules_dir = MODULES + "/fake_dir";
@@ -73,7 +78,8 @@ TEST_CASE("Agent::Agent without CRL", "[agent]") {
                                                "test_agent",
                                                "",    // don't set broker proxy
                                                "",    // don't set master proxy
-                                               5000, 10, 5, 5, 2, 15, 30, 120 };
+                                               5000, 10, 5, 5, 2, 15, 30, 120, 1024,
+                                               leatherman::logging::log_level::none };
 
     SECTION("does not throw if it fails to find the external modules directory") {
         agent_configuration.modules_dir = MODULES + "/fake_dir";

--- a/lib/tests/unit/pxp_connector_v1_test.cc
+++ b/lib/tests/unit/pxp_connector_v1_test.cc
@@ -8,6 +8,6 @@ using namespace PXPAgent;
 
 TEST_CASE("PXPConnectorV1::PXPConnectorV1", "[agent]") {
     SECTION("successfully instantiates with valid arguments") {
-        REQUIRE_NOTHROW(PXPConnectorV1{AGENT_CONFIGURATION});
+        REQUIRE_NOTHROW((PXPConnectorV1{AGENT_CONFIGURATION, nullptr}));
     };
 }

--- a/lib/tests/unit/pxp_connector_v2_test.cc
+++ b/lib/tests/unit/pxp_connector_v2_test.cc
@@ -8,6 +8,6 @@ using namespace PXPAgent;
 
 TEST_CASE("PXPConnectorV2::PXPConnectorV2", "[agent]") {
     SECTION("successfully instantiates with valid arguments") {
-        REQUIRE_NOTHROW(PXPConnectorV2{AGENT_CONFIGURATION});
+        REQUIRE_NOTHROW((PXPConnectorV2{AGENT_CONFIGURATION, nullptr}));
     };
 }


### PR DESCRIPTION
We now pass the log level and stream through to the cpp-pcp-client
Connector classes which in turn use them to configure logging on the
websocketpp connection. This entails storing the parsed log level on the
Configuration::Agent object and providing a method to retrieve the log
stream object.

This depends on https://github.com/puppetlabs/cpp-pcp-client/pull/257