### PR TITLE
(PA-4487) Add make in the pre-suite

### DIFF
--- a/acceptance/setup/common/050_Setup_Broker.rb
+++ b/acceptance/setup/common/050_Setup_Broker.rb
@@ -2,6 +2,7 @@ require 'pxp-agent/test_helper'
 
 step 'Install build dependencies for broker' do
   # Assumes RedHat master
+  master.install_package('make')
   master.install_package('git')
   master.install_package('java-1.8.0-openjdk-devel')
 end


### PR DESCRIPTION
If a VM doesn't have make installed then Lein will fail to build. Historically our EL platforms
had make installed my default, but the new GCE images we'll be switching to does not have it installed.