### PR TITLE
(PE-37243) update acceptance test java version to jdk11

### DIFF
--- a/acceptance/setup/common/050_Setup_Broker.rb
+++ b/acceptance/setup/common/050_Setup_Broker.rb
@@ -3,7 +3,7 @@ require 'pxp-agent/test_helper'
 step 'Install build dependencies for broker' do
   # Assumes RedHat master
   master.install_package('git')
-  master.install_package('java-1.8.0-openjdk-devel')
+  master.install_package('java-11-openjdk-devel')
 end
 
 NUM_BROKERS = 2


### PR DESCRIPTION
The move to trapperkeeper-webserver-jetty10 is incompatible with jdk8. Since main branch of pxp agent is promoted into both 7.x and main branch (which has tkw10) of agent and update to jdk11 is required.