### PR TITLE
(maint) ensure int32_t type defined

### DIFF
--- a/lib/inc/pxp-agent/pxp_connector.hpp
+++ b/lib/inc/pxp-agent/pxp_connector.hpp
@@ -3,6 +3,7 @@
 #include <vector>
 #include <string>
 #include <functional>
+#include <cstdint>
 
 namespace PCPClient {
 struct ParsedChunks;


### PR DESCRIPTION
int32_t type def is optional in C++11, some vendors ship gcc suite with them automatically included, some don't.

observed `'uint32_t' does not name a type` with gcc 13, which will ship with Ubuntu 24.

https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes