### PR TITLE
(PE-37243) update lein to v2.9.0

### DIFF
--- a/acceptance/setup/common/050_Setup_Broker.rb
+++ b/acceptance/setup/common/050_Setup_Broker.rb
@@ -48,7 +48,7 @@ end
 
 step 'Download lein bootstrap' do
   on master, 'cd /usr/bin && '\
-    'curl -O https://raw.githubusercontent.com/technomancy/leiningen/2.7.1/bin/lein'
+    'curl -O https://raw.githubusercontent.com/technomancy/leiningen/2.9.0/bin/lein'
 end
 
 step 'Run lein once so it sets itself up' do


### PR DESCRIPTION
In a previous commit [1], the jdk version used in the acceptance tests was updated to v11 and the version of lein that the test was using (2.7.1) incompatible with jdk11. This commit updates to the version of lein that runs elsewhere in CI.

[1]: 9db00cfee8c019f6a7590d76dbdc46886f760f4a